### PR TITLE
[exporter/awsemfexporter] Always set Timestamp & Version for EMF v0

### DIFF
--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -368,6 +368,12 @@ func translateCWMetricToEMF(cWMetric *cWMetrics, config *Config) *cwlogs.Event {
 		}
 	}
 
+	// For backwards compatibility, if EMF v0, always include version & timestamp (even for non-EMF events)
+	if config.Version == "0" {
+		fieldMap["Version"] = "0"
+		fieldMap["Timestamp"] = fmt.Sprint(cWMetric.timestampMs)
+	}
+
 	// Create EMF metrics if there are measurements
 	// https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html#CloudWatch_Embedded_Metric_Format_Specification_structure
 	if len(cWMetric.measurements) > 0 {
@@ -405,11 +411,8 @@ func translateCWMetricToEMF(cWMetric *cWMetrics, config *Config) *cwlogs.Event {
 					"Timestamp": "1668387032641"
 			  	}
 			*/
-			fieldMap["Version"] = "0"
-			fieldMap["Timestamp"] = fmt.Sprint(cWMetric.timestampMs)
 			fieldMap["CloudWatchMetrics"] = cWMetric.measurements
 		}
-
 	}
 
 	pleMsg, err := json.Marshal(fieldMap)

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -600,6 +600,11 @@ func TestTranslateCWMetricToEMF(t *testing.T) {
 			measurements:        nil,
 			expectedEMFLogEvent: "{\"OTelLib\":\"cloudwatch-otel\",\"Sources\":[\"cadvisor\",\"pod\",\"calculated\"],\"kubernetes\":{\"container_name\":\"cloudwatch-agent\",\"docker\":{\"container_id\":\"fc1b0a4c3faaa1808e187486a3a90cbea883dccaf2e2c46d4069d663b032a1ca\"},\"host\":\"ip-192-168-58-245.ec2.internal\",\"labels\":{\"controller-revision-hash\":\"5bdbf497dc\",\"name\":\"cloudwatch-agent\",\"pod-template-generation\":\"1\"},\"namespace_name\":\"amazon-cloudwatch\",\"pod_id\":\"e23f3413-af2e-4a98-89e0-5df2251e7f05\",\"pod_name\":\"cloudwatch-agent-26bl6\",\"pod_owners\":[{\"owner_kind\":\"DaemonSet\",\"owner_name\":\"cloudwatch-agent\"}]},\"spanCounter\":0,\"spanName\":\"test\"}",
 		},
+		"WithNoMeasurementAndEMFV0": {
+			emfVersion:          "0",
+			measurements:        nil,
+			expectedEMFLogEvent: "{\"OTelLib\":\"cloudwatch-otel\",\"Sources\":[\"cadvisor\",\"pod\",\"calculated\"],\"Timestamp\":\"1596151098037\",\"Version\":\"0\",\"kubernetes\":{\"container_name\":\"cloudwatch-agent\",\"docker\":{\"container_id\":\"fc1b0a4c3faaa1808e187486a3a90cbea883dccaf2e2c46d4069d663b032a1ca\"},\"host\":\"ip-192-168-58-245.ec2.internal\",\"labels\":{\"controller-revision-hash\":\"5bdbf497dc\",\"name\":\"cloudwatch-agent\",\"pod-template-generation\":\"1\"},\"namespace_name\":\"amazon-cloudwatch\",\"pod_id\":\"e23f3413-af2e-4a98-89e0-5df2251e7f05\",\"pod_name\":\"cloudwatch-agent-26bl6\",\"pod_owners\":[{\"owner_kind\":\"DaemonSet\",\"owner_name\":\"cloudwatch-agent\"}]},\"spanCounter\":0,\"spanName\":\"test\"}",
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
**Description:** Always set Timestamp & Version for EMF v0 - even for non-EMF log events
* Example of existing non-EMF log event from CWA EKS CI:
```
{
  "AutoScalingGroupName": "eks-cw1-ng-5ec244c0-bedf-d668-e90c-18064cc7c293",
  "ClusterName": "cwa1",
  "InstanceId": "i-0e1104896e4b76eb8",
  "InstanceType": "t3.small",
  "NodeName": "ip-192-168-228-23.ec2.internal",
  "Sources": [
    "cadvisor",
    "calculated"
  ],
  "Timestamp": "1683149073064",
  "Type": "NodeNet",
  "Version": "0",
  "interface": "eth0",
  "kubernetes": {
    "host": "ip-192-168-228-23.ec2.internal"
  },
  "node_interface_network_rx_bytes": 3488.2609543812264,
  "node_interface_network_rx_dropped": 0,
  "node_interface_network_rx_errors": 0,
  "node_interface_network_rx_packets": 15.266481881592593,
  "node_interface_network_total_bytes": 8031.807898565579,
  "node_interface_network_tx_bytes": 4543.5469441843525,
  "node_interface_network_tx_dropped": 0,
  "node_interface_network_tx_errors": 0,
  "node_interface_network_tx_packets": 15.817728970596942
}
```

**Testing:** Updated unit tests