### PR TITLE
[receiver/awscontainerinsightreceiver] Add new node level status metrics

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -86,6 +86,14 @@ const (
 	FSInodesfree  = "filesystem_inodes_free"
 	FSUtilization = "filesystem_utilization"
 
+	StatusConditionReady              = "status_condition_ready"
+	StatusConditionDiskPressure       = "status_condition_disk_pressure"
+	StatusConditionMemoryPressure     = "status_condition_memory_pressure"
+	StatusConditionPIDPressure        = "status_condition_pid_pressure"
+	StatusConditionNetworkUnavailable = "status_condition_network_unavailable"
+	StatusCapacityPods                = "status_capacity_pods"
+	StatusAllocatablePods             = "status_allocatable_pods"
+
 	RunningPodCount       = "number_of_running_pods"
 	RunningContainerCount = "number_of_running_containers"
 	ContainerCount        = "number_of_containers"
@@ -200,6 +208,15 @@ func init() {
 		FSInodes:      UnitCount,
 		FSInodesfree:  UnitCount,
 		FSUtilization: UnitPercent,
+
+		// status metrics
+		StatusConditionReady:              UnitCount,
+		StatusConditionDiskPressure:       UnitCount,
+		StatusConditionMemoryPressure:     UnitCount,
+		StatusConditionPIDPressure:        UnitCount,
+		StatusConditionNetworkUnavailable: UnitCount,
+		StatusCapacityPods:                UnitCount,
+		StatusAllocatablePods:             UnitCount,
 
 		// cluster metrics
 		NodeCount:       UnitCount,

--- a/internal/aws/k8s/k8sclient/clientset_test.go
+++ b/internal/aws/k8s/k8sclient/clientset_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/fields"
 )
 
 func TestGetShutdown(t *testing.T) {
@@ -29,6 +30,8 @@ func TestGetShutdown(t *testing.T) {
 		KubeConfigPath(tmpConfigPath),
 		InitSyncPollInterval(10*time.Nanosecond),
 		InitSyncPollTimeout(20*time.Nanosecond),
+		NodeSelector(fields.OneTermEqualSelector("testField", "testVal")),
+		CaptureNodeLevelInfo(true),
 	)
 	assert.Equal(t, 1, len(optionsToK8sClient))
 	assert.NotNil(t, k8sClient.GetClientSet())
@@ -37,6 +40,8 @@ func TestGetShutdown(t *testing.T) {
 	assert.NotNil(t, k8sClient.GetNodeClient())
 	assert.NotNil(t, k8sClient.GetPodClient())
 	assert.NotNil(t, k8sClient.GetReplicaSetClient())
+	assert.True(t, k8sClient.captureNodeLevelInfo)
+	assert.Equal(t, "testField=testVal", k8sClient.nodeSelector.String())
 	k8sClient.Shutdown()
 	assert.Nil(t, k8sClient.ep)
 	assert.Nil(t, k8sClient.job)

--- a/internal/aws/k8s/k8sclient/node.go
+++ b/internal/aws/k8s/k8sclient/node.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -41,6 +42,9 @@ type NodeClient interface {
 	ClusterFailedNodeCount() int
 	// Get the number of nodes for current cluster
 	ClusterNodeCount() int
+	NodeToCapacityMap() map[string]v1.ResourceList
+	NodeToAllocatableMap() map[string]v1.ResourceList
+	NodeToConditionsMap() map[string]map[v1.NodeConditionType]v1.ConditionStatus
 }
 
 type nodeClientOption func(*nodeClient)
@@ -51,16 +55,39 @@ func nodeSyncCheckerOption(checker initialSyncChecker) nodeClientOption {
 	}
 }
 
+func nodeSelectorOption(nodeSelector fields.Selector) nodeClientOption {
+	return func(n *nodeClient) {
+		n.nodeSelector = nodeSelector
+	}
+}
+
+func captureNodeLevelInfoOption(captureNodeLevelInfo bool) nodeClientOption {
+	return func(n *nodeClient) {
+		n.captureNodeLevelInfo = captureNodeLevelInfo
+	}
+}
+
 type nodeClient struct {
 	stopChan chan struct{}
 	store    *ObjStore
+	logger   *zap.Logger
 
 	stopped     bool
 	syncChecker initialSyncChecker
 
+	nodeSelector fields.Selector
+
+	// The node client can be used in several places, including code paths that execute on both leader and non-leader nodes.
+	// But for logic on the leader node (for ex in k8sapiserver.go), there is no need to obtain node level info since only cluster
+	// level info is needed there. Hence, this optimization allows us to save on memory by not capturing node level info when not needed.
+	captureNodeLevelInfo bool
+
 	mu                     sync.RWMutex
 	clusterFailedNodeCount int
 	clusterNodeCount       int
+	nodeToCapacityMap      map[string]v1.ResourceList
+	nodeToAllocatableMap   map[string]v1.ResourceList
+	nodeToConditionsMap    map[string]map[v1.NodeConditionType]v1.ConditionStatus
 }
 
 func (c *nodeClient) ClusterFailedNodeCount() int {
@@ -81,6 +108,42 @@ func (c *nodeClient) ClusterNodeCount() int {
 	return c.clusterNodeCount
 }
 
+func (c *nodeClient) NodeToCapacityMap() map[string]v1.ResourceList {
+	if !c.captureNodeLevelInfo {
+		c.logger.Warn("trying to access node level info when captureNodeLevelInfo is not set, will return empty data")
+	}
+	if c.store.GetResetRefreshStatus() {
+		c.refresh()
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.nodeToCapacityMap
+}
+
+func (c *nodeClient) NodeToAllocatableMap() map[string]v1.ResourceList {
+	if !c.captureNodeLevelInfo {
+		c.logger.Warn("trying to access node level info when captureNodeLevelInfo is not set, will return empty data")
+	}
+	if c.store.GetResetRefreshStatus() {
+		c.refresh()
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.nodeToAllocatableMap
+}
+
+func (c *nodeClient) NodeToConditionsMap() map[string]map[v1.NodeConditionType]v1.ConditionStatus {
+	if !c.captureNodeLevelInfo {
+		c.logger.Warn("trying to access node level info when captureNodeLevelInfo is not set, will return empty data")
+	}
+	if c.store.GetResetRefreshStatus() {
+		c.refresh()
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.nodeToConditionsMap
+}
+
 func (c *nodeClient) refresh() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -89,9 +152,22 @@ func (c *nodeClient) refresh() {
 
 	clusterFailedNodeCountNew := 0
 	clusterNodeCountNew := 0
+	nodeToCapacityMap := make(map[string]v1.ResourceList)
+	nodeToAllocatableMap := make(map[string]v1.ResourceList)
+	nodeToConditionsMap := make(map[string]map[v1.NodeConditionType]v1.ConditionStatus)
+
 	for _, obj := range objsList {
 		node := obj.(*nodeInfo)
 
+		if c.captureNodeLevelInfo {
+			nodeToCapacityMap[node.name] = node.capacity
+			nodeToAllocatableMap[node.name] = node.allocatable
+			conditionsMap := make(map[v1.NodeConditionType]v1.ConditionStatus)
+			for _, condition := range node.conditions {
+				conditionsMap[condition.Type] = condition.Status
+			}
+			nodeToConditionsMap[node.name] = conditionsMap
+		}
 		clusterNodeCountNew++
 
 		failed := false
@@ -115,11 +191,15 @@ func (c *nodeClient) refresh() {
 
 	c.clusterFailedNodeCount = clusterFailedNodeCountNew
 	c.clusterNodeCount = clusterNodeCountNew
+	c.nodeToCapacityMap = nodeToCapacityMap
+	c.nodeToAllocatableMap = nodeToAllocatableMap
+	c.nodeToConditionsMap = nodeToConditionsMap
 }
 
 func newNodeClient(clientSet kubernetes.Interface, logger *zap.Logger, options ...nodeClientOption) *nodeClient {
 	c := &nodeClient{
 		stopChan: make(chan struct{}),
+		logger:   logger,
 	}
 
 	for _, option := range options {
@@ -128,7 +208,7 @@ func newNodeClient(clientSet kubernetes.Interface, logger *zap.Logger, options .
 
 	c.store = NewObjStore(transformFuncNode, logger)
 
-	lw := createNodeListWatch(clientSet)
+	lw := c.createNodeListWatch(clientSet)
 	reflector := cache.NewReflector(lw, &v1.Node{}, c.store, 0)
 	go reflector.Run(c.stopChan)
 
@@ -154,9 +234,12 @@ func transformFuncNode(obj interface{}) (interface{}, error) {
 		return nil, fmt.Errorf("input obj %v is not Node type", obj)
 	}
 	info := new(nodeInfo)
-	info.conditions = []*nodeCondition{}
+	info.name = node.Name
+	info.capacity = node.Status.Capacity
+	info.allocatable = node.Status.Allocatable
+	info.conditions = []*NodeCondition{}
 	for _, condition := range node.Status.Conditions {
-		info.conditions = append(info.conditions, &nodeCondition{
+		info.conditions = append(info.conditions, &NodeCondition{
 			Type:   condition.Type,
 			Status: condition.Status,
 		})
@@ -164,13 +247,19 @@ func transformFuncNode(obj interface{}) (interface{}, error) {
 	return info, nil
 }
 
-func createNodeListWatch(client kubernetes.Interface) cache.ListerWatcher {
+func (c *nodeClient) createNodeListWatch(client kubernetes.Interface) cache.ListerWatcher {
 	ctx := context.Background()
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			if c.nodeSelector != nil {
+				opts.FieldSelector = c.nodeSelector.String()
+			}
 			return client.CoreV1().Nodes().List(ctx, opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			if c.nodeSelector != nil {
+				opts.FieldSelector = c.nodeSelector.String()
+			}
 			return client.CoreV1().Nodes().Watch(ctx, opts)
 		},
 	}

--- a/internal/aws/k8s/k8sclient/node_info.go
+++ b/internal/aws/k8s/k8sclient/node_info.go
@@ -19,10 +19,13 @@ import (
 )
 
 type nodeInfo struct {
-	conditions []*nodeCondition
+	name        string
+	conditions  []*NodeCondition
+	capacity    v1.ResourceList
+	allocatable v1.ResourceList
 }
 
-type nodeCondition struct {
+type NodeCondition struct {
 	Type   v1.NodeConditionType
 	Status v1.ConditionStatus
 }

--- a/internal/aws/k8s/k8sclient/node_test.go
+++ b/internal/aws/k8s/k8sclient/node_test.go
@@ -15,13 +15,14 @@
 package k8sclient
 
 import (
-	"log"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -53,6 +54,12 @@ var nodeArray = []interface{}{
 			},
 		},
 		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourcePods: *resource.NewQuantity(5, resource.DecimalSI),
+			},
+			Allocatable: v1.ResourceList{
+				v1.ResourcePods: *resource.NewQuantity(5, resource.DecimalSI),
+			},
 			Conditions: []v1.NodeCondition{
 				{
 					Type:   "MemoryPressure",
@@ -143,6 +150,12 @@ var nodeArray = []interface{}{
 			},
 		},
 		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourcePods: *resource.NewQuantity(10, resource.DecimalSI),
+			},
+			Allocatable: v1.ResourceList{
+				v1.ResourcePods: *resource.NewQuantity(10, resource.DecimalSI),
+			},
 			Conditions: []v1.NodeCondition{
 				{
 					Type:   "MemoryPressure",
@@ -233,6 +246,12 @@ var nodeArray = []interface{}{
 			},
 		},
 		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourcePods: *resource.NewQuantity(5, resource.DecimalSI),
+			},
+			Allocatable: v1.ResourceList{
+				v1.ResourcePods: *resource.NewQuantity(1, resource.DecimalSI),
+			},
 			Conditions: []v1.NodeCondition{
 				{
 					Type:   "MemoryPressure",
@@ -272,7 +291,7 @@ var nodeArray = []interface{}{
 				},
 				{
 					Type:   "Ready",
-					Status: "True",
+					Status: "False",
 					LastHeartbeatTime: metav1.Time{
 						Time: time.Now(),
 					},
@@ -280,7 +299,7 @@ var nodeArray = []interface{}{
 						Time: time.Now(),
 					},
 					Reason:  "KubeletReady",
-					Message: "kubelet is posting ready status",
+					Message: "kubelet is not posting ready status",
 				},
 			},
 			NodeInfo: v1.NodeSystemInfo{
@@ -300,22 +319,91 @@ var nodeArray = []interface{}{
 }
 
 func TestNodeClient(t *testing.T) {
-	setOption := nodeSyncCheckerOption(&mockReflectorSyncChecker{})
+	testCases := map[string]struct {
+		options []nodeClientOption
+		want    map[string]interface{}
+	}{
+		"Default": {
+			options: []nodeClientOption{
+				nodeSyncCheckerOption(&mockReflectorSyncChecker{}),
+			},
+			want: map[string]interface{}{
+				"clusterNodeCount":       3,
+				"clusterFailedNodeCount": 1,
+				"nodeToCapacityMap":      map[string]v1.ResourceList{},                             // Node level info is not captured by default
+				"nodeToAllocatableMap":   map[string]v1.ResourceList{},                             // Node level info is not captured by default
+				"nodeToConditionsMap":    map[string]map[v1.NodeConditionType]v1.ConditionStatus{}, // Node level info is not captured by default
+			},
+		},
+		"CaptureNodeLevelInfo": {
+			options: []nodeClientOption{
+				nodeSyncCheckerOption(&mockReflectorSyncChecker{}),
+				captureNodeLevelInfoOption(true),
+			},
+			want: map[string]interface{}{
+				"clusterNodeCount":       3,
+				"clusterFailedNodeCount": 1,
+				"nodeToCapacityMap": map[string]v1.ResourceList{
+					"ip-192-168-200-63.eu-west-1.compute.internal": {
+						"pods": *resource.NewQuantity(5, resource.DecimalSI),
+					},
+					"ip-192-168-76-61.eu-west-1.compute.internal": {
+						"pods": *resource.NewQuantity(10, resource.DecimalSI),
+					},
+					"ip-192-168-153-1.eu-west-1.compute.internal": {
+						"pods": *resource.NewQuantity(5, resource.DecimalSI),
+					},
+				},
+				"nodeToAllocatableMap": map[string]v1.ResourceList{
+					"ip-192-168-200-63.eu-west-1.compute.internal": {
+						"pods": *resource.NewQuantity(5, resource.DecimalSI),
+					},
+					"ip-192-168-76-61.eu-west-1.compute.internal": {
+						"pods": *resource.NewQuantity(10, resource.DecimalSI),
+					},
+					"ip-192-168-153-1.eu-west-1.compute.internal": {
+						"pods": *resource.NewQuantity(1, resource.DecimalSI),
+					},
+				},
+				"nodeToConditionsMap": map[string]map[v1.NodeConditionType]v1.ConditionStatus{
+					"ip-192-168-200-63.eu-west-1.compute.internal": {
+						"DiskPressure":   "False",
+						"MemoryPressure": "False",
+						"PIDPressure":    "False",
+						"Ready":          "True",
+					},
+					"ip-192-168-76-61.eu-west-1.compute.internal": {
+						"DiskPressure":   "False",
+						"MemoryPressure": "False",
+						"PIDPressure":    "False",
+						"Ready":          "True",
+					},
+					"ip-192-168-153-1.eu-west-1.compute.internal": {
+						"DiskPressure":   "True",
+						"MemoryPressure": "False",
+						"PIDPressure":    "False",
+						"Ready":          "False",
+					},
+				},
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			fakeClientSet := fake.NewSimpleClientset()
+			client := newNodeClient(fakeClientSet, zap.NewNop(), testCase.options...)
+			assert.NoError(t, client.store.Replace(nodeArray, ""))
 
-	fakeClientSet := fake.NewSimpleClientset()
-	client := newNodeClient(fakeClientSet, zap.NewNop(), setOption)
-	assert.NoError(t, client.store.Replace(nodeArray, ""))
+			require.Equal(t, testCase.want["clusterNodeCount"], client.ClusterNodeCount())
+			require.Equal(t, testCase.want["clusterFailedNodeCount"], client.ClusterFailedNodeCount())
+			require.Equal(t, testCase.want["nodeToCapacityMap"], client.NodeToCapacityMap())
+			require.Equal(t, testCase.want["nodeToAllocatableMap"], client.NodeToAllocatableMap())
+			require.Equal(t, testCase.want["nodeToConditionsMap"], client.NodeToConditionsMap())
 
-	expectedClusterNodeCount := 3
-	expectedClusterFailedNodeCount := 1
-	clusterNodeCount := client.ClusterNodeCount()
-	clusterFailedNodeCount := client.ClusterFailedNodeCount()
-	log.Printf("clusterNodeCount: %v, clusterFailedNodeCount: %v", clusterNodeCount, clusterFailedNodeCount)
-
-	assert.Equal(t, clusterNodeCount, expectedClusterNodeCount)
-	assert.Equal(t, clusterFailedNodeCount, expectedClusterFailedNodeCount)
-	client.shutdown()
-	assert.True(t, client.stopped)
+			client.shutdown()
+			assert.True(t, client.stopped)
+		})
+	}
 }
 
 func TestTransformFuncNode(t *testing.T) {

--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -400,42 +400,49 @@ kubectl apply -f config.yaml
 <br/><br/> 
 
 ### Node
-| Metric                              | Unit          |
-|-------------------------------------|---------------|
-| node_cpu_limit                      | Millicore     |
-| node_cpu_request                    | Millicore     |
-| node_cpu_reserved_capacity          | Percent       |
-| node_cpu_usage_system               | Millicore     |
-| node_cpu_usage_total                | Millicore     |
-| node_cpu_usage_user                 | Millicore     |
-| node_cpu_utilization                | Percent       |
-| node_memory_cache                   | Bytes         |
-| node_memory_failcnt                 | Count         |
-| node_memory_hierarchical_pgfault    | Count/Second  |
-| node_memory_hierarchical_pgmajfault | Count/Second  |
-| node_memory_limit                   | Bytes         |
-| node_memory_mapped_file             | Bytes         |
-| node_memory_max_usage               | Bytes         |
-| node_memory_pgfault                 | Count/Second  |
-| node_memory_pgmajfault              | Count/Second  |
-| node_memory_request                 | Bytes         |
-| node_memory_reserved_capacity       | Percent       |
-| node_memory_rss                     | Bytes         |
-| node_memory_swap                    | Bytes         |
-| node_memory_usage                   | Bytes         |
-| node_memory_utilization             | Percent       |
-| node_memory_working_set             | Bytes         |
-| node_network_rx_bytes               | Bytes/Second  |
-| node_network_rx_dropped             | Count/Second  |
-| node_network_rx_errors              | Count/Second  |
-| node_network_rx_packets             | Count/Second  |
-| node_network_total_bytes            | Bytes/Second  |
-| node_network_tx_bytes               | Bytes/Second  |
-| node_network_tx_dropped             | Count/Second  |
-| node_network_tx_errors              | Count/Second  |
-| node_network_tx_packets             | Count/Second  |
-| node_number_of_running_containers   | Count         |
-| node_number_of_running_pods         | Count         |
+| Metric                                    | Unit         |
+|-------------------------------------------|--------------|
+| node_cpu_limit                            | Millicore    |
+| node_cpu_request                          | Millicore    |
+| node_cpu_reserved_capacity                | Percent      |
+| node_cpu_usage_system                     | Millicore    |
+| node_cpu_usage_total                      | Millicore    |
+| node_cpu_usage_user                       | Millicore    |
+| node_cpu_utilization                      | Percent      |
+| node_memory_cache                         | Bytes        |
+| node_memory_failcnt                       | Count        |
+| node_memory_hierarchical_pgfault          | Count/Second |
+| node_memory_hierarchical_pgmajfault       | Count/Second |
+| node_memory_limit                         | Bytes        |
+| node_memory_mapped_file                   | Bytes        |
+| node_memory_max_usage                     | Bytes        |
+| node_memory_pgfault                       | Count/Second |
+| node_memory_pgmajfault                    | Count/Second |
+| node_memory_request                       | Bytes        |
+| node_memory_reserved_capacity             | Percent      |
+| node_memory_rss                           | Bytes        |
+| node_memory_swap                          | Bytes        |
+| node_memory_usage                         | Bytes        |
+| node_memory_utilization                   | Percent      |
+| node_memory_working_set                   | Bytes        |
+| node_network_rx_bytes                     | Bytes/Second |
+| node_network_rx_dropped                   | Count/Second |
+| node_network_rx_errors                    | Count/Second |
+| node_network_rx_packets                   | Count/Second |
+| node_network_total_bytes                  | Bytes/Second |
+| node_network_tx_bytes                     | Bytes/Second |
+| node_network_tx_dropped                   | Count/Second |
+| node_network_tx_errors                    | Count/Second |
+| node_network_tx_packets                   | Count/Second |
+| node_number_of_running_containers         | Count        |
+| node_number_of_running_pods               | Count        |
+| node_status_condition_ready               | Count        |
+| node_status_condition_pid_pressure        | Count        |
+| node_status_condition_memory_pressure     | Count        |
+| node_status_condition_disk_pressure       | Count        |
+| node_status_condition_network_unavailable | Count        |
+| node_status_capacity_pods                 | Count        |
+| node_status_allocatable_pods              | Count        |
 
 <br/><br/> 
 | Resource Attribute   |

--- a/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
 )
 
 type nodeStats struct {
@@ -29,6 +30,9 @@ type nodeStats struct {
 }
 
 type nodeInfo struct {
+	nodeName string
+	provider nodeInfoProvider
+
 	statsLock sync.RWMutex
 	nodeStats nodeStats
 
@@ -41,9 +45,17 @@ type nodeInfo struct {
 	logger *zap.Logger
 }
 
-func newNodeInfo(logger *zap.Logger) *nodeInfo {
+type nodeInfoProvider interface {
+	NodeToCapacityMap() map[string]v1.ResourceList
+	NodeToAllocatableMap() map[string]v1.ResourceList
+	NodeToConditionsMap() map[string]map[v1.NodeConditionType]v1.ConditionStatus
+}
+
+func newNodeInfo(nodeName string, provider nodeInfoProvider, logger *zap.Logger) *nodeInfo {
 	nc := &nodeInfo{
-		logger: logger,
+		nodeName: nodeName,
+		provider: provider,
+		logger:   logger,
 	}
 	return nc
 }
@@ -82,6 +94,36 @@ func (n *nodeInfo) getNodeStats() nodeStats {
 	n.statsLock.RLock()
 	defer n.statsLock.RUnlock()
 	return n.nodeStats
+}
+
+func (n *nodeInfo) getNodeStatusCapacityPods() (uint64, bool) {
+	capacityResources, ok := n.provider.NodeToCapacityMap()[n.nodeName]
+	if !ok {
+		return 0, false
+	}
+	pods, _ := capacityResources.Pods().AsInt64()
+	return forceConvertToInt64(pods, n.logger), true
+}
+
+func (n *nodeInfo) getNodeStatusAllocatablePods() (uint64, bool) {
+	allocatableResources, ok := n.provider.NodeToAllocatableMap()[n.nodeName]
+	if !ok {
+		return 0, false
+	}
+	pods, _ := allocatableResources.Pods().AsInt64()
+	return forceConvertToInt64(pods, n.logger), true
+}
+
+func (n *nodeInfo) getNodeStatusCondition(conditionType v1.NodeConditionType) (uint64, bool) {
+	if nodeConditions, ok := n.provider.NodeToConditionsMap()[n.nodeName]; ok {
+		if conditionType, ok := nodeConditions[conditionType]; ok {
+			if conditionType == v1.ConditionTrue {
+				return 1, true
+			}
+			return 0, true // v1.ConditionFalse or v1.ConditionUnknown
+		}
+	}
+	return 0, false
 }
 
 func forceConvertToInt64(v interface{}, logger *zap.Logger) uint64 {


### PR DESCRIPTION
### Description 
This change introduces new node level metrics that help understand the status of a node. Precisely, the new metrics are:
* node_status_condition_ready
* node_status_condition_pid_pressure
* node_status_condition_memory_pressure
* node_status_condition_disk_pressure
* node_status_capacity_pods
* node_status_allocatable_pods

These metrics are typically consumed by customers at two aggregation levels: at a cluster level and at a node level. Customers can do this by specifying two dimension sets in their [awsemfexporter's](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awsemfexporter) `metric_declaration` config corresponding to `[ClusterName]` and `[ClusterName, InstanceId, NodeName]`.

This code while running on each node in the cluster queries the status of the node its running on via the k8s api server. The filtering of request to just the node is done via the `NodeSelector` config option while initializing the k8s api server client. 

Note that other places in the code such as the `k8sapiserver.go` logic that also acquire a k8s api server client do not pass a node filter and hence by default, they would pull back the status of every node in the cluster and persist in memory and never really use this info - which is wasteful. Hence to avoid this, a client level config option `CaptureNodeLevelInfo` is introduced that persists node level info only when set explicitly to true.

### Testing
#### Setup
* Deployed changes to a dev cluster running with 2 nodes.

#### Analysis of new metrics introduced by the change
<img width="1235" alt="image" src="https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/108111936/176502e9-d92b-42a3-9f8f-293efde8e180">

* The following is the filtered-down output of `kubectl describe node`
```
Name:               ip-192-168-172-149.ec2.internal
Conditions:
  Type             Status  LastHeartbeatTime                 LastTransitionTime                Reason                       Message
  ----             ------  -----------------                 ------------------                ------                       -------
  MemoryPressure   False   Tue, 23 May 2023 22:52:32 -0400   Mon, 22 May 2023 01:13:47 -0400   KubeletHasSufficientMemory   kubelet has sufficient memory available
  DiskPressure     False   Tue, 23 May 2023 22:52:32 -0400   Mon, 22 May 2023 01:13:47 -0400   KubeletHasNoDiskPressure     kubelet has no disk pressure
  PIDPressure      False   Tue, 23 May 2023 22:52:32 -0400   Mon, 22 May 2023 01:13:47 -0400   KubeletHasSufficientPID      kubelet has sufficient PID available
  Ready            True    Tue, 23 May 2023 22:52:32 -0400   Mon, 22 May 2023 01:13:47 -0400   KubeletReady                 kubelet is posting ready status
Capacity:
  attachable-volumes-aws-ebs:  25
  cpu:                         2
  ephemeral-storage:           10473452Ki
  hugepages-1Gi:               0
  hugepages-2Mi:               0
  memory:                      1970520Ki
  pods:                        11
Allocatable:
  attachable-volumes-aws-ebs:  25
  cpu:                         1930m
  ephemeral-storage:           8578591524
  hugepages-1Gi:               0
  hugepages-2Mi:               0
  memory:                      1483096Ki
  pods:                        11
```
* As can be seen above, both the capacity & allocatable pods have a value of 11 which match the metric values.
* Similarly, it can be seen the node has a status condition of `Ready` and accordingly, the `node_status_condition_ready` has a value 1 and the other status condition metrics have a value 0.

#### Comparing metrics before & after the change

* We see 88 metrics before the change
<img width="2227" alt="image" src="https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/108111936/50435dd1-4273-4873-b824-900b0bf363b3">

* We see 120 metrics after the change
<img width="2227" alt="image" src="https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/108111936/21c53078-b9ac-42e1-959e-bda08ee22196">

* The additional 32 metrics after the change comprise:
```
8 new metrics for the dimension set [ClusterName]
node_status_condition_ready
node_status_condition_pid_pressure
node_status_condition_memory_pressure
node_status_condition_disk_pressure
node_status_capacity_pods
node_status_allocatable_pods
node_filesystem_inodes
node_filesystem_inodes_free

12 new metrics per node (total of 24) for the dimension set [ClusterName, InstanceId, NodeName]
node_status_condition_ready
node_status_condition_pid_pressure
node_status_condition_memory_pressure
node_status_condition_disk_pressure
node_status_capacity_pods
node_status_allocatable_pods
node_filesystem_inodes
node_filesystem_inodes_free
node_cpu_limit
node_cpu_usage_total
node_memory_limit
node_memory_working_set
```
* Besides the `node_status_*` metrics introduced by this change, the other metrics seen here are as a result of us allow-listing them for this testing exercise.