### PR TITLE
[receiver/awscontainerinsightreceiver] Add option to override cluster name

### DIFF
--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -57,7 +57,7 @@ The "FullPodName" attribute is the pod name including suffix. If false FullPodNa
 
 **cluster_name (optional)**
 
-"ClusterName" can be used to explicitly provide the cluster's name for scenarios where it's not possible to auto-detect it using EC2 tags.
+"ClusterName" can be used to explicitly provide the cluster's name for EKS/ECS NOT on EC2 since it's not possible to auto-detect it using EC2 tags.
 
 ## Sample configuration for Container Insights 
 This is a sample configuration for AWS Container Insights using the `awscontainerinsightreceiver` and `awsemfexporter` for an EKS cluster:

--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -12,7 +12,7 @@ AWS Container Insights Receiver (`awscontainerinsightreceiver`) is an AWS specif
 and summarize metrics and logs from your containerized applications and microservices. Data are collected as as performance log events 
 using [embedded metric format](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format.html). From the EMF data, Amazon CloudWatch can create the aggregated CloudWatch metrics at the cluster, node, pod, task, and service level.
 
-CloudWatch Container Insights has been supported by [ECS Agent](https://github.com/aws/amazon-ecs-agent) and [CloudWatch Agent](https://github.com/aws/amazon-cloudwatch-agent) to collect infrastructure metrics for many resources such as such as CPU, memory, disk, and network. To migrate existing customers to use OpenTelemetry, AWS Container Insights Receiver (together with CloudWatch EMF Exporter) aims to support the same CloudWatch Container Insights experience for the following platforms:  
+CloudWatch Container Insights has been supported by [ECS Agent](https://github.com/aws/amazon-ecs-agent) and [CloudWatch Agent](https://github.com/aws/amazon-cloudwatch-agent) to collect infrastructure metrics for many resources such as CPU, memory, disk, and network. To migrate existing customers to use OpenTelemetry, AWS Container Insights Receiver (together with CloudWatch EMF Exporter) aims to support the same CloudWatch Container Insights experience for the following platforms:  
   * Amazon ECS 
   * Amazon EKS
   * Kubernetes platforms on Amazon EC2
@@ -54,6 +54,10 @@ The "PodName" attribute is set based on the name of the relevant controllers lik
 **add_full_pod_name_metric_label (optional)**
 
 The "FullPodName" attribute is the pod name including suffix. If false FullPodName label is not added. The default value is false
+
+**cluster_name (optional)**
+
+"ClusterName" can be used to explicitly provide the cluster's name for scenarios where it's not possible to auto-detect it using EC2 tags.
 
 ## Sample configuration for Container Insights 
 This is a sample configuration for AWS Container Insights using the `awscontainerinsightreceiver` and `awsemfexporter` for an EKS cluster:

--- a/receiver/awscontainerinsightreceiver/config.go
+++ b/receiver/awscontainerinsightreceiver/config.go
@@ -39,4 +39,8 @@ type Config struct {
 	// If false FullPodName label is not added
 	// The default value is false
 	AddFullPodNameMetricLabel bool `mapstructure:"add_full_pod_name_metric_label"`
+
+	// ClusterName can be used to explicitly provide the Cluster's Name for scenarios where it's not
+	// possible to auto-detect it using EC2 tags.
+	ClusterName string `mapstructure:"cluster_name"`
 }

--- a/receiver/awscontainerinsightreceiver/config_test.go
+++ b/receiver/awscontainerinsightreceiver/config_test.go
@@ -48,6 +48,16 @@ func TestLoadConfig(t *testing.T) {
 				PrefFullPodName:       false,
 			},
 		},
+		{
+			id: component.NewIDWithName(typeStr, "cluster_name"),
+			expected: &Config{
+				CollectionInterval:    60 * time.Second,
+				ContainerOrchestrator: "eks",
+				TagService:            true,
+				PrefFullPodName:       false,
+				ClusterName:           "override_cluster",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/receiver/awscontainerinsightreceiver/factory.go
+++ b/receiver/awscontainerinsightreceiver/factory.go
@@ -45,6 +45,9 @@ const (
 
 	// Don't tag pod full name by default
 	defaultAddFullPodNameMetricLabel = false
+
+	// Rely on EC2 tags to auto-detect cluster name by default
+	defaultClusterName = ""
 )
 
 // NewFactory creates a factory for AWS container insight receiver
@@ -63,6 +66,7 @@ func createDefaultConfig() component.Config {
 		TagService:                defaultTagService,
 		PrefFullPodName:           defaultPrefFullPodName,
 		AddFullPodNameMetricLabel: defaultAddFullPodNameMetricLabel,
+		ClusterName:               defaultClusterName,
 	}
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_instance_info.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_instance_info.go
@@ -51,12 +51,13 @@ type ContainerInstance struct {
 	ContainerInstanceArn string
 }
 
-func newECSInstanceInfo(ctx context.Context, ecsAgentEndpointProvider hostIPProvider,
+func newECSInstanceInfo(ctx context.Context, clusterName string, ecsAgentEndpointProvider hostIPProvider,
 	refreshInterval time.Duration, logger *zap.Logger, httpClient doer, readyC chan bool) containerInstanceInfoProvider {
 	cii := &containerInstanceInfo{
 		logger:                   logger,
 		httpClient:               httpClient,
 		refreshInterval:          refreshInterval,
+		clusterName:              clusterName,
 		ecsAgentEndpointProvider: ecsAgentEndpointProvider,
 		readyC:                   readyC,
 	}
@@ -104,6 +105,9 @@ func (cii *containerInstanceInfo) refresh(ctx context.Context) {
 }
 
 func (cii *containerInstanceInfo) GetClusterName() string {
+	if cii.clusterName != "" {
+		return cii.clusterName
+	}
 	cii.RLock()
 	defer cii.RUnlock()
 	return cii.clusterName

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_instance_info.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_instance_info.go
@@ -94,7 +94,9 @@ func (cii *containerInstanceInfo) refresh(ctx context.Context) {
 	}
 
 	cii.Lock()
-	cii.clusterName = cluster
+	if cii.clusterName == "" { // Update cluster name only when it wasn't already provided via config
+		cii.clusterName = cluster
+	}
 	cii.containerInstanceID = instanceID
 	defer cii.Unlock()
 
@@ -105,9 +107,6 @@ func (cii *containerInstanceInfo) refresh(ctx context.Context) {
 }
 
 func (cii *containerInstanceInfo) GetClusterName() string {
-	if cii.clusterName != "" {
-		return cii.clusterName
-	}
 	cii.RLock()
 	defer cii.RUnlock()
 	return cii.clusterName

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_instance_info_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_instance_info_test.go
@@ -61,7 +61,7 @@ func TestECSInstanceInfo(t *testing.T) {
 	}
 
 	// normal case
-	ecsinstanceinfo := newECSInstanceInfo(ctx, hostIPProvider, time.Minute, zap.NewNop(), mockHTTP, instanceReadyC)
+	ecsinstanceinfo := newECSInstanceInfo(ctx, "", hostIPProvider, time.Minute, zap.NewNop(), mockHTTP, instanceReadyC)
 
 	assert.NotNil(t, ecsinstanceinfo)
 
@@ -86,11 +86,10 @@ func TestECSInstanceInfo(t *testing.T) {
 		response: httpResponse,
 		err:      err,
 	}
-	ecsinstanceinfo = newECSInstanceInfo(ctx, hostIPProvider, time.Minute, zap.NewNop(), mockHTTP, instanceReadyC)
+	ecsinstanceinfo = newECSInstanceInfo(ctx, "override-cluster", hostIPProvider, time.Minute, zap.NewNop(), mockHTTP, instanceReadyC)
 
 	assert.NotNil(t, ecsinstanceinfo)
 
-	assert.Equal(t, "", ecsinstanceinfo.GetClusterName())
+	assert.Equal(t, "override-cluster", ecsinstanceinfo.GetClusterName())
 	assert.Equal(t, "", ecsinstanceinfo.GetContainerInstanceID())
-
 }

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo.go
@@ -91,10 +91,16 @@ func (e *EcsInfo) GetClusterName() string {
 	return ""
 }
 
-type ecsInfoOption func(*EcsInfo)
+func WithClusterName(name string) Option {
+	return func(info *EcsInfo) {
+		info.clusterName = name
+	}
+}
+
+type Option func(*EcsInfo)
 
 // New creates a k8sApiServer which can generate cluster-level metrics
-func NewECSInfo(refreshInterval time.Duration, clusterName string, hostIPProvider hostIPProvider, host component.Host, settings component.TelemetrySettings, options ...ecsInfoOption) (*EcsInfo, error) {
+func NewECSInfo(refreshInterval time.Duration, hostIPProvider hostIPProvider, host component.Host, settings component.TelemetrySettings, options ...Option) (*EcsInfo, error) {
 	setting := confighttp.HTTPClientSettings{
 		Timeout: defaultTimeout,
 	}
@@ -112,7 +118,6 @@ func NewECSInfo(refreshInterval time.Duration, clusterName string, hostIPProvide
 		logger:                       settings.Logger,
 		hostIPProvider:               hostIPProvider,
 		refreshInterval:              refreshInterval,
-		clusterName:                  clusterName,
 		httpClient:                   client,
 		cancel:                       cancel,
 		containerInstanceInfoCreator: newECSInstanceInfo,

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo_test.go
@@ -88,7 +88,7 @@ func TestNewECSInfo(t *testing.T) {
 	// test the case when containerInstanceInfor fails to initialize
 	containerInstanceInfoCreatorOpt := func(ei *EcsInfo) {
 
-		ei.containerInstanceInfoCreator = func(context.Context, hostIPProvider, time.Duration, *zap.Logger, doer, chan bool) containerInstanceInfoProvider {
+		ei.containerInstanceInfoCreator = func(context.Context, string, hostIPProvider, time.Duration, *zap.Logger, doer, chan bool) containerInstanceInfoProvider {
 			return &MockInstanceInfo{
 				clusterName: "Cluster-name",
 				instanceID:  "instance-id",
@@ -118,7 +118,7 @@ func TestNewECSInfo(t *testing.T) {
 	}
 	hostIPProvider := &FakehostInfo{}
 
-	ecsinfo, _ := NewECSInfo(time.Minute, hostIPProvider, componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings(), containerInstanceInfoCreatorOpt, taskinfoCreatorOpt, cgroupScannerCreatorOpt)
+	ecsinfo, _ := NewECSInfo(time.Minute, "", hostIPProvider, componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings(), containerInstanceInfoCreatorOpt, taskinfoCreatorOpt, cgroupScannerCreatorOpt)
 	assert.NotNil(t, ecsinfo)
 
 	<-ecsinfo.taskInfoTestReadyC

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo_test.go
@@ -118,7 +118,7 @@ func TestNewECSInfo(t *testing.T) {
 	}
 	hostIPProvider := &FakehostInfo{}
 
-	ecsinfo, _ := NewECSInfo(time.Minute, "", hostIPProvider, componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings(), containerInstanceInfoCreatorOpt, taskinfoCreatorOpt, cgroupScannerCreatorOpt)
+	ecsinfo, _ := NewECSInfo(time.Minute, hostIPProvider, componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings(), containerInstanceInfoCreatorOpt, taskinfoCreatorOpt, cgroupScannerCreatorOpt)
 	assert.NotNil(t, ecsinfo)
 
 	<-ecsinfo.taskInfoTestReadyC

--- a/receiver/awscontainerinsightreceiver/internal/host/hostinfo.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/hostinfo.go
@@ -33,6 +33,7 @@ type Info struct {
 	awsSession            *session.Session
 	refreshInterval       time.Duration
 	containerOrchestrator string
+	clusterName           string
 	instanceIDReadyC      chan bool // close of this channel indicates instance ID is ready
 	instanceIPReadyC      chan bool // close of this channel indicates instance Ip is ready
 
@@ -54,7 +55,7 @@ type Info struct {
 type machineInfoOption func(*Info)
 
 // NewInfo creates a new Info struct
-func NewInfo(containerOrchestrator string, refreshInterval time.Duration, logger *zap.Logger, options ...machineInfoOption) (*Info, error) {
+func NewInfo(containerOrchestrator string, refreshInterval time.Duration, clusterName string, logger *zap.Logger, options ...machineInfoOption) (*Info, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	mInfo := &Info{
 		cancel:           cancel,
@@ -64,6 +65,7 @@ func NewInfo(containerOrchestrator string, refreshInterval time.Duration, logger
 		logger:           logger,
 
 		containerOrchestrator: containerOrchestrator,
+		clusterName:           clusterName,
 		awsSessionCreator:     awsutil.GetAWSConfigSession,
 		nodeCapacityCreator:   newNodeCapacity,
 		ec2MetadataCreator:    newEC2Metadata,
@@ -156,6 +158,9 @@ func (m *Info) GetEBSVolumeID(devName string) string {
 
 // GetClusterName returns the cluster name associated with the host
 func (m *Info) GetClusterName() string {
+	if m.clusterName != "" {
+		return m.clusterName
+	}
 	if m.ec2Tags != nil {
 		return m.ec2Tags.getClusterName()
 	}

--- a/receiver/awscontainerinsightreceiver/internal/host/hostinfo.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/hostinfo.go
@@ -52,10 +52,16 @@ type Info struct {
 	ec2TagsCreator      func(context.Context, *session.Session, string, string, string, time.Duration, *zap.Logger, ...ec2TagsOption) ec2TagsProvider
 }
 
-type machineInfoOption func(*Info)
+type Option func(*Info)
+
+func WithClusterName(name string) Option {
+	return func(info *Info) {
+		info.clusterName = name
+	}
+}
 
 // NewInfo creates a new Info struct
-func NewInfo(containerOrchestrator string, refreshInterval time.Duration, clusterName string, logger *zap.Logger, options ...machineInfoOption) (*Info, error) {
+func NewInfo(containerOrchestrator string, refreshInterval time.Duration, logger *zap.Logger, options ...Option) (*Info, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	mInfo := &Info{
 		cancel:           cancel,
@@ -65,7 +71,6 @@ func NewInfo(containerOrchestrator string, refreshInterval time.Duration, cluste
 		logger:           logger,
 
 		containerOrchestrator: containerOrchestrator,
-		clusterName:           clusterName,
 		awsSessionCreator:     awsutil.GetAWSConfigSession,
 		nodeCapacityCreator:   newNodeCapacity,
 		ec2MetadataCreator:    newEC2Metadata,

--- a/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
@@ -90,7 +90,7 @@ func TestInfo(t *testing.T) {
 	}
 	m, err := NewInfo(ci.EKS, time.Minute, "", zap.NewNop(), nodeCapacityCreatorOpt)
 	assert.Nil(t, m)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	// test the case when aws session fails to initialize
 	nodeCapacityCreatorOpt = func(m *Info) {
@@ -105,7 +105,7 @@ func TestInfo(t *testing.T) {
 	}
 	m, err = NewInfo(ci.EKS, time.Minute, "", zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
 	assert.Nil(t, m)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	// test normal case where everything is working
 	awsSessionCreatorOpt = func(m *Info) {
@@ -133,7 +133,7 @@ func TestInfo(t *testing.T) {
 	}
 	m, err = NewInfo(ci.EKS, time.Minute, "", zap.NewNop(), awsSessionCreatorOpt,
 		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, m)
 
 	// befoe ebsVolume and ec2Tags are initialized
@@ -157,7 +157,7 @@ func TestInfo(t *testing.T) {
 	// Test with cluster name override
 	m, err = NewInfo(ci.EKS, time.Minute, "override-cluster", zap.NewNop(), awsSessionCreatorOpt,
 		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, m)
 
 	assert.Equal(t, "override-cluster", m.GetClusterName())
@@ -172,7 +172,7 @@ func TestInfoForECS(t *testing.T) {
 	}
 	m, err := NewInfo(ci.ECS, time.Minute, "", zap.NewNop(), nodeCapacityCreatorOpt)
 	assert.Nil(t, m)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	// test the case when aws session fails to initialize
 	nodeCapacityCreatorOpt = func(m *Info) {
@@ -187,7 +187,7 @@ func TestInfoForECS(t *testing.T) {
 	}
 	m, err = NewInfo(ci.ECS, time.Minute, "", zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
 	assert.Nil(t, m)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	// test normal case where everything is working
 	awsSessionCreatorOpt = func(m *Info) {
@@ -215,7 +215,7 @@ func TestInfoForECS(t *testing.T) {
 	}
 	m, err = NewInfo(ci.ECS, time.Minute, "", zap.NewNop(), awsSessionCreatorOpt,
 		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, m)
 
 	// befoe ebsVolume and ec2Tags are initialized

--- a/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
@@ -88,7 +88,7 @@ func TestInfo(t *testing.T) {
 			return nil, errors.New("error")
 		}
 	}
-	m, err := NewInfo(ci.EKS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt)
+	m, err := NewInfo(ci.EKS, time.Minute, "", zap.NewNop(), nodeCapacityCreatorOpt)
 	assert.Nil(t, m)
 	assert.NotNil(t, err)
 
@@ -103,7 +103,7 @@ func TestInfo(t *testing.T) {
 			return nil, nil, errors.New("error")
 		}
 	}
-	m, err = NewInfo(ci.EKS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
+	m, err = NewInfo(ci.EKS, time.Minute, "", zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
 	assert.Nil(t, m)
 	assert.NotNil(t, err)
 
@@ -131,7 +131,7 @@ func TestInfo(t *testing.T) {
 			return &mockEC2Tags{}
 		}
 	}
-	m, err = NewInfo(ci.EKS, time.Minute, zap.NewNop(), awsSessionCreatorOpt,
+	m, err = NewInfo(ci.EKS, time.Minute, "", zap.NewNop(), awsSessionCreatorOpt,
 		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt)
 	assert.Nil(t, err)
 	assert.NotNil(t, m)
@@ -153,6 +153,14 @@ func TestInfo(t *testing.T) {
 	assert.Equal(t, "ebs-volume-id", m.GetEBSVolumeID("dev"))
 	assert.Equal(t, "cluster-name", m.GetClusterName())
 	assert.Equal(t, "asg", m.GetAutoScalingGroupName())
+
+	// Test with cluster name override
+	m, err = NewInfo(ci.EKS, time.Minute, "override-cluster", zap.NewNop(), awsSessionCreatorOpt,
+		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt)
+	assert.Nil(t, err)
+	assert.NotNil(t, m)
+
+	assert.Equal(t, "override-cluster", m.GetClusterName())
 }
 
 func TestInfoForECS(t *testing.T) {
@@ -162,7 +170,7 @@ func TestInfoForECS(t *testing.T) {
 			return nil, errors.New("error")
 		}
 	}
-	m, err := NewInfo(ci.ECS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt)
+	m, err := NewInfo(ci.ECS, time.Minute, "", zap.NewNop(), nodeCapacityCreatorOpt)
 	assert.Nil(t, m)
 	assert.NotNil(t, err)
 
@@ -177,7 +185,7 @@ func TestInfoForECS(t *testing.T) {
 			return nil, nil, errors.New("error")
 		}
 	}
-	m, err = NewInfo(ci.ECS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
+	m, err = NewInfo(ci.ECS, time.Minute, "", zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
 	assert.Nil(t, m)
 	assert.NotNil(t, err)
 
@@ -205,7 +213,7 @@ func TestInfoForECS(t *testing.T) {
 			return &mockEC2Tags{}
 		}
 	}
-	m, err = NewInfo(ci.ECS, time.Minute, zap.NewNop(), awsSessionCreatorOpt,
+	m, err = NewInfo(ci.ECS, time.Minute, "", zap.NewNop(), awsSessionCreatorOpt,
 		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt)
 	assert.Nil(t, err)
 	assert.NotNil(t, m)

--- a/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
@@ -155,11 +155,8 @@ func TestInfo(t *testing.T) {
 	assert.Equal(t, "asg", m.GetAutoScalingGroupName())
 
 	// Test with cluster name override
-	clusterNameOpt := func(m *Info) {
-		m.clusterName = "override-cluster"
-	}
 	m, err = NewInfo(ci.EKS, time.Minute, zap.NewNop(), awsSessionCreatorOpt,
-		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt, clusterNameOpt)
+		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt, WithClusterName("override-cluster"))
 	assert.NoError(t, err)
 	assert.NotNil(t, m)
 

--- a/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
@@ -88,7 +88,7 @@ func TestInfo(t *testing.T) {
 			return nil, errors.New("error")
 		}
 	}
-	m, err := NewInfo(ci.EKS, time.Minute, "", zap.NewNop(), nodeCapacityCreatorOpt)
+	m, err := NewInfo(ci.EKS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt)
 	assert.Nil(t, m)
 	assert.Error(t, err)
 
@@ -103,7 +103,7 @@ func TestInfo(t *testing.T) {
 			return nil, nil, errors.New("error")
 		}
 	}
-	m, err = NewInfo(ci.EKS, time.Minute, "", zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
+	m, err = NewInfo(ci.EKS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
 	assert.Nil(t, m)
 	assert.Error(t, err)
 
@@ -131,7 +131,7 @@ func TestInfo(t *testing.T) {
 			return &mockEC2Tags{}
 		}
 	}
-	m, err = NewInfo(ci.EKS, time.Minute, "", zap.NewNop(), awsSessionCreatorOpt,
+	m, err = NewInfo(ci.EKS, time.Minute, zap.NewNop(), awsSessionCreatorOpt,
 		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt)
 	assert.NoError(t, err)
 	assert.NotNil(t, m)
@@ -155,8 +155,11 @@ func TestInfo(t *testing.T) {
 	assert.Equal(t, "asg", m.GetAutoScalingGroupName())
 
 	// Test with cluster name override
-	m, err = NewInfo(ci.EKS, time.Minute, "override-cluster", zap.NewNop(), awsSessionCreatorOpt,
-		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt)
+	clusterNameOpt := func(m *Info) {
+		m.clusterName = "override-cluster"
+	}
+	m, err = NewInfo(ci.EKS, time.Minute, zap.NewNop(), awsSessionCreatorOpt,
+		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt, clusterNameOpt)
 	assert.NoError(t, err)
 	assert.NotNil(t, m)
 
@@ -170,7 +173,7 @@ func TestInfoForECS(t *testing.T) {
 			return nil, errors.New("error")
 		}
 	}
-	m, err := NewInfo(ci.ECS, time.Minute, "", zap.NewNop(), nodeCapacityCreatorOpt)
+	m, err := NewInfo(ci.ECS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt)
 	assert.Nil(t, m)
 	assert.Error(t, err)
 
@@ -185,7 +188,7 @@ func TestInfoForECS(t *testing.T) {
 			return nil, nil, errors.New("error")
 		}
 	}
-	m, err = NewInfo(ci.ECS, time.Minute, "", zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
+	m, err = NewInfo(ci.ECS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
 	assert.Nil(t, m)
 	assert.Error(t, err)
 
@@ -213,7 +216,7 @@ func TestInfoForECS(t *testing.T) {
 			return &mockEC2Tags{}
 		}
 	}
-	m, err = NewInfo(ci.ECS, time.Minute, "", zap.NewNop(), awsSessionCreatorOpt,
+	m, err = NewInfo(ci.ECS, time.Minute, zap.NewNop(), awsSessionCreatorOpt,
 		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt)
 	assert.NoError(t, err)
 	assert.NotNil(t, m)

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -93,7 +93,7 @@ func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host compone
 	}
 	if acir.config.ContainerOrchestrator == ci.ECS {
 
-		ecsInfo, err := ecsinfo.NewECSInfo(acir.config.CollectionInterval, acir.config.ClusterName, hostinfo, host, acir.settings)
+		ecsInfo, err := ecsinfo.NewECSInfo(acir.config.CollectionInterval, hostinfo, host, acir.settings, ecsinfo.WithClusterName(acir.config.ClusterName))
 		if err != nil {
 			return err
 		}

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -70,7 +70,7 @@ func newAWSContainerInsightReceiver(
 func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host component.Host) error {
 	ctx, acir.cancel = context.WithCancel(ctx)
 
-	hostinfo, err := hostInfo.NewInfo(acir.config.ContainerOrchestrator, acir.config.CollectionInterval, acir.config.ClusterName, acir.settings.Logger)
+	hostinfo, err := hostInfo.NewInfo(acir.config.ContainerOrchestrator, acir.config.CollectionInterval, acir.settings.Logger, hostInfo.WithClusterName(acir.config.ClusterName))
 	if err != nil {
 		return err
 	}

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -70,7 +70,7 @@ func newAWSContainerInsightReceiver(
 func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host component.Host) error {
 	ctx, acir.cancel = context.WithCancel(ctx)
 
-	hostinfo, err := hostInfo.NewInfo(acir.config.ContainerOrchestrator, acir.config.CollectionInterval, acir.settings.Logger)
+	hostinfo, err := hostInfo.NewInfo(acir.config.ContainerOrchestrator, acir.config.CollectionInterval, acir.config.ClusterName, acir.settings.Logger)
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host compone
 	}
 	if acir.config.ContainerOrchestrator == ci.ECS {
 
-		ecsInfo, err := ecsinfo.NewECSInfo(acir.config.CollectionInterval, hostinfo, host, acir.settings)
+		ecsInfo, err := ecsinfo.NewECSInfo(acir.config.CollectionInterval, acir.config.ClusterName, hostinfo, host, acir.settings)
 		if err != nil {
 			return err
 		}

--- a/receiver/awscontainerinsightreceiver/testdata/config.yaml
+++ b/receiver/awscontainerinsightreceiver/testdata/config.yaml
@@ -2,3 +2,5 @@ awscontainerinsightreceiver:
   container_orchestrator: eks
 awscontainerinsightreceiver/collection_interval_settings:
   collection_interval: 60s
+awscontainerinsightreceiver/cluster_name:
+  cluster_name: override_cluster


### PR DESCRIPTION
Description: Add config option to override cluster name. This is to maintain backwards compatibility to CloudWatchAgent where customers have the option to specify a cluster name via the config.

Testing: Unit tests added/updated to test config option

Documentation: Updated README.md