### PR TITLE
[receiver/awscontainerinsightreceiver] Add new deployment and daemonset metrics

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -93,6 +93,14 @@ const (
 	StatusConditionNetworkUnavailable = "status_condition_network_unavailable"
 	StatusCapacityPods                = "status_capacity_pods"
 	StatusAllocatablePods             = "status_allocatable_pods"
+	StatusNumberAvailable             = "status_number_available"
+	StatusNumberUnavailable           = "status_number_unavailable"
+	StatusDesiredNumberScheduled      = "status_desired_number_scheduled"
+	StatusCurrentNumberScheduled      = "status_current_number_scheduled"
+	StatusReplicasAvailable           = "status_replicas_available"
+	StatusReplicasUnavailable         = "status_replicas_unavailable"
+	StatusReplicas                    = "status_replicas"
+	SpecReplicas                      = "spec_replicas"
 	StatusRunning                     = "status_running"
 	StatusTerminated                  = "status_terminated"
 	StatusWaiting                     = "status_waiting"
@@ -115,23 +123,25 @@ const (
 	DiskIOTotal              = "Total"
 
 	// Define the metric types
-	TypeCluster          = "Cluster"
-	TypeClusterService   = "ClusterService"
-	TypeClusterNamespace = "ClusterNamespace"
-	TypeService          = "Service"
-	TypeInstance         = "Instance" // mean EC2 Instance in ECS
-	TypeNode             = "Node"     // mean EC2 Instance in EKS
-	TypeInstanceFS       = "InstanceFS"
-	TypeNodeFS           = "NodeFS"
-	TypeInstanceNet      = "InstanceNet"
-	TypeNodeNet          = "NodeNet"
-	TypeInstanceDiskIO   = "InstanceDiskIO"
-	TypeNodeDiskIO       = "NodeDiskIO"
-	TypePod              = "Pod"
-	TypePodNet           = "PodNet"
-	TypeContainer        = "Container"
-	TypeContainerFS      = "ContainerFS"
-	TypeContainerDiskIO  = "ContainerDiskIO"
+	TypeCluster           = "Cluster"
+	TypeClusterService    = "ClusterService"
+	TypeClusterDeployment = "ClusterDeployment"
+	TypeClusterDaemonSet  = "ClusterDaemonSet"
+	TypeClusterNamespace  = "ClusterNamespace"
+	TypeService           = "Service"
+	TypeInstance          = "Instance" // mean EC2 Instance in ECS
+	TypeNode              = "Node"     // mean EC2 Instance in EKS
+	TypeInstanceFS        = "InstanceFS"
+	TypeNodeFS            = "NodeFS"
+	TypeInstanceNet       = "InstanceNet"
+	TypeNodeNet           = "NodeNet"
+	TypeInstanceDiskIO    = "InstanceDiskIO"
+	TypeNodeDiskIO        = "NodeDiskIO"
+	TypePod               = "Pod"
+	TypePodNet            = "PodNet"
+	TypeContainer         = "Container"
+	TypeContainerFS       = "ContainerFS"
+	TypeContainerDiskIO   = "ContainerDiskIO"
 	// Special type for pause container
 	// because containerd does not set container name pause container name to POD like docker does.
 	TypeInfraContainer = "InfraContainer"
@@ -213,7 +223,7 @@ func init() {
 		FSInodesfree:  UnitCount,
 		FSUtilization: UnitPercent,
 
-		// status metrics
+		// status & spec metrics
 		StatusConditionReady:              UnitCount,
 		StatusConditionDiskPressure:       UnitCount,
 		StatusConditionMemoryPressure:     UnitCount,
@@ -221,6 +231,14 @@ func init() {
 		StatusConditionNetworkUnavailable: UnitCount,
 		StatusCapacityPods:                UnitCount,
 		StatusAllocatablePods:             UnitCount,
+		StatusReplicas:                    UnitCount,
+		StatusReplicasAvailable:           UnitCount,
+		StatusReplicasUnavailable:         UnitCount,
+		StatusNumberAvailable:             UnitCount,
+		StatusNumberUnavailable:           UnitCount,
+		StatusDesiredNumberScheduled:      UnitCount,
+		StatusCurrentNumberScheduled:      UnitCount,
+		SpecReplicas:                      UnitCount,
 
 		// kube-state-metrics equivalents
 		StatusRunning:              UnitCount,

--- a/internal/aws/containerinsight/utils.go
+++ b/internal/aws/containerinsight/utils.go
@@ -106,6 +106,8 @@ func getPrefixByMetricType(mType string) string {
 	service := "service_"
 	cluster := "cluster_"
 	namespace := "namespace_"
+	deployment := "deployment_"
+	daemonSet := "daemonset_"
 
 	switch mType {
 	case TypeInstance:
@@ -142,6 +144,10 @@ func getPrefixByMetricType(mType string) string {
 		prefix = service
 	case TypeClusterNamespace:
 		prefix = namespace
+	case TypeClusterDeployment:
+		prefix = deployment
+	case TypeClusterDaemonSet:
+		prefix = daemonSet
 	default:
 		log.Printf("E! Unexpected MetricType: %s", mType)
 	}

--- a/internal/aws/k8s/k8sclient/daemonset.go
+++ b/internal/aws/k8s/k8sclient/daemonset.go
@@ -1,0 +1,151 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+
+import (
+	"context"
+	"fmt"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"sync"
+)
+
+type DaemonSetClient interface {
+	// DaemonSetInfos contains the information about each daemon set in the cluster
+	DaemonSetInfos() []*DaemonSetInfo
+}
+
+type noOpDaemonSetClient struct {
+}
+
+func (nd *noOpDaemonSetClient) DaemonSetInfos() []*DaemonSetInfo {
+	return []*DaemonSetInfo{}
+}
+
+func (nd *noOpDaemonSetClient) shutdown() {
+}
+
+type daemonSetClientOption func(*daemonSetClient)
+
+func daemonSetSyncCheckerOption(checker initialSyncChecker) daemonSetClientOption {
+	return func(d *daemonSetClient) {
+		d.syncChecker = checker
+	}
+}
+
+type daemonSetClient struct {
+	stopChan chan struct{}
+	stopped  bool
+
+	store *ObjStore
+
+	syncChecker initialSyncChecker
+
+	mu             sync.RWMutex
+	daemonSetInfos []*DaemonSetInfo
+}
+
+func (d *daemonSetClient) refresh() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	var daemonSetInfos []*DaemonSetInfo
+	objsList := d.store.List()
+	for _, obj := range objsList {
+		daemonSet, ok := obj.(*DaemonSetInfo)
+		if !ok {
+			continue
+		}
+		daemonSetInfos = append(daemonSetInfos, daemonSet)
+	}
+
+	d.daemonSetInfos = daemonSetInfos
+}
+
+func (d *daemonSetClient) DaemonSetInfos() []*DaemonSetInfo {
+	if d.store.GetResetRefreshStatus() {
+		d.refresh()
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.daemonSetInfos
+}
+
+func newDaemonSetClient(clientSet kubernetes.Interface, logger *zap.Logger, options ...daemonSetClientOption) (*daemonSetClient, error) {
+	d := &daemonSetClient{
+		stopChan: make(chan struct{}),
+	}
+
+	for _, option := range options {
+		option(d)
+	}
+
+	ctx := context.Background()
+	if _, err := clientSet.AppsV1().DaemonSets(metav1.NamespaceAll).List(ctx, metav1.ListOptions{}); err != nil {
+		return nil, fmt.Errorf("cannot list DaemonSets. err: %w", err)
+	}
+
+	d.store = NewObjStore(transformFuncDaemonSet, logger)
+	lw := createDaemonSetListWatch(clientSet, metav1.NamespaceAll)
+	reflector := cache.NewReflector(lw, &appsv1.DaemonSet{}, d.store, 0)
+
+	go reflector.Run(d.stopChan)
+
+	if d.syncChecker != nil {
+		// check the init sync for potential connection issue
+		d.syncChecker.Check(reflector, "DaemonSet initial sync timeout")
+	}
+
+	return d, nil
+}
+
+func (d *daemonSetClient) shutdown() {
+	close(d.stopChan)
+	d.stopped = true
+}
+
+func transformFuncDaemonSet(obj interface{}) (interface{}, error) {
+	daemonSet, ok := obj.(*appsv1.DaemonSet)
+	if !ok {
+		return nil, fmt.Errorf("input obj %v is not DaemonSet type", obj)
+	}
+	info := new(DaemonSetInfo)
+	info.Name = daemonSet.Name
+	info.Namespace = daemonSet.Namespace
+	info.Status = &DaemonSetStatus{
+		NumberAvailable:        uint32(daemonSet.Status.NumberAvailable),
+		NumberUnavailable:      uint32(daemonSet.Status.NumberUnavailable),
+		DesiredNumberScheduled: uint32(daemonSet.Status.DesiredNumberScheduled),
+		CurrentNumberScheduled: uint32(daemonSet.Status.CurrentNumberScheduled),
+	}
+	return info, nil
+}
+
+func createDaemonSetListWatch(client kubernetes.Interface, ns string) cache.ListerWatcher {
+	ctx := context.Background()
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return client.AppsV1().DaemonSets(ns).List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return client.AppsV1().DaemonSets(ns).Watch(ctx, opts)
+		},
+	}
+}

--- a/internal/aws/k8s/k8sclient/daemonset_info.go
+++ b/internal/aws/k8s/k8sclient/daemonset_info.go
@@ -1,0 +1,28 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+
+type DaemonSetInfo struct {
+	Name      string
+	Namespace string
+	Status    *DaemonSetStatus
+}
+
+type DaemonSetStatus struct {
+	NumberAvailable        uint32
+	NumberUnavailable      uint32
+	DesiredNumberScheduled uint32
+	CurrentNumberScheduled uint32
+}

--- a/internal/aws/k8s/k8sclient/daemonset_test.go
+++ b/internal/aws/k8s/k8sclient/daemonset_test.go
@@ -1,0 +1,94 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package k8sclient
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	"testing"
+)
+
+var daemonSetObjects = []runtime.Object{
+	&appsv1.DaemonSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-daemonset-1",
+			Namespace: "test-namespace",
+			UID:       types.UID("test-daemonset-1-uid"),
+		},
+		Status: appsv1.DaemonSetStatus{
+			NumberAvailable:        5,
+			NumberUnavailable:      3,
+			DesiredNumberScheduled: 2,
+			CurrentNumberScheduled: 1,
+		},
+	},
+	&appsv1.DaemonSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-daemonset-2",
+			Namespace: "test-namespace",
+			UID:       types.UID("test-daemonset-2-uid"),
+		},
+		Status: appsv1.DaemonSetStatus{
+			NumberAvailable:        10,
+			NumberUnavailable:      4,
+			DesiredNumberScheduled: 7,
+			CurrentNumberScheduled: 7,
+		},
+	},
+}
+
+func TestDaemonSetClient(t *testing.T) {
+	options := daemonSetSyncCheckerOption(&mockReflectorSyncChecker{})
+
+	fakeClientSet := fake.NewSimpleClientset(daemonSetObjects...)
+	client, _ := newDaemonSetClient(fakeClientSet, zap.NewNop(), options)
+
+	daemonSets := make([]interface{}, len(daemonSetObjects))
+	for i := range daemonSetObjects {
+		daemonSets[i] = daemonSetObjects[i]
+	}
+	assert.NoError(t, client.store.Replace(daemonSets, ""))
+
+	expected := []*DaemonSetInfo{
+		{
+			Name:      "test-daemonset-1",
+			Namespace: "test-namespace",
+			Status: &DaemonSetStatus{
+				NumberAvailable:        5,
+				NumberUnavailable:      3,
+				DesiredNumberScheduled: 2,
+				CurrentNumberScheduled: 1,
+			},
+		},
+		{
+			Name:      "test-daemonset-2",
+			Namespace: "test-namespace",
+			Status: &DaemonSetStatus{
+				NumberAvailable:        10,
+				NumberUnavailable:      4,
+				DesiredNumberScheduled: 7,
+				CurrentNumberScheduled: 7,
+			},
+		},
+	}
+	actual := client.DaemonSetInfos()
+	assert.Equal(t, expected, actual)
+	client.shutdown()
+	assert.True(t, client.stopped)
+}

--- a/internal/aws/k8s/k8sclient/deployment.go
+++ b/internal/aws/k8s/k8sclient/deployment.go
@@ -1,0 +1,153 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+
+import (
+	"context"
+	"fmt"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"sync"
+)
+
+type DeploymentClient interface {
+	// DeploymentInfos contains the information about each deployment in the cluster
+	DeploymentInfos() []*DeploymentInfo
+}
+
+type noOpDeploymentClient struct {
+}
+
+func (nd *noOpDeploymentClient) DeploymentInfos() []*DeploymentInfo {
+	return []*DeploymentInfo{}
+}
+
+func (nd *noOpDeploymentClient) shutdown() {
+}
+
+type deploymentClientOption func(*deploymentClient)
+
+func deploymentSyncCheckerOption(checker initialSyncChecker) deploymentClientOption {
+	return func(d *deploymentClient) {
+		d.syncChecker = checker
+	}
+}
+
+type deploymentClient struct {
+	stopChan chan struct{}
+	stopped  bool
+
+	store *ObjStore
+
+	syncChecker initialSyncChecker
+
+	mu              sync.RWMutex
+	deploymentInfos []*DeploymentInfo
+}
+
+func (d *deploymentClient) refresh() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	var deploymentInfos []*DeploymentInfo
+	objsList := d.store.List()
+	for _, obj := range objsList {
+		deployment, ok := obj.(*DeploymentInfo)
+		if !ok {
+			continue
+		}
+		deploymentInfos = append(deploymentInfos, deployment)
+	}
+
+	d.deploymentInfos = deploymentInfos
+}
+
+func (d *deploymentClient) DeploymentInfos() []*DeploymentInfo {
+	if d.store.GetResetRefreshStatus() {
+		d.refresh()
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.deploymentInfos
+}
+
+func newDeploymentClient(clientSet kubernetes.Interface, logger *zap.Logger, options ...deploymentClientOption) (*deploymentClient, error) {
+	d := &deploymentClient{
+		stopChan: make(chan struct{}),
+	}
+
+	for _, option := range options {
+		option(d)
+	}
+
+	ctx := context.Background()
+	if _, err := clientSet.AppsV1().Deployments(metav1.NamespaceAll).List(ctx, metav1.ListOptions{}); err != nil {
+		return nil, fmt.Errorf("cannot list Deployments. err: %w", err)
+	}
+
+	d.store = NewObjStore(transformFuncDeployment, logger)
+	lw := createDeploymentListWatch(clientSet, metav1.NamespaceAll)
+	reflector := cache.NewReflector(lw, &appsv1.Deployment{}, d.store, 0)
+
+	go reflector.Run(d.stopChan)
+
+	if d.syncChecker != nil {
+		// check the init sync for potential connection issue
+		d.syncChecker.Check(reflector, "Deployment initial sync timeout")
+	}
+
+	return d, nil
+}
+
+func (d *deploymentClient) shutdown() {
+	close(d.stopChan)
+	d.stopped = true
+}
+
+func transformFuncDeployment(obj interface{}) (interface{}, error) {
+	deployment, ok := obj.(*appsv1.Deployment)
+	if !ok {
+		return nil, fmt.Errorf("input obj %v is not Deployment type", obj)
+	}
+	info := new(DeploymentInfo)
+	info.Name = deployment.Name
+	info.Namespace = deployment.Namespace
+	info.Spec = &DeploymentSpec{
+		Replicas: uint32(*deployment.Spec.Replicas),
+	}
+	info.Status = &DeploymentStatus{
+		Replicas:            uint32(deployment.Status.Replicas),
+		AvailableReplicas:   uint32(deployment.Status.AvailableReplicas),
+		UnavailableReplicas: uint32(deployment.Status.UnavailableReplicas),
+	}
+	return info, nil
+}
+
+func createDeploymentListWatch(client kubernetes.Interface, ns string) cache.ListerWatcher {
+	ctx := context.Background()
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return client.AppsV1().Deployments(ns).List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return client.AppsV1().Deployments(ns).Watch(ctx, opts)
+		},
+	}
+}

--- a/internal/aws/k8s/k8sclient/deployment_info.go
+++ b/internal/aws/k8s/k8sclient/deployment_info.go
@@ -1,0 +1,32 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+
+type DeploymentInfo struct {
+	Name      string
+	Namespace string
+	Spec      *DeploymentSpec
+	Status    *DeploymentStatus
+}
+
+type DeploymentSpec struct {
+	Replicas uint32
+}
+
+type DeploymentStatus struct {
+	Replicas            uint32
+	AvailableReplicas   uint32
+	UnavailableReplicas uint32
+}

--- a/internal/aws/k8s/k8sclient/deployment_test.go
+++ b/internal/aws/k8s/k8sclient/deployment_test.go
@@ -1,0 +1,104 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package k8sclient
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	"testing"
+)
+
+var desired = int32(20)
+
+var deploymentObjects = []runtime.Object{
+	&appsv1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-deployment-1",
+			Namespace: "test-namespace",
+			UID:       types.UID("test-deployment-1-uid"),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &desired,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            5,
+			AvailableReplicas:   5,
+			UnavailableReplicas: 1,
+		},
+	},
+	&appsv1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-deployment-2",
+			Namespace: "test-namespace",
+			UID:       types.UID("test-deployment-2-uid"),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &desired,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:            15,
+			AvailableReplicas:   15,
+			UnavailableReplicas: 2,
+		},
+	},
+}
+
+func TestDeploymentClient(t *testing.T) {
+	options := deploymentSyncCheckerOption(&mockReflectorSyncChecker{})
+
+	fakeClientSet := fake.NewSimpleClientset(deploymentObjects...)
+	client, _ := newDeploymentClient(fakeClientSet, zap.NewNop(), options)
+
+	deployments := make([]interface{}, len(deploymentObjects))
+	for i := range deploymentObjects {
+		deployments[i] = deploymentObjects[i]
+	}
+	assert.NoError(t, client.store.Replace(deployments, ""))
+
+	expected := []*DeploymentInfo{
+		{
+			Name:      "test-deployment-1",
+			Namespace: "test-namespace",
+			Spec: &DeploymentSpec{
+				Replicas: 20,
+			},
+			Status: &DeploymentStatus{
+				Replicas:            5,
+				AvailableReplicas:   5,
+				UnavailableReplicas: 1,
+			},
+		},
+		{
+			Name:      "test-deployment-2",
+			Namespace: "test-namespace",
+			Spec: &DeploymentSpec{
+				Replicas: 20,
+			},
+			Status: &DeploymentStatus{
+				Replicas:            15,
+				AvailableReplicas:   15,
+				UnavailableReplicas: 2,
+			},
+		},
+	}
+	actual := client.DeploymentInfos()
+	assert.Equal(t, expected, actual)
+	client.shutdown()
+	assert.True(t, client.stopped)
+}

--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -399,6 +399,58 @@ kubectl apply -f config.yaml
 <br/><br/> 
 <br/><br/> 
 
+### Cluster Deployment
+| Metric                                 | Unit  |
+|----------------------------------------|-------|
+| deployment_spec_replicas               | Count |
+| deployment_status_replicas             | Count |
+| deployment_status_replicas_available   | Count |
+| deployment_status_replicas_unavailable | Count |
+
+
+<br/><br/>
+| Resource Attribute |
+|--------------------|
+| ClusterName        |
+| NodeName           |
+| Namespace          |
+| PodName            |
+| Type               |
+| Timestamp          |
+| Version            |
+| Sources            |
+| kubernetes         |
+
+
+<br/><br/>
+<br/><br/>
+
+### Cluster DaemonSet
+| Metric                                    | Unit  |
+|-------------------------------------------|-------|
+| daemonset_status_number_available         | Count |
+| daemonset_status_number_unavailable       | Count |
+| daemonset_status_desired_number_scheduled | Count |
+| daemonset_status_current_number_scheduled | Count |
+
+
+<br/><br/>
+| Resource Attribute |
+|--------------------|
+| ClusterName        |
+| NodeName           |
+| Namespace          |
+| PodName            |
+| Type               |
+| Timestamp          |
+| Version            |
+| Sources            |
+| kubernetes         |
+
+
+<br/><br/>
+<br/><br/>
+
 ### Node
 | Metric                                    | Unit         |
 |-------------------------------------------|--------------|


### PR DESCRIPTION
**Description:** Add new deployment and daemon set metrics for EKS Container Insights.
* Precisely, the following are the new metrics:
```
deployment_spec_replicas
deployment_status_replicas
deployment_status_replicas_available
deployment_status_replicas_unavailable

daemonset_status_number_available
daemonset_status_number_unavailable
daemonset_status_desired_number_scheduled
daemonset_status_current_number_scheduled
```
* These new metrics are scraped as part of the `k8sapiserver` logic - meaning these are extracted by making calls to the k8s api server. Since these are collected for the whole cluster and should be done only once, this code gets executed only on the leader node's code path.
* Note that for the service account running the agent/collector pod, the role its bound to should grant `list` and `watch` permissions to `apps/deployments` and `apps/daemonsets`.

**Testing:**
* Updated unit tests
* Manually tested the changes on a dev cluster. Results as follows when used in combination with `awsemfexporter` to send metrics to AWS CloudWatch.
![image](https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/108111936/7495f559-abcb-4da0-a820-bf66d7f6a5d5)
* Trimmed output of running `kubectl describe deployment` shows the values match to what's seen above.
```
% kubectl describe deployment coredns -n kube-system --context cw1
  Name:                   coredns
  Namespace:              kube-system
  Selector:               eks.amazonaws.com/component=coredns,k8s-app=kube-dns
  Replicas:               2 desired | 2 updated | 2 total | 2 available | 0 unavailable
```
* Trimmed output of running `kubectl describe daemonset` shows the values match to what's seen above.
```
% kubectl describe daemonset kube-proxy -n kube-system --context cw1
  Name:           kube-proxy
  Desired Number of Nodes Scheduled: 2
  Current Number of Nodes Scheduled: 2
  Number of Nodes Scheduled with Up-to-date Pods: 2
  Number of Nodes Scheduled with Available Pods: 2
  Number of Nodes Misscheduled: 0
  Pods Status:  2 Running / 0 Waiting / 0 Succeeded / 0 Failed
```
* Sample EMF log event for `Type=ClusterDeployment`
```
{
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights/ClusterMetricsEnabled",
            "Dimensions": [
                [
                    "ClusterName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "deployment_spec_replicas",
                    "Unit": "Count"
                },
                {
                    "Name": "deployment_status_replicas",
                    "Unit": "Count"
                },
                {
                    "Name": "deployment_status_replicas_available",
                    "Unit": "Count"
                },
                {
                    "Name": "deployment_status_replicas_unavailable",
                    "Unit": "Count"
                }
            ]
        }
    ],
    "ClusterName": "ccwa_cluster",
    "Namespace": "kube-system",
    "NodeName": "ip-192-168-231-102.ec2.internal",
    "PodName": "coredns",
    "Sources": [
        "apiserver"
    ],
    "Timestamp": "1685133150227",
    "Type": "ClusterDeployment",
    "Version": "0",
    "deployment_spec_replicas": 2,
    "deployment_status_replicas": 2,
    "deployment_status_replicas_available": 2,
    "deployment_status_replicas_unavailable": 0
}
```
* Sample EMF log event for `Type=ClusterDaemonSet`
```
{
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights/ClusterMetricsEnabled",
            "Dimensions": [
                [
                    "ClusterName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "daemonset_status_number_available",
                    "Unit": "Count"
                },
                {
                    "Name": "daemonset_status_number_unavailable",
                    "Unit": "Count"
                },
                {
                    "Name": "daemonset_status_desired_number_scheduled",
                    "Unit": "Count"
                },
                {
                    "Name": "daemonset_status_current_number_scheduled",
                    "Unit": "Count"
                }
            ]
        }
    ],
    "ClusterName": "ccwa_cluster",
    "Namespace": "kube-system",
    "NodeName": "ip-192-168-231-102.ec2.internal",
    "PodName": "aws-node",
    "Sources": [
        "apiserver"
    ],
    "Timestamp": "1685133150227",
    "Type": "ClusterDaemonSet",
    "Version": "0",
    "daemonset_status_current_number_scheduled": 2,
    "daemonset_status_desired_number_scheduled": 2,
    "daemonset_status_number_available": 2,
    "daemonset_status_number_unavailable": 0
}
```
* The following log insights query shows we only generate one log event each for ClusterDeployment and ClusterDaemonSet types per resource.
![image](https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/108111936/cf715f03-91c2-4187-86a5-2c50d015b8a0)

**Documentation:** Updated README.md