### PR TITLE
Fix repeated append of SDK language

### DIFF
--- a/exporter/awsxrayexporter/internal/translator/aws.go
+++ b/exporter/awsxrayexporter/internal/translator/aws.go
@@ -237,12 +237,12 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 		cwl = getLogGroupMetadata(configSlice, false)
 	}
 
-	if sdkName != "" && sdkLanguage != "" {
+	sdkLanguageSuffix := " for " + sdkLanguage
+	sdk = sdkName
+	if sdkName != "" && sdkLanguage != "" && !strings.HasSuffix(strings.ToLower(sdkName), strings.ToLower(sdkLanguageSuffix)) {
 		// Convention for SDK name for xray SDK information is e.g., `X-Ray SDK for Java`, `X-Ray for Go`.
 		// We fill in with e.g, `opentelemetry for java` by using the conventions
-		sdk = sdkName + " for " + sdkLanguage
-	} else {
-		sdk = sdkName
+		sdk += sdkLanguageSuffix
 	}
 
 	xray := &awsxray.XRayMetaData{

--- a/exporter/awsxrayexporter/internal/translator/aws_test.go
+++ b/exporter/awsxrayexporter/internal/translator/aws_test.go
@@ -388,6 +388,21 @@ func TestCustomSDK(t *testing.T) {
 	assert.Equal(t, "2.0.3", *awsData.XRay.SDKVersion)
 }
 
+func TestCustomSDKForLanguage(t *testing.T) {
+	attributes := make(map[string]pcommon.Value)
+	resource := pcommon.NewResource()
+	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKName, "test for java")
+	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKLanguage, "java")
+	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKVersion, "2.0.3")
+
+	filtered, awsData := makeAws(attributes, resource, nil)
+
+	assert.NotNil(t, filtered)
+	assert.NotNil(t, awsData)
+	assert.Equal(t, "test for java", *awsData.XRay.SDK)
+	assert.Equal(t, "2.0.3", *awsData.XRay.SDKVersion)
+}
+
 func TestLogGroups(t *testing.T) {
 	cwl1 := awsxray.LogGroupMetadata{
 		LogGroup: awsxray.String("group1"),


### PR DESCRIPTION
**Description:**
The X-Ray SDK already sets the SDK name as `X-Ray for Go`, so the function in the awsxrayexporter is appending an additional "for Go" at the end.

Current implementation results in:
```
"aws": {
    "xray": {
        "auto_instrumentation": false,
        "sdk_version": "1.8.1",
        "sdk": "X-Ray for Go for Go"
    }
},
```

The change checks to see if it has the suffix already and skips the append if it does.

**Testing:** Added unit test.