### PR TITLE
[receiver/awscontainerinsightreceiver] Add option for adding container name as a metric label

### DIFF
--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -31,7 +31,8 @@ receivers:
     container_orchestrator: eks
     add_service_as_attribute: true 
     prefer_full_pod_name: false 
-    add_full_pod_name_metric_label: false 
+    add_full_pod_name_metric_label: false
+    add_container_name_metric_label: false 
 ```
 There is no need to provide any parameters since they are all optional. 
 
@@ -54,6 +55,10 @@ The "PodName" attribute is set based on the name of the relevant controllers lik
 **add_full_pod_name_metric_label (optional)**
 
 The "FullPodName" attribute is the pod name including suffix. If false FullPodName label is not added. The default value is false
+
+**add_container_name_metric_label (optional)**
+
+The "ContainerName" attribute is the name of the container. If false ContainerName label is not added. The default value is false
 
 **cluster_name (optional)**
 

--- a/receiver/awscontainerinsightreceiver/config.go
+++ b/receiver/awscontainerinsightreceiver/config.go
@@ -40,6 +40,11 @@ type Config struct {
 	// The default value is false
 	AddFullPodNameMetricLabel bool `mapstructure:"add_full_pod_name_metric_label"`
 
+	// The "ContainerName" attribute is the name of the container
+	// If false ContainerName label is not added
+	// The default value is false
+	AddContainerNameMetricLabel bool `mapstructure:"add_container_name_metric_label"`
+
 	// ClusterName can be used to explicitly provide the Cluster's Name for scenarios where it's not
 	// possible to auto-detect it using EC2 tags.
 	ClusterName string `mapstructure:"cluster_name"`

--- a/receiver/awscontainerinsightreceiver/factory.go
+++ b/receiver/awscontainerinsightreceiver/factory.go
@@ -46,6 +46,9 @@ const (
 	// Don't tag pod full name by default
 	defaultAddFullPodNameMetricLabel = false
 
+	// Don't tag container name by default
+	defaultAddContainerNameMetricLabel = false
+
 	// Rely on EC2 tags to auto-detect cluster name by default
 	defaultClusterName = ""
 
@@ -64,13 +67,14 @@ func NewFactory() receiver.Factory {
 // createDefaultConfig returns a default config for the receiver.
 func createDefaultConfig() component.Config {
 	return &Config{
-		CollectionInterval:        defaultCollectionInterval,
-		ContainerOrchestrator:     defaultContainerOrchestrator,
-		TagService:                defaultTagService,
-		PrefFullPodName:           defaultPrefFullPodName,
-		AddFullPodNameMetricLabel: defaultAddFullPodNameMetricLabel,
-		ClusterName:               defaultClusterName,
-		LeaderLockName:            defaultLeaderLockName,
+		CollectionInterval:          defaultCollectionInterval,
+		ContainerOrchestrator:       defaultContainerOrchestrator,
+		TagService:                  defaultTagService,
+		PrefFullPodName:             defaultPrefFullPodName,
+		AddFullPodNameMetricLabel:   defaultAddFullPodNameMetricLabel,
+		AddContainerNameMetricLabel: defaultAddContainerNameMetricLabel,
+		ClusterName:                 defaultClusterName,
+		LeaderLockName:              defaultLeaderLockName,
 	}
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/stores/store.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/store.go
@@ -50,17 +50,19 @@ type K8sDecorator struct {
 	// It would be easier to keep the ctx here than passing it as a parameter for Decorate(...) function.
 	// The K8sStore (e.g. podstore) does network request in Decorate function, thus needs to take a context
 	// object for canceling the request
-	ctx context.Context
+	ctx                         context.Context
+	addContainerNameMetricLabel bool
 }
 
-func NewK8sDecorator(ctx context.Context, tagService bool, prefFullPodName bool, addFullPodNameMetricLabel bool, logger *zap.Logger) (*K8sDecorator, error) {
+func NewK8sDecorator(ctx context.Context, tagService bool, prefFullPodName bool, addFullPodNameMetricLabel bool, addContainerNameMetricLabel bool, logger *zap.Logger) (*K8sDecorator, error) {
 	hostIP := os.Getenv("HOST_IP")
 	if hostIP == "" {
 		return nil, errors.New("environment variable HOST_IP is not set in k8s deployment config")
 	}
 
 	k := &K8sDecorator{
-		ctx: ctx,
+		ctx:                         ctx,
+		addContainerNameMetricLabel: addContainerNameMetricLabel,
 	}
 
 	podstore, err := NewPodStore(hostIP, prefFullPodName, addFullPodNameMetricLabel, logger)
@@ -104,7 +106,7 @@ func (k *K8sDecorator) Decorate(metric *extractors.CAdvisorMetric) *extractors.C
 		}
 	}
 
-	AddKubernetesInfo(metric, kubernetesBlob)
+	AddKubernetesInfo(metric, kubernetesBlob, k.addContainerNameMetricLabel)
 	TagMetricSource(metric)
 	return metric
 }

--- a/receiver/awscontainerinsightreceiver/internal/stores/utils.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/utils.go
@@ -143,11 +143,15 @@ func TagMetricSource(metric CIMetric) {
 	}
 }
 
-func AddKubernetesInfo(metric CIMetric, kubernetesBlob map[string]interface{}) {
-	needMoveToKubernetes := map[string]string{ci.ContainerNamekey: "container_name", ci.K8sPodNameKey: "pod_name",
-		ci.PodIDKey: "pod_id"}
-
+func AddKubernetesInfo(metric CIMetric, kubernetesBlob map[string]interface{}, retainContainerNameTag bool) {
+	needMoveToKubernetes := map[string]string{ci.K8sPodNameKey: "pod_name", ci.PodIDKey: "pod_id"}
 	needCopyToKubernetes := map[string]string{ci.K8sNamespace: "namespace_name", ci.TypeService: "service_name", ci.NodeNameKey: "host"}
+
+	if retainContainerNameTag {
+		needCopyToKubernetes[ci.ContainerNamekey] = "container_name"
+	} else {
+		needMoveToKubernetes[ci.ContainerNamekey] = "container_name"
+	}
 
 	for k, v := range needMoveToKubernetes {
 		if attVal := metric.GetTag(k); attVal != "" {

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -76,7 +76,7 @@ func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host compone
 	}
 
 	if acir.config.ContainerOrchestrator == ci.EKS {
-		k8sDecorator, err := stores.NewK8sDecorator(ctx, acir.config.TagService, acir.config.PrefFullPodName, acir.config.AddFullPodNameMetricLabel, acir.settings.Logger)
+		k8sDecorator, err := stores.NewK8sDecorator(ctx, acir.config.TagService, acir.config.PrefFullPodName, acir.config.AddFullPodNameMetricLabel, acir.config.AddContainerNameMetricLabel, acir.settings.Logger)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**Description:** Add option for adding container name as a metric label. Currently, the container name tag/label is copied over to the kubernetes blob and there is no way to retain it as a label.
Example:
```
{
  "AutoScalingGroupName": "eks-cw1-ng-5ec244c0-bedf-d668-e90c-18064cc7c293",
  "ClusterName": "cw_gpu",
  "InstanceId": "i-0e1104896e4b76eb8",
  "InstanceType": "t3.small",
  "Namespace": "kube-system",
  "NodeName": "ip-192-168-228-23.ec2.internal",
  "PodName": "kube-proxy",
  "Sources": [
    "cadvisor",
    "pod",
    "calculated"
  ],
  "Timestamp": "1682460806199",
  "Type": "Container",
  "Version": "0",
  "container_cpu_request": 100,
  "container_cpu_usage_system": 0.2375214653312615,
  "container_cpu_usage_total": 0.44476191624426764,
  "container_cpu_usage_user": 0.1357265516178637,
  "container_cpu_utilization": 0.022238095812213383,
  "container_last_termination_reason": "Unknown",
  "container_memory_cache": 40144896,
  "container_memory_failcnt": 0,
  "container_memory_hierarchical_pgfault": 21.946983396608566,
  "container_memory_hierarchical_pgmajfault": 0,
  "container_memory_mapped_file": 29736960,
  "container_memory_max_usage": 52666368,
  "container_memory_pgfault": 21.946983396608566,
  "container_memory_pgmajfault": 0,
  "container_memory_rss": 9596928,
  "container_memory_swap": 0,
  "container_memory_usage": 50728960,
  "container_memory_utilization": 0.9148512534571693,
  "container_memory_working_set": 18575360,
  "container_status": "Running",
  "kubernetes": {
    "container_name": "kube-proxy",
    "containerd": {
      "container_id": "4837b6e1a389cc04ee5e1352f8b855414c98edbba36c8141e4ec13a20545e8a5"
    },
    "host": "ip-192-168-228-23.ec2.internal",
    "labels": {
      "controller-revision-hash": "5795b88684",
      "k8s-app": "kube-proxy",
      "pod-template-generation": "2"
    },
    "namespace_name": "kube-system",
    "pod_id": "8fd74bbf-be8c-4727-a8ec-d5c25f051b9a",
    "pod_name": "kube-proxy-ph9fp",
    "pod_owners": [
      {
        "owner_kind": "DaemonSet",
        "owner_name": "kube-proxy"
      }
    ]
  }
}
```
With this change, when set to true, the ContainerName should be retained as a label in the log event.
Example:
```
{
  "AutoScalingGroupName": "eks-cw1-ng-5ec244c0-bedf-d668-e90c-18064cc7c293",
  "ClusterName": "cw_gpu",
  "ContainerName": "kube-proxy", 
  "InstanceId": "i-0e1104896e4b76eb8",
  "InstanceType": "t3.small",
  "Namespace": "kube-system",
  "NodeName": "ip-192-168-228-23.ec2.internal",
  "PodName": "kube-proxy",
  "Sources": [
    "cadvisor",
    "pod",
    "calculated"
  ],
  "Timestamp": "1682460806199",
  "Type": "Container",
  "Version": "0",
  "container_cpu_request": 100,
  "container_cpu_usage_system": 0.2375214653312615,
  "container_cpu_usage_total": 0.44476191624426764,
  "container_cpu_usage_user": 0.1357265516178637,
  "container_cpu_utilization": 0.022238095812213383,
  "container_last_termination_reason": "Unknown",
  "container_memory_cache": 40144896,
  "container_memory_failcnt": 0,
  "container_memory_hierarchical_pgfault": 21.946983396608566,
  "container_memory_hierarchical_pgmajfault": 0,
  "container_memory_mapped_file": 29736960,
  "container_memory_max_usage": 52666368,
  "container_memory_pgfault": 21.946983396608566,
  "container_memory_pgmajfault": 0,
  "container_memory_rss": 9596928,
  "container_memory_swap": 0,
  "container_memory_usage": 50728960,
  "container_memory_utilization": 0.9148512534571693,
  "container_memory_working_set": 18575360,
  "container_status": "Running",
  "kubernetes": {
    "container_name": "kube-proxy",
    "containerd": {
      "container_id": "4837b6e1a389cc04ee5e1352f8b855414c98edbba36c8141e4ec13a20545e8a5"
    },
    "host": "ip-192-168-228-23.ec2.internal",
    "labels": {
      "controller-revision-hash": "5795b88684",
      "k8s-app": "kube-proxy",
      "pod-template-generation": "2"
    },
    "namespace_name": "kube-system",
    "pod_id": "8fd74bbf-be8c-4727-a8ec-d5c25f051b9a",
    "pod_name": "kube-proxy-ph9fp",
    "pod_owners": [
      {
        "owner_kind": "DaemonSet",
        "owner_name": "kube-proxy"
      }
    ]
  }
}
```

**Testing:** 
* Updated unit tests that verify the existence and absence of the ContainerName tag for both cases.
* Manual integration test with CWA EKS CI in progress.

**Documentation:** Updated README.md