### PR TITLE
Tw control plane additional metrics

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_consumer.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_consumer.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 )
@@ -49,7 +48,6 @@ type prometheusConsumer struct {
 	logger            *zap.Logger
 	clusterName       string
 	nodeName          string
-	resource          pcommon.Resource
 	resourcesToType   map[string]string
 	metricsToResource map[string]string
 }

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_consumer.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_consumer.go
@@ -2,27 +2,51 @@ package k8sapiserver // import "github.com/open-telemetry/opentelemetry-collecto
 
 import (
 	"context"
-	"strconv"
-	"time"
+	"fmt"
 
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 )
 
+const (
+	controlPlaneResourceType = "control_plane"
+)
+
+var (
+	defaultResourceToType = map[string]string{
+		controlPlaneResourceType: "Cluster",
+	}
+	defaultMetricsToResource = map[string]string{
+		"apiserver_storage_objects":                                 controlPlaneResourceType,
+		"apiserver_request_total":                                   controlPlaneResourceType,
+		"apiserver_request_duration_seconds":                        controlPlaneResourceType,
+		"apiserver_admission_controller_admission_duration_seconds": controlPlaneResourceType,
+		"rest_client_request_duration_seconds":                      controlPlaneResourceType,
+		"etcd_request_duration_seconds":                             controlPlaneResourceType,
+		"etcd_db_total_size_in_bytes":                               controlPlaneResourceType,
+	}
+)
+
 type prometheusConsumer struct {
-	nextConsumer consumer.Metrics
-	logger       *zap.Logger
-	clusterName  string
-	nodeName     string
+	nextConsumer      consumer.Metrics
+	logger            *zap.Logger
+	clusterName       string
+	nodeName          string
+	resource          pcommon.Resource
+	resourcesToType   map[string]string
+	metricsToResource map[string]string
 }
 
 func newPrometheusConsumer(logger *zap.Logger, nextConsumer consumer.Metrics, clusterName string, nodeName string) prometheusConsumer {
 	return prometheusConsumer{
-		logger:       logger,
-		nextConsumer: nextConsumer,
-		clusterName:  clusterName,
-		nodeName:     nodeName,
+		logger:            logger,
+		nextConsumer:      nextConsumer,
+		clusterName:       clusterName,
+		nodeName:          nodeName,
+		resourcesToType:   defaultResourceToType,
+		metricsToResource: defaultMetricsToResource,
 	}
 }
 func (c prometheusConsumer) Capabilities() consumer.Capabilities {
@@ -31,24 +55,52 @@ func (c prometheusConsumer) Capabilities() consumer.Capabilities {
 	}
 }
 
-func (c prometheusConsumer) ConsumeMetrics(ctx context.Context, ld pmetric.Metrics) error {
-	rms := ld.ResourceMetrics()
+func (c prometheusConsumer) ConsumeMetrics(ctx context.Context, originalMetrics pmetric.Metrics) error {
 
-	for i := 0; i < rms.Len(); i++ {
+	localScopeMetrics := map[string]pmetric.ScopeMetrics{}
+	newMetrics := pmetric.NewMetrics()
 
-		rm := rms.At(i)
-		timestampNs := strconv.FormatInt(time.Now().UnixNano(), 10)
+	for key, value := range c.resourcesToType {
+		newResourceMetrics := newMetrics.ResourceMetrics().AppendEmpty()
+		// common attributes
+		newResourceMetrics.Resource().Attributes().PutStr("ClusterName", c.clusterName)
+		newResourceMetrics.Resource().Attributes().PutStr("Version", "0")
+		newResourceMetrics.Resource().Attributes().PutStr("Sources", "[\"apiserver\"]")
+		newResourceMetrics.Resource().Attributes().PutStr("NodeName", c.nodeName)
 
-		rm.Resource().Attributes().PutStr("ClusterName", c.clusterName)
-		rm.Resource().Attributes().PutStr("Type", "Cluster")
-		rm.Resource().Attributes().PutStr("Timestamp", timestampNs)
-		rm.Resource().Attributes().PutStr("Version", "0")
-		rm.Resource().Attributes().PutStr("Sources", "[\"apiserver\"]")
-		rm.Resource().Attributes().PutStr("NodeName", c.nodeName)
+		// resource-specific type metric
+		newResourceMetrics.Resource().Attributes().PutStr("Type", value)
 
-		// TODO: need to separate out metrics by type (cluster, service, etc)
+		newScopeMetrics := newResourceMetrics.ScopeMetrics().AppendEmpty()
+		localScopeMetrics[key] = newScopeMetrics
 	}
 
-	// forward on the metrics
-	return c.nextConsumer.ConsumeMetrics(ctx, ld)
+	rms := originalMetrics.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		scopeMetrics := rms.At(i).ScopeMetrics()
+		for j := 0; j < scopeMetrics.Len(); j++ {
+			scopeMetric := scopeMetrics.At(j)
+			for k := 0; k < scopeMetric.Metrics().Len(); k++ {
+				metric := scopeMetric.Metrics().At(k)
+				// check control plane metrics
+				resourceName, ok := c.metricsToResource[metric.Name()]
+				if !ok {
+					continue
+				}
+				resourceSpecificScopeMetrics, ok := localScopeMetrics[resourceName]
+				if !ok {
+					continue
+				}
+				c.logger.Debug(fmt.Sprintf("Copying metric %s into resource %s", metric.Name(), resourceName))
+				metric.CopyTo(resourceSpecificScopeMetrics.Metrics().AppendEmpty())
+			}
+		}
+	}
+
+	c.logger.Info("Forwarding on k8sapiserver prometheus metrics",
+		zap.Int("MetricCount", newMetrics.MetricCount()),
+		zap.Int("DataPointCount", newMetrics.DataPointCount()))
+
+	// forward on the new metrics
+	return c.nextConsumer.ConsumeMetrics(ctx, newMetrics)
 }

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_consumer.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_consumer.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package k8sapiserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8sapiserver"
 
 import (
@@ -24,6 +38,7 @@ var (
 		"apiserver_request_duration_seconds":                        controlPlaneResourceType,
 		"apiserver_admission_controller_admission_duration_seconds": controlPlaneResourceType,
 		"rest_client_request_duration_seconds":                      controlPlaneResourceType,
+		"rest_client_requests_total":                                controlPlaneResourceType,
 		"etcd_request_duration_seconds":                             controlPlaneResourceType,
 		"etcd_db_total_size_in_bytes":                               controlPlaneResourceType,
 	}
@@ -39,8 +54,8 @@ type prometheusConsumer struct {
 	metricsToResource map[string]string
 }
 
-func newPrometheusConsumer(logger *zap.Logger, nextConsumer consumer.Metrics, clusterName string, nodeName string) prometheusConsumer {
-	return prometheusConsumer{
+func newPrometheusConsumer(logger *zap.Logger, nextConsumer consumer.Metrics, clusterName string, nodeName string) *prometheusConsumer {
+	return &prometheusConsumer{
 		logger:            logger,
 		nextConsumer:      nextConsumer,
 		clusterName:       clusterName,

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_consumer_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_consumer_test.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package k8sapiserver
 
 import (

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_consumer_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_consumer_test.go
@@ -41,8 +41,8 @@ func (m mockNextConsumer) ConsumeMetrics(ctx context.Context, md pmetric.Metrics
 	assert.NotEmpty(m.t, value.Str())
 
 	value, found = md.ResourceMetrics().At(0).Resource().Attributes().Get("Timestamp")
-	assert.True(m.t, found)
-	assert.NotEmpty(m.t, value.Str())
+	assert.False(m.t, found)
+	assert.Empty(m.t, value.Str())
 
 	value, found = md.ResourceMetrics().At(0).Resource().Attributes().Get("Sources")
 	assert.True(m.t, found)
@@ -51,6 +51,15 @@ func (m mockNextConsumer) ConsumeMetrics(ctx context.Context, md pmetric.Metrics
 	value, found = md.ResourceMetrics().At(0).Resource().Attributes().Get("NodeName")
 	assert.True(m.t, found)
 	assert.Equal(m.t, "test-node", value.Str())
+
+	assert.Equal(m.t, len(defaultResourceToType), md.ResourceMetrics().Len())
+	assert.Equal(m.t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+
+	metric1 := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+	assert.Equal(m.t, "apiserver_storage_objects", metric1.Name())
+	assert.Equal(m.t, 123.4, metric1.Gauge().DataPoints().At(0).DoubleValue())
+
+	assert.Equal(m.t, 1, md.MetricCount())
 
 	return nil
 }
@@ -62,12 +71,28 @@ func TestPrometheusConsumeMetrics(t *testing.T) {
 	}
 
 	consumer := newPrometheusConsumer(zap.NewNop(), nextConsumer, "test-cluster", "test-node")
+	consumer.metricsToResource["invalid-metrics-to-resource"] = "invalid"
 
 	cap := consumer.Capabilities()
 	assert.True(t, cap.MutatesData)
 
 	metrics := pmetric.NewMetrics()
-	metrics.ResourceMetrics().AppendEmpty()
+	metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	metric1 := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+	metric1.SetName("apiserver_storage_objects")
+	metric1.SetEmptyGauge().DataPoints().AppendEmpty().SetDoubleValue(123.4)
+
+	metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().AppendEmpty()
+	metric2 := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(1)
+	metric2.SetName("some_excluded_metric")
+	metric2.SetEmptyGauge().DataPoints().AppendEmpty().SetDoubleValue(456.7)
+
+	metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().AppendEmpty()
+	metric3 := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(1)
+	metric3.SetName("invalid-metrics-to-resource")
+	metric3.SetEmptyGauge().DataPoints().AppendEmpty().SetDoubleValue(99.9)
+
+	assert.Equal(t, 3, metrics.MetricCount())
 
 	result := consumer.ConsumeMetrics(context.TODO(), metrics)
 	assert.NoError(t, result)

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package k8sapiserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8sapiserver"
 
 import (

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configtls"
@@ -29,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver"
 )
 
 const (
@@ -95,10 +95,10 @@ func NewPrometheusScraper(ctx context.Context, telemetrySettings component.Telem
 	}, nil
 }
 
-func (ps *PrometheusScraper) Start() {
-	ps.simplePrometheusReceiver.Start(ps.ctx, ps.host)
+func (ps *PrometheusScraper) Start() error {
+	return ps.simplePrometheusReceiver.Start(ps.ctx, ps.host)
 }
 
-func (ps *PrometheusScraper) Shutdown() {
-	ps.simplePrometheusReceiver.Shutdown(ps.ctx)
+func (ps *PrometheusScraper) Shutdown() error {
+	return ps.simplePrometheusReceiver.Shutdown(ps.ctx)
 }

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper_test.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package k8sapiserver
 
 import (

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -29,6 +28,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver"
 )
 
 const renameMetric = `
@@ -108,6 +109,7 @@ func TestNewPrometheusScraperEndToEnd(t *testing.T) {
 		},
 	}
 	mp, cfg, err := setupMockPrometheus(targets...)
+	assert.NoError(t, err)
 
 	split := strings.Split(mp.srv.URL, "http://")
 
@@ -133,10 +135,10 @@ func TestNewPrometheusScraperEndToEnd(t *testing.T) {
 	assert.NotNil(t, mp)
 	defer mp.Close()
 
-	scraper.Start()
+	assert.NoError(t, scraper.Start())
 
 	t.Cleanup(func() {
-		scraper.Shutdown()
+		assert.NoError(t, scraper.Shutdown())
 	})
 
 	// wait for scrape

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -143,7 +143,7 @@ func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host compone
 // Shutdown stops the awsContainerInsightReceiver receiver.
 func (acir *awsContainerInsightReceiver) Shutdown(context.Context) error {
 	if acir.prometheusScraper != nil {
-		acir.prometheusScraper.Shutdown()
+		acir.prometheusScraper.Shutdown() //nolint:errcheck
 	}
 
 	if acir.cancel == nil {


### PR DESCRIPTION
**Description:** 
Add 6 additional control plane metrics.  These are raw metrics that are emitting **a lot** of data points.  Next step is to do aggregation of the data points

This builds on this PR: https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/14

The following diff in CCWA enable the metrics:
```
diff --git a/translator/translate/otel/exporter/awsemf/kubernetes.go b/translator/translate/otel/exporter/awsemf/kubernetes.go
index d9c6476..00dc8e4 100644
--- a/translator/translate/otel/exporter/awsemf/kubernetes.go
+++ b/translator/translate/otel/exporter/awsemf/kubernetes.go
@@ -4,9 +4,10 @@
 package awsemf

 import (
-       "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter"
        "go.opentelemetry.io/collector/confmap"

+       "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter"
+
        "github.com/aws/private-amazon-cloudwatch-agent-staging/translator/translate/otel/common"
 )

@@ -88,6 +89,39 @@ func setKubernetesMetricDeclaration(conf *confmap.Conf, cfg *awsemfexporter.Conf
                },
        }...)

+       kubernetesMetricDeclarations = append(kubernetesMetricDeclarations, []*awsemfexporter.MetricDeclaration{
+               {
+                       Dimensions: [][]string{{"ClusterName", "resource"}},
+                       MetricNameSelectors: []string{
+                               "apiserver_storage_objects", // For testing
+                       },
+               },
+               {
+                       Dimensions: [][]string{{"ClusterName", "code"}},
+                       MetricNameSelectors: []string{
+                               "apiserver_request_total",
+                       },
+               },
+               {
+                       Dimensions: [][]string{{"ClusterName", "endpoint"}},
+                       MetricNameSelectors: []string{
+                               "etcd_db_total_size_in_bytes",
+                       },
+               },
+               {
+                       Dimensions: [][]string{{"ClusterName"}},
+                       MetricNameSelectors: []string{
+                               "apiserver_storage_objects",
+                               "apiserver_request_total",
+                               "apiserver_request_duration_seconds",
+                               "apiserver_admission_controller_admission_duration_seconds",
+                               "rest_client_request_duration_seconds",
+                               "etcd_request_duration_seconds",
+                               "etcd_db_total_size_in_bytes",
+                       },
+               },
+       }...)
+
        // Setup service metrics
        kubernetesMetricDeclarations = append(kubernetesMetricDeclarations, []*awsemfexporter.MetricDeclaration{
                {
```

Relevant commit:
https://github.com/amazon-contributing/opentelemetry-collector-contrib/commit/5df18e7d9fada4b185e37061f63e833ea105b406

**Link to tracking Issue:** <Issue number if applicable>

**Testing:**Metrics flowing
![Screen Shot 2023-05-22 at 4 53 06 PM](https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/5192710/acf6f56b-e523-4ca7-90fa-8020394d784e)


**Documentation:** <Describe the documentation added.>