### PR TITLE
Get AWS Session From Config awscontainerinsightreceiver

### DIFF
--- a/internal/aws/awsutil/awsconfig.go
+++ b/internal/aws/awsutil/awsconfig.go
@@ -37,6 +37,10 @@ type AWSSessionSettings struct {
 	ResourceARN string `mapstructure:"resource_arn"`
 	// IAM role to upload segments to a different account.
 	RoleARN string `mapstructure:"role_arn"`
+	// Change the default profile for shared creds file
+	Profile string `mapstructure:"profile"`
+	// Change the default profile for shared creds file
+	SharedCredentialsFile []string `mapstructure:"shared_credentials_file"`
 }
 
 func CreateDefaultSessionConfig() AWSSessionSettings {

--- a/internal/aws/awsutil/awsconfig.go
+++ b/internal/aws/awsutil/awsconfig.go
@@ -39,7 +39,7 @@ type AWSSessionSettings struct {
 	RoleARN string `mapstructure:"role_arn"`
 	// Change the default profile for shared creds file
 	Profile string `mapstructure:"profile"`
-	// Change the default profile for shared creds file
+	// Change the default shared creds file location
 	SharedCredentialsFile []string `mapstructure:"shared_credentials_file"`
 }
 

--- a/internal/aws/awsutil/conn_test.go
+++ b/internal/aws/awsutil/conn_test.go
@@ -43,7 +43,7 @@ func (c *mockConn) getEC2Region(s *session.Session) (string, error) {
 	return ec2Region, nil
 }
 
-func (c *mockConn) newAWSSession(logger *zap.Logger, roleArn string, region string) (*session.Session, error) {
+func (c *mockConn) newAWSSession(logger *zap.Logger, roleArn string, region string, profile string, sharedCredentialsFile []string) (*session.Session, error) {
 	return c.sn, nil
 }
 
@@ -119,11 +119,11 @@ func TestNewAWSSessionWithErr(t *testing.T) {
 	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 	t.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "fake")
 	conn := &Conn{}
-	se, err := conn.newAWSSession(logger, roleArn, region)
+	se, err := conn.newAWSSession(logger, roleArn, region, "", nil)
 	assert.NotNil(t, err)
 	assert.Nil(t, se)
 	roleArn = ""
-	se, err = conn.newAWSSession(logger, roleArn, region)
+	se, err = conn.newAWSSession(logger, roleArn, region, "", nil)
 	assert.NotNil(t, err)
 	assert.Nil(t, se)
 	t.Setenv("AWS_SDK_LOAD_CONFIG", "true")
@@ -153,7 +153,7 @@ func TestGetSTSCredsFromPrimaryRegionEndpoint(t *testing.T) {
 func TestGetDefaultSession(t *testing.T) {
 	logger := zap.NewNop()
 	t.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "fake")
-	_, err := GetDefaultSession(logger)
+	_, err := GetDefaultSession(logger, session.Options{})
 	assert.NotNil(t, err)
 }
 

--- a/receiver/awscontainerinsightreceiver/config.go
+++ b/receiver/awscontainerinsightreceiver/config.go
@@ -16,10 +16,15 @@ package awscontainerinsightreceiver // import "github.com/open-telemetry/opentel
 
 import (
 	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil"
 )
 
 // Config defines configuration for aws ecs container metrics receiver.
 type Config struct {
+	// AWSSessionSettings contains the common configuration options
+	// for creating AWS session to communicate with backend
+	awsutil.AWSSessionSettings `mapstructure:",squash"`
 
 	// CollectionInterval is the interval at which metrics should be collected. The default is 60 second.
 	CollectionInterval time.Duration `mapstructure:"collection_interval"`

--- a/receiver/awscontainerinsightreceiver/internal/host/hostinfo.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/hostinfo.go
@@ -61,7 +61,7 @@ func WithClusterName(name string) Option {
 }
 
 // NewInfo creates a new Info struct
-func NewInfo(containerOrchestrator string, refreshInterval time.Duration, logger *zap.Logger, options ...Option) (*Info, error) {
+func NewInfo(awsSessionSettings awsutil.AWSSessionSettings, containerOrchestrator string, refreshInterval time.Duration, logger *zap.Logger, options ...Option) (*Info, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	mInfo := &Info{
 		cancel:           cancel,
@@ -92,8 +92,7 @@ func NewInfo(containerOrchestrator string, refreshInterval time.Duration, logger
 	}
 	mInfo.nodeCapacity = nodeCapacity
 
-	defaultSessionConfig := awsutil.CreateDefaultSessionConfig()
-	_, session, err := mInfo.awsSessionCreator(logger, &awsutil.Conn{}, &defaultSessionConfig)
+	_, session, err := mInfo.awsSessionCreator(logger, &awsutil.Conn{}, &awsSessionSettings)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create aws session: %w", err)
 	}

--- a/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
@@ -88,7 +88,7 @@ func TestInfo(t *testing.T) {
 			return nil, errors.New("error")
 		}
 	}
-	m, err := NewInfo(ci.EKS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt)
+	m, err := NewInfo(awsutil.CreateDefaultSessionConfig(), ci.EKS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt)
 	assert.Nil(t, m)
 	assert.Error(t, err)
 
@@ -103,7 +103,7 @@ func TestInfo(t *testing.T) {
 			return nil, nil, errors.New("error")
 		}
 	}
-	m, err = NewInfo(ci.EKS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
+	m, err = NewInfo(awsutil.CreateDefaultSessionConfig(), ci.EKS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
 	assert.Nil(t, m)
 	assert.Error(t, err)
 
@@ -131,7 +131,7 @@ func TestInfo(t *testing.T) {
 			return &mockEC2Tags{}
 		}
 	}
-	m, err = NewInfo(ci.EKS, time.Minute, zap.NewNop(), awsSessionCreatorOpt,
+	m, err = NewInfo(awsutil.CreateDefaultSessionConfig(), ci.EKS, time.Minute, zap.NewNop(), awsSessionCreatorOpt,
 		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt)
 	assert.NoError(t, err)
 	assert.NotNil(t, m)
@@ -155,7 +155,7 @@ func TestInfo(t *testing.T) {
 	assert.Equal(t, "asg", m.GetAutoScalingGroupName())
 
 	// Test with cluster name override
-	m, err = NewInfo(ci.EKS, time.Minute, zap.NewNop(), awsSessionCreatorOpt,
+	m, err = NewInfo(awsutil.CreateDefaultSessionConfig(), ci.EKS, time.Minute, zap.NewNop(), awsSessionCreatorOpt,
 		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt, WithClusterName("override-cluster"))
 	assert.NoError(t, err)
 	assert.NotNil(t, m)
@@ -170,7 +170,7 @@ func TestInfoForECS(t *testing.T) {
 			return nil, errors.New("error")
 		}
 	}
-	m, err := NewInfo(ci.ECS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt)
+	m, err := NewInfo(awsutil.CreateDefaultSessionConfig(), ci.ECS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt)
 	assert.Nil(t, m)
 	assert.Error(t, err)
 
@@ -185,7 +185,7 @@ func TestInfoForECS(t *testing.T) {
 			return nil, nil, errors.New("error")
 		}
 	}
-	m, err = NewInfo(ci.ECS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
+	m, err = NewInfo(awsutil.CreateDefaultSessionConfig(), ci.ECS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
 	assert.Nil(t, m)
 	assert.Error(t, err)
 
@@ -213,7 +213,7 @@ func TestInfoForECS(t *testing.T) {
 			return &mockEC2Tags{}
 		}
 	}
-	m, err = NewInfo(ci.ECS, time.Minute, zap.NewNop(), awsSessionCreatorOpt,
+	m, err = NewInfo(awsutil.CreateDefaultSessionConfig(), ci.ECS, time.Minute, zap.NewNop(), awsSessionCreatorOpt,
 		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt)
 	assert.NoError(t, err)
 	assert.NotNil(t, m)

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -71,7 +71,7 @@ func newAWSContainerInsightReceiver(
 func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host component.Host) error {
 	ctx, acir.cancel = context.WithCancel(ctx)
 
-	hostinfo, err := hostInfo.NewInfo(acir.config.ContainerOrchestrator, acir.config.CollectionInterval, acir.settings.Logger, hostInfo.WithClusterName(acir.config.ClusterName))
+	hostinfo, err := hostInfo.NewInfo(acir.config.AWSSessionSettings, acir.config.ContainerOrchestrator, acir.config.CollectionInterval, acir.settings.Logger, hostInfo.WithClusterName(acir.config.ClusterName))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Add Profile And Shared Credentials File To AWS Session Settings

**Description:** 
Add feature, 
turn on container insights if aws session region is passed in
allow configuring profile and shared creds via exporter config. 

**Link to tracking Issue:** 
internal ticket

**Testing:** 
Confirmed metrics and logs are published to cw when running minikube on my mac. While mounting the creds file. 
Config
```
exporters:
    awsemf/containerinsights:
        detailed_metrics: false
        dimension_rollup_option: NoDimensionRollup
        eks_fargate_container_insights_enabled: false
        endpoint: ""
        local_mode: false
        log_group_name: /aws/containerinsights/{ClusterName}/performance
        log_retention: 0
        log_stream_name: '{NodeName}'
        max_retries: 2
        metric_declarations:
            - dimensions:
                - - ClusterName
                  - Namespace
                  - PodName
                - - ClusterName
                  - Namespace
                  - Service
                - - ClusterName
                  - Namespace
                - - ClusterName
              label_matchers: []
              metric_name_selectors:
                - pod_cpu_utilization
                - pod_memory_utilization
                - pod_network_rx_bytes
                - pod_network_tx_bytes
                - pod_cpu_utilization_over_pod_limit
                - pod_memory_utilization_over_pod_limit
            - dimensions:
                - - ClusterName
                  - Namespace
                  - PodName
                - - ClusterName
              label_matchers: []
              metric_name_selectors:
                - pod_cpu_reserved_capacity
                - pod_memory_reserved_capacity
            - dimensions:
                - - ClusterName
                  - Namespace
                  - PodName
              label_matchers: []
              metric_name_selectors:
                - pod_number_of_container_restarts
            - dimensions:
                - - ClusterName
                  - InstanceId
                  - NodeName
                - - ClusterName
              label_matchers: []
              metric_name_selectors:
                - node_cpu_utilization
                - node_memory_utilization
                - node_network_total_bytes
                - node_cpu_reserved_capacity
                - node_memory_reserved_capacity
                - node_number_of_running_pods
                - node_number_of_running_containers
            - dimensions:
                - - ClusterName
              label_matchers: []
              metric_name_selectors:
                - node_cpu_usage_total
                - node_cpu_limit
                - node_memory_working_set
                - node_memory_limit
            - dimensions:
                - - ClusterName
                  - InstanceId
                  - NodeName
                - - ClusterName
              label_matchers: []
              metric_name_selectors:
                - node_filesystem_utilization
            - dimensions:
                - - ClusterName
                  - Namespace
                  - Service
                - - ClusterName
              label_matchers: []
              metric_name_selectors:
                - service_number_of_running_pods
            - dimensions:
                - - ClusterName
                  - Namespace
                - - ClusterName
              label_matchers: []
              metric_name_selectors:
                - namespace_number_of_running_pods
            - dimensions:
                - - ClusterName
              label_matchers: []
              metric_name_selectors:
                - cluster_node_count
                - cluster_failed_node_count
            - dimensions:
                - - ClusterName
                  - endpoint
                - - ClusterName
              label_matchers: []
              metric_name_selectors:
                - etcd_db_total_size_in_bytes
            - dimensions:
                - - ClusterName
              label_matchers: []
              metric_name_selectors:
                - apiserver_storage_objects
                - apiserver_request_total
                - apiserver_request_duration_seconds
                - apiserver_admission_controller_admission_duration_seconds
                - rest_client_request_duration_seconds
                - rest_client_requests_total
                - etcd_request_duration_seconds
        metric_descriptors: []
        namespace: ContainerInsights
        no_verify_ssl: false
        num_workers: 8
        output_destination: cloudwatch
        parse_json_encoded_attr_values:
            - Sources
            - kubernetes
        profile: AmazonCloudWatchAgent
        proxy_address: ""
        region: us-west-2
        request_timeout_seconds: 30
        resource_arn: ""
        resource_to_telemetry_conversion:
            enabled: true
        retain_initial_value_of_delta_metric: false
        role_arn: ""
        shared_credentials_file:
            - /root/.aws/credentials
        version: "0"
extensions: {}
processors:
    batch/containerinsights:
        send_batch_max_size: 0
        send_batch_size: 8192
        timeout: 200ms
receivers:
    awscontainerinsightreceiver:
        add_container_name_metric_label: false
        add_full_pod_name_metric_label: false
        add_service_as_attribute: true
        cluster_name: og
        collection_interval: 1m0s
        container_orchestrator: eks
        endpoint: ""
        leader_lock_name: cwagent-clusterleader
        leader_lock_using_config_map_only: true
        local_mode: false
        max_retries: 0
        no_verify_ssl: false
        num_workers: 0
        prefer_full_pod_name: false
        profile: ""
        proxy_address: ""
        region: us-west-2
        request_timeout_seconds: 0
        resource_arn: ""
        role_arn: ""
        shared_credentials_file: []
service:
    extensions: []
    pipelines:
        metrics/containerinsights:
            exporters:
                - awsemf/containerinsights
            processors:
                - batch/containerinsights
            receivers:
                - awscontainerinsightreceiver
    telemetry:
        logs:
            development: false
            disable_caller: false
            disable_stacktrace: false
            encoding: console
            error_output_paths: []
            initial_fields: {}
            level: debug
            output_paths: []
            sampling:
                initial: 2
                thereafter: 500
        metrics:
            address: ""
            level: None
        resource: {}
        traces:
            propagators: []
```

**Documentation:** 
N/A