### PR TITLE
[receiver/awscontainerinsightreceiver] Parameterize EKS CI leader loc…

### DIFF
--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -59,6 +59,10 @@ The "FullPodName" attribute is the pod name including suffix. If false FullPodNa
 
 "ClusterName" can be used to explicitly provide the cluster's name for EKS/ECS NOT on EC2 since it's not possible to auto-detect it using EC2 tags.
 
+**leader_lock_name (optional)**
+
+"LeaderLockName" can be used to optionally override the lock resource name to be used during leader election for EKS Container Insights. The elected leader is responsible for scraping cluster level metrics. The default value is "otel-container-insight-clusterleader".
+
 ## Sample configuration for Container Insights 
 This is a sample configuration for AWS Container Insights using the `awscontainerinsightreceiver` and `awsemfexporter` for an EKS cluster:
 ```

--- a/receiver/awscontainerinsightreceiver/config.go
+++ b/receiver/awscontainerinsightreceiver/config.go
@@ -43,4 +43,9 @@ type Config struct {
 	// ClusterName can be used to explicitly provide the Cluster's Name for scenarios where it's not
 	// possible to auto-detect it using EC2 tags.
 	ClusterName string `mapstructure:"cluster_name"`
+
+	// The "LeaderLockName" is an optional attribute to override the name of the locking resource (e.g. config map) used during the leader
+	// election process for EKS Container Insights. The elected leader is responsible for scraping cluster level metrics.
+	// The default value is "otel-container-insight-clusterleader".
+	LeaderLockName string `mapstructure:"leader_lock_name"`
 }

--- a/receiver/awscontainerinsightreceiver/config.go
+++ b/receiver/awscontainerinsightreceiver/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	// possible to auto-detect it using EC2 tags.
 	ClusterName string `mapstructure:"cluster_name"`
 
-	// The "LeaderLockName" is an optional attribute to override the name of the locking resource (e.g. config map) used during the leader
+	// LeaderLockName is an optional attribute to override the name of the locking resource (e.g. config map) used during the leader
 	// election process for EKS Container Insights. The elected leader is responsible for scraping cluster level metrics.
 	// The default value is "otel-container-insight-clusterleader".
 	LeaderLockName string `mapstructure:"leader_lock_name"`

--- a/receiver/awscontainerinsightreceiver/config_test.go
+++ b/receiver/awscontainerinsightreceiver/config_test.go
@@ -46,6 +46,7 @@ func TestLoadConfig(t *testing.T) {
 				ContainerOrchestrator: "eks",
 				TagService:            true,
 				PrefFullPodName:       false,
+				LeaderLockName:        "otel-container-insight-clusterleader",
 			},
 		},
 		{
@@ -56,6 +57,17 @@ func TestLoadConfig(t *testing.T) {
 				TagService:            true,
 				PrefFullPodName:       false,
 				ClusterName:           "override_cluster",
+				LeaderLockName:        "otel-container-insight-clusterleader",
+			},
+		},
+		{
+			id: component.NewIDWithName(typeStr, "leader_lock_name"),
+			expected: &Config{
+				CollectionInterval:    60 * time.Second,
+				ContainerOrchestrator: "eks",
+				TagService:            true,
+				PrefFullPodName:       false,
+				LeaderLockName:        "override-container-insight-clusterleader",
 			},
 		},
 	}

--- a/receiver/awscontainerinsightreceiver/factory.go
+++ b/receiver/awscontainerinsightreceiver/factory.go
@@ -48,6 +48,9 @@ const (
 
 	// Rely on EC2 tags to auto-detect cluster name by default
 	defaultClusterName = ""
+
+	// Default locking resource name during EKS leader election
+	defaultLeaderLockName = "otel-container-insight-clusterleader"
 )
 
 // NewFactory creates a factory for AWS container insight receiver
@@ -67,6 +70,7 @@ func createDefaultConfig() component.Config {
 		PrefFullPodName:           defaultPrefFullPodName,
 		AddFullPodNameMetricLabel: defaultAddFullPodNameMetricLabel,
 		ClusterName:               defaultClusterName,
+		LeaderLockName:            defaultLeaderLockName,
 	}
 }
 

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -86,7 +86,7 @@ func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host compone
 		if err != nil {
 			return err
 		}
-		acir.k8sapiserver, err = k8sapiserver.New(hostinfo, acir.settings.Logger)
+		acir.k8sapiserver, err = k8sapiserver.New(hostinfo, acir.settings.Logger, k8sapiserver.WithLeaderLockName(acir.config.LeaderLockName))
 		if err != nil {
 			return err
 		}

--- a/receiver/awscontainerinsightreceiver/testdata/config.yaml
+++ b/receiver/awscontainerinsightreceiver/testdata/config.yaml
@@ -4,3 +4,5 @@ awscontainerinsightreceiver/collection_interval_settings:
   collection_interval: 60s
 awscontainerinsightreceiver/cluster_name:
   cluster_name: override_cluster
+awscontainerinsightreceiver/leader_lock_name:
+  leader_lock_name: override-container-insight-clusterleader


### PR DESCRIPTION
…k name

**Description:** Currently, the name of the configmap/leases i.e. the lock resource to be used during leader election process is hardcoded. With this change, we allow customers to optionally override this.

**Testing:** Updated unit tests.

**Documentation:** Updated README.md