### PR TITLE
[receiver/awscontainerinsightreceiver] Add option to only use config …

### DIFF
--- a/receiver/awscontainerinsightreceiver/config.go
+++ b/receiver/awscontainerinsightreceiver/config.go
@@ -48,4 +48,10 @@ type Config struct {
 	// election process for EKS Container Insights. The elected leader is responsible for scraping cluster level metrics.
 	// The default value is "otel-container-insight-clusterleader".
 	LeaderLockName string `mapstructure:"leader_lock_name"`
+
+	// LeaderLockUsingConfigMapOnly is an optional attribute to override the default behavior when obtaining a locking resource to be used during the leader
+	// election process for EKS Container Insights. By default, the leader election logic prefers a Lease and alternatively the combination of Lease & ConfigMap.
+	// When this flag is set to true, the leader election logic will be forced to use ConfigMap only. This flag mainly exists for backwards compatibility.
+	// The default value is false.
+	LeaderLockUsingConfigMapOnly bool `mapstructure:"leader_lock_using_config_map_only"`
 }

--- a/receiver/awscontainerinsightreceiver/config_test.go
+++ b/receiver/awscontainerinsightreceiver/config_test.go
@@ -70,6 +70,17 @@ func TestLoadConfig(t *testing.T) {
 				LeaderLockName:        "override-container-insight-clusterleader",
 			},
 		},
+		{
+			id: component.NewIDWithName(typeStr, "leader_lock_using_config_map_only"),
+			expected: &Config{
+				CollectionInterval:           60 * time.Second,
+				ContainerOrchestrator:        "eks",
+				TagService:                   true,
+				PrefFullPodName:              false,
+				LeaderLockName:               "otel-container-insight-clusterleader",
+				LeaderLockUsingConfigMapOnly: true,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/configmaplock.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/configmaplock.go
@@ -1,3 +1,17 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package k8sapiserver
 
 import (

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/configmaplock.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/configmaplock.go
@@ -1,0 +1,106 @@
+package k8sapiserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type ConfigMapLock struct {
+	// ConfigMapMeta should contain a Name and a Namespace of a
+	// ConfigMapMeta object that the LeaderElector will attempt to lead.
+	ConfigMapMeta metav1.ObjectMeta
+	Client        corev1client.ConfigMapsGetter
+	LockConfig    resourcelock.ResourceLockConfig
+	cm            *v1.ConfigMap
+}
+
+// Get returns the election record from a ConfigMap Annotation
+func (cml *ConfigMapLock) Get(ctx context.Context) (*resourcelock.LeaderElectionRecord, []byte, error) {
+	var record resourcelock.LeaderElectionRecord
+	var err error
+	cml.cm, err = cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Get(ctx, cml.ConfigMapMeta.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	if cml.cm.Annotations == nil {
+		cml.cm.Annotations = make(map[string]string)
+	}
+	recordStr, found := cml.cm.Annotations[resourcelock.LeaderElectionRecordAnnotationKey]
+	recordBytes := []byte(recordStr)
+	if found {
+		if err := json.Unmarshal(recordBytes, &record); err != nil {
+			return nil, nil, err
+		}
+	}
+	return &record, recordBytes, nil
+}
+
+// Create attempts to create a LeaderElectionRecord annotation
+func (cml *ConfigMapLock) Create(ctx context.Context, ler resourcelock.LeaderElectionRecord) error {
+	recordBytes, err := json.Marshal(ler)
+	if err != nil {
+		return err
+	}
+	cml.cm, err = cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Create(ctx, &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cml.ConfigMapMeta.Name,
+			Namespace: cml.ConfigMapMeta.Namespace,
+			Annotations: map[string]string{
+				resourcelock.LeaderElectionRecordAnnotationKey: string(recordBytes),
+			},
+		},
+	}, metav1.CreateOptions{})
+	return err
+}
+
+// Update will update an existing annotation on a given resource.
+func (cml *ConfigMapLock) Update(ctx context.Context, ler resourcelock.LeaderElectionRecord) error {
+	if cml.cm == nil {
+		return errors.New("configmap not initialized, call get or create first")
+	}
+	recordBytes, err := json.Marshal(ler)
+	if err != nil {
+		return err
+	}
+	if cml.cm.Annotations == nil {
+		cml.cm.Annotations = make(map[string]string)
+	}
+	cml.cm.Annotations[resourcelock.LeaderElectionRecordAnnotationKey] = string(recordBytes)
+	cm, err := cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Update(ctx, cml.cm, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	cml.cm = cm
+	return nil
+}
+
+// RecordEvent in leader election while adding meta-data
+func (cml *ConfigMapLock) RecordEvent(s string) {
+	if cml.LockConfig.EventRecorder == nil {
+		return
+	}
+	events := fmt.Sprintf("%v %v", cml.LockConfig.Identity, s)
+	subject := &v1.ConfigMap{ObjectMeta: cml.cm.ObjectMeta}
+	// Populate the type meta, so we don't have to get it from the schema
+	subject.Kind = "ConfigMap"
+	subject.APIVersion = v1.SchemeGroupVersion.String()
+	cml.LockConfig.EventRecorder.Eventf(subject, v1.EventTypeNormal, "LeaderElection", events)
+}
+
+// Describe is used to convert details on current resource lock
+// into a string
+func (cml *ConfigMapLock) Describe() string {
+	return fmt.Sprintf("%v/%v", cml.ConfigMapMeta.Namespace, cml.ConfigMapMeta.Name)
+}
+
+// Identity returns the Identity of the lock
+func (cml *ConfigMapLock) Identity() string {
+	return cml.LockConfig.Identity
+}

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/configmaplock.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/configmaplock.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package k8sapiserver
+package k8sapiserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8sapiserver"
 
 import (
 	"context"

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/configmaplock.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/configmaplock.go
@@ -20,11 +20,10 @@ import (
 	"errors"
 	"fmt"
 
-	"k8s.io/client-go/tools/leaderelection/resourcelock"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 )
 
 type ConfigMapLock struct {

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/configmaplock.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/configmaplock.go
@@ -19,9 +19,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
@@ -264,9 +264,8 @@ func (k *K8sAPIServer) init() error {
 		if err != nil {
 			k.logger.Warn("Failed to create resource lock", zap.Error(err))
 			return err
-		} else {
-			lock = l
 		}
+		lock = l
 	}
 
 	go k.startLeaderElection(ctx, lock)

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -86,7 +86,8 @@ func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host compone
 		if err != nil {
 			return err
 		}
-		acir.k8sapiserver, err = k8sapiserver.New(hostinfo, acir.settings.Logger, k8sapiserver.WithLeaderLockName(acir.config.LeaderLockName))
+		acir.k8sapiserver, err = k8sapiserver.New(hostinfo, acir.settings.Logger, k8sapiserver.WithLeaderLockName(acir.config.LeaderLockName),
+			k8sapiserver.WithLeaderLockUsingConfigMapOnly(acir.config.LeaderLockUsingConfigMapOnly))
 		if err != nil {
 			return err
 		}

--- a/receiver/awscontainerinsightreceiver/testdata/config.yaml
+++ b/receiver/awscontainerinsightreceiver/testdata/config.yaml
@@ -6,3 +6,5 @@ awscontainerinsightreceiver/cluster_name:
   cluster_name: override_cluster
 awscontainerinsightreceiver/leader_lock_name:
   leader_lock_name: override-container-insight-clusterleader
+awscontainerinsightreceiver/leader_lock_using_config_map_only:
+  leader_lock_using_config_map_only: true


### PR DESCRIPTION
…maps as EKS leader election lock resource

**Description:** With newer versions of k8s go client, the leader election logic only allows specifying the lock type as either leases or a combination of leases & config maps. They stopped allowing only config maps to be used as a lock resource. But this can be a breaking change for existing customers and would require them to update the permissions of their associated ServiceAccount to now add permissions for leases etc.
To avoid a backwards incompatible change for customers, this PR introduces a config option to continue allow using only config maps as a lock resource thus requiring no additional change from customers.