### PR TITLE
Emit 8 new pod_status_* metrics for containerinsights

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -112,6 +112,13 @@ const (
 	StatusTerminated                  = "status_terminated"
 	StatusWaiting                     = "status_waiting"
 	StatusWaitingReasonCrashed        = "status_waiting_reason_crashed"
+	StatusPending                     = "status_pending"
+	StatusSucceeded                   = "status_succeeded"
+	StatusFailed                      = "status_failed"
+	StatusUnknown                     = "status_unknown"
+	StatusReady                       = "status_ready"
+	StatusScheduled                   = "status_scheduled"
+	StatusInitialized                 = "status_initialized"
 
 	RunningPodCount       = "number_of_running_pods"
 	RunningContainerCount = "number_of_running_containers"
@@ -152,7 +159,6 @@ const (
 	// Special type for pause container
 	// because containerd does not set container name pause container name to POD like docker does.
 	TypeInfraContainer = "InfraContainer"
-	TypePodStatus      = "PodStatus"
 
 	// unit
 	UnitBytes       = "Bytes"

--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -14,7 +14,6 @@
 package containerinsight // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	"strings"
 	"time"
 )
@@ -167,8 +166,6 @@ const (
 )
 
 var metricToUnitMap map[string]string
-var PodPhaseMetricNames map[corev1.PodPhase]string
-var PodConditionMetricNames map[corev1.PodConditionType]string
 
 func init() {
 	metricToUnitMap = map[string]string{
@@ -275,19 +272,5 @@ func init() {
 		ContainerCount:        UnitCount,
 		ContainerRestartCount: UnitCount,
 		RunningTaskCount:      UnitCount,
-	}
-
-	PodPhaseMetricNames = map[corev1.PodPhase]string{
-		corev1.PodPending:   MetricName(TypePodStatus, "pending"),
-		corev1.PodRunning:   MetricName(TypePodStatus, "running"),
-		corev1.PodSucceeded: MetricName(TypePodStatus, "succeeded"),
-		corev1.PodFailed:    MetricName(TypePodStatus, "failed"),
-		corev1.PodUnknown:   MetricName(TypePodStatus, "unknown"),
-	}
-
-	PodConditionMetricNames = map[corev1.PodConditionType]string{
-		corev1.PodReady:       MetricName(TypePodStatus, "ready"),
-		corev1.PodScheduled:   MetricName(TypePodStatus, "scheduled"),
-		corev1.PodInitialized: MetricName(TypePodStatus, "initialized"),
 	}
 }

--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -14,6 +14,7 @@
 package containerinsight // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"strings"
 	"time"
 )
@@ -152,6 +153,7 @@ const (
 	// Special type for pause container
 	// because containerd does not set container name pause container name to POD like docker does.
 	TypeInfraContainer = "InfraContainer"
+	TypePodStatus      = "PodStatus"
 
 	// unit
 	UnitBytes       = "Bytes"
@@ -165,6 +167,8 @@ const (
 )
 
 var metricToUnitMap map[string]string
+var PodPhaseMetricNames map[corev1.PodPhase]string
+var PodConditionMetricNames map[corev1.PodConditionType]string
 
 func init() {
 	metricToUnitMap = map[string]string{
@@ -271,5 +275,19 @@ func init() {
 		ContainerCount:        UnitCount,
 		ContainerRestartCount: UnitCount,
 		RunningTaskCount:      UnitCount,
+	}
+
+	PodPhaseMetricNames = map[corev1.PodPhase]string{
+		corev1.PodPending:   MetricName(TypePodStatus, "pending"),
+		corev1.PodRunning:   MetricName(TypePodStatus, "running"),
+		corev1.PodSucceeded: MetricName(TypePodStatus, "succeeded"),
+		corev1.PodFailed:    MetricName(TypePodStatus, "failed"),
+		corev1.PodUnknown:   MetricName(TypePodStatus, "unknown"),
+	}
+
+	PodConditionMetricNames = map[corev1.PodConditionType]string{
+		corev1.PodReady:       MetricName(TypePodStatus, "ready"),
+		corev1.PodScheduled:   MetricName(TypePodStatus, "scheduled"),
+		corev1.PodInitialized: MetricName(TypePodStatus, "initialized"),
 	}
 }

--- a/internal/aws/containerinsight/utils.go
+++ b/internal/aws/containerinsight/utils.go
@@ -108,6 +108,7 @@ func getPrefixByMetricType(mType string) string {
 	namespace := "namespace_"
 	deployment := "deployment_"
 	daemonSet := "daemonset_"
+	podStatusPrefix := "kube_pod_status_"
 
 	switch mType {
 	case TypeInstance:
@@ -148,6 +149,8 @@ func getPrefixByMetricType(mType string) string {
 		prefix = deployment
 	case TypeClusterDaemonSet:
 		prefix = daemonSet
+	case TypePodStatus:
+		prefix = podStatusPrefix
 	default:
 		log.Printf("E! Unexpected MetricType: %s", mType)
 	}

--- a/internal/aws/containerinsight/utils.go
+++ b/internal/aws/containerinsight/utils.go
@@ -108,7 +108,6 @@ func getPrefixByMetricType(mType string) string {
 	namespace := "namespace_"
 	deployment := "deployment_"
 	daemonSet := "daemonset_"
-	podStatusPrefix := "pod_status_"
 
 	switch mType {
 	case TypeInstance:
@@ -149,8 +148,6 @@ func getPrefixByMetricType(mType string) string {
 		prefix = deployment
 	case TypeClusterDaemonSet:
 		prefix = daemonSet
-	case TypePodStatus:
-		prefix = podStatusPrefix
 	default:
 		log.Printf("E! Unexpected MetricType: %s", mType)
 	}

--- a/internal/aws/containerinsight/utils.go
+++ b/internal/aws/containerinsight/utils.go
@@ -108,7 +108,7 @@ func getPrefixByMetricType(mType string) string {
 	namespace := "namespace_"
 	deployment := "deployment_"
 	daemonSet := "daemonset_"
-	podStatusPrefix := "kube_pod_status_"
+	podStatusPrefix := "pod_status_"
 
 	switch mType {
 	case TypeInstance:

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -49,17 +49,17 @@ var (
 	re = regexp.MustCompile(splitRegexStr)
 
 	PodPhaseMetricNames = map[corev1.PodPhase]string{
-		corev1.PodPending:   ci.MetricName(ci.TypePodStatus, "pending"),
-		corev1.PodRunning:   ci.MetricName(ci.TypePodStatus, "running"),
-		corev1.PodSucceeded: ci.MetricName(ci.TypePodStatus, "succeeded"),
-		corev1.PodFailed:    ci.MetricName(ci.TypePodStatus, "failed"),
-		corev1.PodUnknown:   ci.MetricName(ci.TypePodStatus, "unknown"),
+		corev1.PodPending:   ci.MetricName(ci.TypePod, ci.StatusPending),
+		corev1.PodRunning:   ci.MetricName(ci.TypePod, ci.StatusRunning),
+		corev1.PodSucceeded: ci.MetricName(ci.TypePod, ci.StatusSucceeded),
+		corev1.PodFailed:    ci.MetricName(ci.TypePod, ci.StatusFailed),
+		corev1.PodUnknown:   ci.MetricName(ci.TypePod, ci.StatusUnknown),
 	}
 
 	PodConditionMetricNames = map[corev1.PodConditionType]string{
-		corev1.PodReady:       ci.MetricName(ci.TypePodStatus, "ready"),
-		corev1.PodScheduled:   ci.MetricName(ci.TypePodStatus, "scheduled"),
-		corev1.PodInitialized: ci.MetricName(ci.TypePodStatus, "initialized"),
+		corev1.PodReady:       ci.MetricName(ci.TypePod, ci.StatusReady),
+		corev1.PodScheduled:   ci.MetricName(ci.TypePod, ci.StatusScheduled),
+		corev1.PodInitialized: ci.MetricName(ci.TypePod, ci.StatusInitialized),
 	}
 )
 

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -291,6 +292,90 @@ func TestPodStore_addContainerCount(t *testing.T) {
 	addContainerCount(metric, pod)
 	assert.Equal(t, int(0), metric.GetField(ci.MetricName(ci.TypePod, ci.RunningContainerCount)).(int))
 	assert.Equal(t, int(1), metric.GetField(ci.MetricName(ci.TypePod, ci.ContainerCount)).(int))
+}
+
+const (
+	PodFailedMetricName      = "kube_pod_status_failed"
+	PodPendingMetricName     = "kube_pod_status_pending"
+	PodRunningMetricName     = "kube_pod_status_running"
+	PodSucceededMetricName   = "kube_pod_status_succeeded"
+	PodUnknownMetricName     = "kube_pod_status_unknown"
+	PodReadyMetricName       = "kube_pod_status_ready"
+	PodScheduledMetricName   = "kube_pod_status_scheduled"
+	PodInitializedMetricName = "kube_pod_status_initialized"
+)
+
+func TestPodStore_addStatus_adds_pod_failed_metric(t *testing.T) {
+	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric(
+		"./test_resources/pod_in_phase_failed.json")
+
+	assert.Equal(t, 1, decoratedResultMetric.GetField(PodFailedMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodPendingMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodRunningMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodSucceededMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodUnknownMetricName))
+}
+
+func TestPodStore_addStatus_adds_pod_pending_metric(t *testing.T) {
+	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric(
+		"./test_resources/pod_in_phase_pending.json")
+
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodFailedMetricName))
+	assert.Equal(t, 1, decoratedResultMetric.GetField(PodPendingMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodRunningMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodSucceededMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodUnknownMetricName))
+}
+
+func TestPodStore_addStatus_adds_pod_running_metric(t *testing.T) {
+	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric(
+		"./test_resources/pod_in_phase_running.json")
+
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodFailedMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodPendingMetricName))
+	assert.Equal(t, 1, decoratedResultMetric.GetField(PodRunningMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodSucceededMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodUnknownMetricName))
+}
+
+func TestPodStore_addStatus_adds_pod_succeeded_metric(t *testing.T) {
+	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric(
+		"./test_resources/pod_in_phase_succeeded.json")
+
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodFailedMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodPendingMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodRunningMetricName))
+	assert.Equal(t, 1, decoratedResultMetric.GetField(PodSucceededMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodUnknownMetricName))
+}
+
+func TestPodStore_addStatus_adds_pod_unknown_metric(t *testing.T) {
+	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric(
+		"./test_resources/pod_in_phase_unknown.json")
+
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodFailedMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodPendingMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodRunningMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodSucceededMetricName))
+	assert.Equal(t, 1, decoratedResultMetric.GetField(PodUnknownMetricName))
+}
+
+func TestPodStore_addStatus_adds_all_pod_conditions_as_metrics_when_true_false_unknown(t *testing.T) {
+	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric(
+		"./test_resources/all_pod_conditions_valid.json")
+
+	assert.Equal(t, 1, decoratedResultMetric.GetField(PodInitializedMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodReadyMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodScheduledMetricName))
+}
+
+func TestPodStore_addStatus_adds_all_pod_conditions_as_metrics_when_unexpected(t *testing.T) {
+	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric(
+		"./test_resources/one_pod_condition_invalid.json")
+
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodInitializedMetricName))
+	assert.Equal(t, 1, decoratedResultMetric.GetField(PodReadyMetricName))
+	assert.Equal(t, 1, decoratedResultMetric.GetField(PodScheduledMetricName))
 }
 
 func TestPodStore_addStatus(t *testing.T) {
@@ -715,4 +800,31 @@ func TestPodStore_Decorate(t *testing.T) {
 	// decorate the same metric with a placeholder item in cache
 	ok = podStore.Decorate(ctx, metric, kubernetesBlob)
 	assert.False(t, ok)
+}
+
+func runAddStatusToGetDecoratedCIMetric(podInfoSourceFileName string) CIMetric {
+	podInfo := generatePodInfo(podInfoSourceFileName)
+	podStore := getPodStore()
+	rawCIMetric := generateRawCIMetric()
+	podStore.addStatus(rawCIMetric, podInfo)
+	return rawCIMetric
+}
+
+func generatePodInfo(sourceFileName string) *corev1.Pod {
+	podInfoJson, err := os.ReadFile(sourceFileName)
+	if err != nil {
+		panic(fmt.Sprintf("reading file failed %v", err))
+	}
+	pods := corev1.PodList{}
+	err = json.Unmarshal([]byte(podInfoJson), &pods)
+	if err != nil {
+		panic(fmt.Sprintf("unmarshal pod err %v", err))
+	}
+	return &pods.Items[0]
+}
+
+func generateRawCIMetric() CIMetric {
+	tags := map[string]string{ci.MetricType: ci.TypePod, ci.K8sNamespace: "default", ci.K8sPodNameKey: "cpu-limit"}
+	fields := map[string]interface{}{ci.MetricName(ci.TypePod, ci.CPUTotal): float64(1)}
+	return generateMetric(fields, tags)
 }

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -816,7 +816,7 @@ func generatePodInfo(sourceFileName string) *corev1.Pod {
 		panic(fmt.Sprintf("reading file failed %v", err))
 	}
 	pods := corev1.PodList{}
-	err = json.Unmarshal(podInfoJson, &pods)
+	err = json.Unmarshal(podInfoJSON, &pods)
 	if err != nil {
 		panic(fmt.Sprintf("unmarshal pod err %v", err))
 	}

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -811,12 +811,12 @@ func runAddStatusToGetDecoratedCIMetric(podInfoSourceFileName string) CIMetric {
 }
 
 func generatePodInfo(sourceFileName string) *corev1.Pod {
-	podInfoJson, err := os.ReadFile(sourceFileName)
+	podInfoJSON, err := os.ReadFile(sourceFileName)
 	if err != nil {
 		panic(fmt.Sprintf("reading file failed %v", err))
 	}
 	pods := corev1.PodList{}
-	err = json.Unmarshal([]byte(podInfoJson), &pods)
+	err = json.Unmarshal(podInfoJson, &pods)
 	if err != nil {
 		panic(fmt.Sprintf("unmarshal pod err %v", err))
 	}

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -295,14 +295,14 @@ func TestPodStore_addContainerCount(t *testing.T) {
 }
 
 const (
-	PodFailedMetricName      = "kube_pod_status_failed"
-	PodPendingMetricName     = "kube_pod_status_pending"
-	PodRunningMetricName     = "kube_pod_status_running"
-	PodSucceededMetricName   = "kube_pod_status_succeeded"
-	PodUnknownMetricName     = "kube_pod_status_unknown"
-	PodReadyMetricName       = "kube_pod_status_ready"
-	PodScheduledMetricName   = "kube_pod_status_scheduled"
-	PodInitializedMetricName = "kube_pod_status_initialized"
+	PodFailedMetricName      = "pod_status_failed"
+	PodPendingMetricName     = "pod_status_pending"
+	PodRunningMetricName     = "pod_status_running"
+	PodSucceededMetricName   = "pod_status_succeeded"
+	PodUnknownMetricName     = "pod_status_unknown"
+	PodReadyMetricName       = "pod_status_ready"
+	PodScheduledMetricName   = "pod_status_scheduled"
+	PodInitializedMetricName = "pod_status_initialized"
 )
 
 func TestPodStore_addStatus_adds_pod_failed_metric(t *testing.T) {

--- a/receiver/awscontainerinsightreceiver/internal/stores/test_resources/all_pod_conditions_valid.json
+++ b/receiver/awscontainerinsightreceiver/internal/stores/test_resources/all_pod_conditions_valid.json
@@ -1,0 +1,156 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "cpu-limit",
+        "namespace": "default",
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "DaemonSet",
+            "name": "DaemonSetTest",
+            "uid": "36779a62-4aca-11e9-977b-0672b6c6fc94"
+          }
+        ],
+        "selfLink": "/api/v1/namespaces/default/pods/cpu-limit",
+        "uid": "764d01e1-2a2f-11e9-95ea-0a695d7ce286",
+        "resourceVersion": "5671573",
+        "creationTimestamp": "2019-02-06T16:51:34Z",
+        "labels": {
+          "app": "hello_test"
+        },
+        "annotations": {
+          "kubernetes.io/config.seen": "2019-02-19T00:06:56.109155665Z",
+          "kubernetes.io/config.source": "api"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-tlgw7",
+            "secret": {
+              "secretName": "default-token-tlgw7",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "ubuntu",
+            "image": "ubuntu",
+            "command": [
+              "/bin/bash"
+            ],
+            "args": [
+              "-c",
+              "sleep 300000000"
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              },
+              "requests": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-tlgw7",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "ip-192-168-67-127.us-west-2.compute.internal",
+        "securityContext": {
+
+        },
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          },
+          {
+            "type": "Ready",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:43Z"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": null
+          },
+          {
+            "type": "PodScheduled",
+            "status": "Unknown",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          }
+        ],
+        "hostIP": "192.168.67.127",
+        "podIP": "192.168.76.93",
+        "startTime": "2019-02-06T16:51:34Z",
+        "containerStatuses": [
+          {
+            "name": "ubuntu",
+            "state": {
+              "running": {
+                "startedAt": "2019-02-06T16:51:42Z"
+              }
+            },
+            "lastState": {
+
+            },
+            "ready": true,
+            "restartCount": 0,
+            "image": "ubuntu:latest",
+            "imageID": "docker-pullable://ubuntu@sha256:7a47ccc3bbe8a451b500d2b53104868b46d60ee8f5b35a24b41a86077c650210",
+            "containerID": "docker://637631e2634ea92c0c1aa5d24734cfe794f09c57933026592c12acafbaf6972c"
+          }
+        ],
+        "qosClass": "Guaranteed"
+      }
+    }
+  ]
+}

--- a/receiver/awscontainerinsightreceiver/internal/stores/test_resources/one_pod_condition_invalid.json
+++ b/receiver/awscontainerinsightreceiver/internal/stores/test_resources/one_pod_condition_invalid.json
@@ -1,0 +1,156 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "cpu-limit",
+        "namespace": "default",
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "DaemonSet",
+            "name": "DaemonSetTest",
+            "uid": "36779a62-4aca-11e9-977b-0672b6c6fc94"
+          }
+        ],
+        "selfLink": "/api/v1/namespaces/default/pods/cpu-limit",
+        "uid": "764d01e1-2a2f-11e9-95ea-0a695d7ce286",
+        "resourceVersion": "5671573",
+        "creationTimestamp": "2019-02-06T16:51:34Z",
+        "labels": {
+          "app": "hello_test"
+        },
+        "annotations": {
+          "kubernetes.io/config.seen": "2019-02-19T00:06:56.109155665Z",
+          "kubernetes.io/config.source": "api"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-tlgw7",
+            "secret": {
+              "secretName": "default-token-tlgw7",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "ubuntu",
+            "image": "ubuntu",
+            "command": [
+              "/bin/bash"
+            ],
+            "args": [
+              "-c",
+              "sleep 300000000"
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              },
+              "requests": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-tlgw7",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "ip-192-168-67-127.us-west-2.compute.internal",
+        "securityContext": {
+
+        },
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "UnexpectedConditionThisShouldNotEverBeTrueFalseOrUnknown ",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:43Z"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": null
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          }
+        ],
+        "hostIP": "192.168.67.127",
+        "podIP": "192.168.76.93",
+        "startTime": "2019-02-06T16:51:34Z",
+        "containerStatuses": [
+          {
+            "name": "ubuntu",
+            "state": {
+              "running": {
+                "startedAt": "2019-02-06T16:51:42Z"
+              }
+            },
+            "lastState": {
+
+            },
+            "ready": true,
+            "restartCount": 0,
+            "image": "ubuntu:latest",
+            "imageID": "docker-pullable://ubuntu@sha256:7a47ccc3bbe8a451b500d2b53104868b46d60ee8f5b35a24b41a86077c650210",
+            "containerID": "docker://637631e2634ea92c0c1aa5d24734cfe794f09c57933026592c12acafbaf6972c"
+          }
+        ],
+        "qosClass": "Guaranteed"
+      }
+    }
+  ]
+}

--- a/receiver/awscontainerinsightreceiver/internal/stores/test_resources/pod_in_phase_failed.json
+++ b/receiver/awscontainerinsightreceiver/internal/stores/test_resources/pod_in_phase_failed.json
@@ -1,0 +1,156 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "cpu-limit",
+        "namespace": "default",
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "DaemonSet",
+            "name": "DaemonSetTest",
+            "uid": "36779a62-4aca-11e9-977b-0672b6c6fc94"
+          }
+        ],
+        "selfLink": "/api/v1/namespaces/default/pods/cpu-limit",
+        "uid": "764d01e1-2a2f-11e9-95ea-0a695d7ce286",
+        "resourceVersion": "5671573",
+        "creationTimestamp": "2019-02-06T16:51:34Z",
+        "labels": {
+          "app": "hello_test"
+        },
+        "annotations": {
+          "kubernetes.io/config.seen": "2019-02-19T00:06:56.109155665Z",
+          "kubernetes.io/config.source": "api"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-tlgw7",
+            "secret": {
+              "secretName": "default-token-tlgw7",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "ubuntu",
+            "image": "ubuntu",
+            "command": [
+              "/bin/bash"
+            ],
+            "args": [
+              "-c",
+              "sleep 300000000"
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              },
+              "requests": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-tlgw7",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "ip-192-168-67-127.us-west-2.compute.internal",
+        "securityContext": {
+
+        },
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0
+      },
+      "status": {
+        "phase": "Failed",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:43Z"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": null
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          }
+        ],
+        "hostIP": "192.168.67.127",
+        "podIP": "192.168.76.93",
+        "startTime": "2019-02-06T16:51:34Z",
+        "containerStatuses": [
+          {
+            "name": "ubuntu",
+            "state": {
+              "running": {
+                "startedAt": "2019-02-06T16:51:42Z"
+              }
+            },
+            "lastState": {
+
+            },
+            "ready": true,
+            "restartCount": 0,
+            "image": "ubuntu:latest",
+            "imageID": "docker-pullable://ubuntu@sha256:7a47ccc3bbe8a451b500d2b53104868b46d60ee8f5b35a24b41a86077c650210",
+            "containerID": "docker://637631e2634ea92c0c1aa5d24734cfe794f09c57933026592c12acafbaf6972c"
+          }
+        ],
+        "qosClass": "Guaranteed"
+      }
+    }
+  ]
+}

--- a/receiver/awscontainerinsightreceiver/internal/stores/test_resources/pod_in_phase_pending.json
+++ b/receiver/awscontainerinsightreceiver/internal/stores/test_resources/pod_in_phase_pending.json
@@ -1,0 +1,156 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "cpu-limit",
+        "namespace": "default",
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "DaemonSet",
+            "name": "DaemonSetTest",
+            "uid": "36779a62-4aca-11e9-977b-0672b6c6fc94"
+          }
+        ],
+        "selfLink": "/api/v1/namespaces/default/pods/cpu-limit",
+        "uid": "764d01e1-2a2f-11e9-95ea-0a695d7ce286",
+        "resourceVersion": "5671573",
+        "creationTimestamp": "2019-02-06T16:51:34Z",
+        "labels": {
+          "app": "hello_test"
+        },
+        "annotations": {
+          "kubernetes.io/config.seen": "2019-02-19T00:06:56.109155665Z",
+          "kubernetes.io/config.source": "api"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-tlgw7",
+            "secret": {
+              "secretName": "default-token-tlgw7",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "ubuntu",
+            "image": "ubuntu",
+            "command": [
+              "/bin/bash"
+            ],
+            "args": [
+              "-c",
+              "sleep 300000000"
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              },
+              "requests": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-tlgw7",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "ip-192-168-67-127.us-west-2.compute.internal",
+        "securityContext": {
+
+        },
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0
+      },
+      "status": {
+        "phase": "Pending",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:43Z"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": null
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          }
+        ],
+        "hostIP": "192.168.67.127",
+        "podIP": "192.168.76.93",
+        "startTime": "2019-02-06T16:51:34Z",
+        "containerStatuses": [
+          {
+            "name": "ubuntu",
+            "state": {
+              "running": {
+                "startedAt": "2019-02-06T16:51:42Z"
+              }
+            },
+            "lastState": {
+
+            },
+            "ready": true,
+            "restartCount": 0,
+            "image": "ubuntu:latest",
+            "imageID": "docker-pullable://ubuntu@sha256:7a47ccc3bbe8a451b500d2b53104868b46d60ee8f5b35a24b41a86077c650210",
+            "containerID": "docker://637631e2634ea92c0c1aa5d24734cfe794f09c57933026592c12acafbaf6972c"
+          }
+        ],
+        "qosClass": "Guaranteed"
+      }
+    }
+  ]
+}

--- a/receiver/awscontainerinsightreceiver/internal/stores/test_resources/pod_in_phase_running.json
+++ b/receiver/awscontainerinsightreceiver/internal/stores/test_resources/pod_in_phase_running.json
@@ -1,0 +1,156 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "cpu-limit",
+        "namespace": "default",
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "DaemonSet",
+            "name": "DaemonSetTest",
+            "uid": "36779a62-4aca-11e9-977b-0672b6c6fc94"
+          }
+        ],
+        "selfLink": "/api/v1/namespaces/default/pods/cpu-limit",
+        "uid": "764d01e1-2a2f-11e9-95ea-0a695d7ce286",
+        "resourceVersion": "5671573",
+        "creationTimestamp": "2019-02-06T16:51:34Z",
+        "labels": {
+          "app": "hello_test"
+        },
+        "annotations": {
+          "kubernetes.io/config.seen": "2019-02-19T00:06:56.109155665Z",
+          "kubernetes.io/config.source": "api"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-tlgw7",
+            "secret": {
+              "secretName": "default-token-tlgw7",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "ubuntu",
+            "image": "ubuntu",
+            "command": [
+              "/bin/bash"
+            ],
+            "args": [
+              "-c",
+              "sleep 300000000"
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              },
+              "requests": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-tlgw7",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "ip-192-168-67-127.us-west-2.compute.internal",
+        "securityContext": {
+
+        },
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:43Z"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": null
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          }
+        ],
+        "hostIP": "192.168.67.127",
+        "podIP": "192.168.76.93",
+        "startTime": "2019-02-06T16:51:34Z",
+        "containerStatuses": [
+          {
+            "name": "ubuntu",
+            "state": {
+              "running": {
+                "startedAt": "2019-02-06T16:51:42Z"
+              }
+            },
+            "lastState": {
+
+            },
+            "ready": true,
+            "restartCount": 0,
+            "image": "ubuntu:latest",
+            "imageID": "docker-pullable://ubuntu@sha256:7a47ccc3bbe8a451b500d2b53104868b46d60ee8f5b35a24b41a86077c650210",
+            "containerID": "docker://637631e2634ea92c0c1aa5d24734cfe794f09c57933026592c12acafbaf6972c"
+          }
+        ],
+        "qosClass": "Guaranteed"
+      }
+    }
+  ]
+}

--- a/receiver/awscontainerinsightreceiver/internal/stores/test_resources/pod_in_phase_succeeded.json
+++ b/receiver/awscontainerinsightreceiver/internal/stores/test_resources/pod_in_phase_succeeded.json
@@ -1,0 +1,156 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "cpu-limit",
+        "namespace": "default",
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "DaemonSet",
+            "name": "DaemonSetTest",
+            "uid": "36779a62-4aca-11e9-977b-0672b6c6fc94"
+          }
+        ],
+        "selfLink": "/api/v1/namespaces/default/pods/cpu-limit",
+        "uid": "764d01e1-2a2f-11e9-95ea-0a695d7ce286",
+        "resourceVersion": "5671573",
+        "creationTimestamp": "2019-02-06T16:51:34Z",
+        "labels": {
+          "app": "hello_test"
+        },
+        "annotations": {
+          "kubernetes.io/config.seen": "2019-02-19T00:06:56.109155665Z",
+          "kubernetes.io/config.source": "api"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-tlgw7",
+            "secret": {
+              "secretName": "default-token-tlgw7",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "ubuntu",
+            "image": "ubuntu",
+            "command": [
+              "/bin/bash"
+            ],
+            "args": [
+              "-c",
+              "sleep 300000000"
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              },
+              "requests": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-tlgw7",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "ip-192-168-67-127.us-west-2.compute.internal",
+        "securityContext": {
+
+        },
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0
+      },
+      "status": {
+        "phase": "Succeeded",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:43Z"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": null
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          }
+        ],
+        "hostIP": "192.168.67.127",
+        "podIP": "192.168.76.93",
+        "startTime": "2019-02-06T16:51:34Z",
+        "containerStatuses": [
+          {
+            "name": "ubuntu",
+            "state": {
+              "running": {
+                "startedAt": "2019-02-06T16:51:42Z"
+              }
+            },
+            "lastState": {
+
+            },
+            "ready": true,
+            "restartCount": 0,
+            "image": "ubuntu:latest",
+            "imageID": "docker-pullable://ubuntu@sha256:7a47ccc3bbe8a451b500d2b53104868b46d60ee8f5b35a24b41a86077c650210",
+            "containerID": "docker://637631e2634ea92c0c1aa5d24734cfe794f09c57933026592c12acafbaf6972c"
+          }
+        ],
+        "qosClass": "Guaranteed"
+      }
+    }
+  ]
+}

--- a/receiver/awscontainerinsightreceiver/internal/stores/test_resources/pod_in_phase_unknown.json
+++ b/receiver/awscontainerinsightreceiver/internal/stores/test_resources/pod_in_phase_unknown.json
@@ -1,0 +1,156 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "cpu-limit",
+        "namespace": "default",
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "DaemonSet",
+            "name": "DaemonSetTest",
+            "uid": "36779a62-4aca-11e9-977b-0672b6c6fc94"
+          }
+        ],
+        "selfLink": "/api/v1/namespaces/default/pods/cpu-limit",
+        "uid": "764d01e1-2a2f-11e9-95ea-0a695d7ce286",
+        "resourceVersion": "5671573",
+        "creationTimestamp": "2019-02-06T16:51:34Z",
+        "labels": {
+          "app": "hello_test"
+        },
+        "annotations": {
+          "kubernetes.io/config.seen": "2019-02-19T00:06:56.109155665Z",
+          "kubernetes.io/config.source": "api"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-tlgw7",
+            "secret": {
+              "secretName": "default-token-tlgw7",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "ubuntu",
+            "image": "ubuntu",
+            "command": [
+              "/bin/bash"
+            ],
+            "args": [
+              "-c",
+              "sleep 300000000"
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              },
+              "requests": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-tlgw7",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "ip-192-168-67-127.us-west-2.compute.internal",
+        "securityContext": {
+
+        },
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0
+      },
+      "status": {
+        "phase": "Unknown",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:43Z"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": null
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          }
+        ],
+        "hostIP": "192.168.67.127",
+        "podIP": "192.168.76.93",
+        "startTime": "2019-02-06T16:51:34Z",
+        "containerStatuses": [
+          {
+            "name": "ubuntu",
+            "state": {
+              "running": {
+                "startedAt": "2019-02-06T16:51:42Z"
+              }
+            },
+            "lastState": {
+
+            },
+            "ready": true,
+            "restartCount": 0,
+            "image": "ubuntu:latest",
+            "imageID": "docker-pullable://ubuntu@sha256:7a47ccc3bbe8a451b500d2b53104868b46d60ee8f5b35a24b41a86077c650210",
+            "containerID": "docker://637631e2634ea92c0c1aa5d24734cfe794f09c57933026592c12acafbaf6972c"
+          }
+        ],
+        "qosClass": "Guaranteed"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Emit 8 new kube_pod_status_* metrics for containerinsights
- pod_status_running
- pod_status_pending
- pod_status_succeeded
- pod_status_failed
- pod_status_unknown
- pod_status_ready
- pod_status_scheduled
- pod_status_initialized

**Testing:** <Describe what testing was performed and which tests were added.>
1. Unit test
2. Made changes to the Cloudwatch Agent code, and verified this data gets emitted as emf log (metrics on dashboard were also tested, but that will be described in the cloudwatch agent code commits.)


<img width="215" alt="Screenshot 2023-06-05 at 13 50 47" src="https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/24197975/3087f211-6fb4-48d7-b0cf-a2694edd3e4b">
