### PR TITLE
Fix X-Ray metadata unmarshaling

### DIFF
--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -442,16 +442,16 @@ func makeXRayAttributes(attributes map[string]pcommon.Value, resource pcommon.Re
 			case strings.HasPrefix(key, awsxray.AWSXraySegmentMetadataAttributePrefix) && value.Type() == pcommon.ValueTypeStr:
 				namespace := strings.TrimPrefix(key, awsxray.AWSXraySegmentMetadataAttributePrefix)
 				var metaVal map[string]interface{}
-				if err := json.Unmarshal([]byte(value.Str()), &metaVal); err != nil {
+				err := json.Unmarshal([]byte(value.Str()), &metaVal)
+				switch {
+				case err != nil:
 					// if unable to unmarshal, keep the original key/value
 					defaultMetadata[key] = value.Str()
-					continue
-				}
-				if strings.EqualFold(namespace, defaultMetadataNamespace) {
+				case strings.EqualFold(namespace, defaultMetadataNamespace):
 					for k, v := range metaVal {
 						defaultMetadata[k] = v
 					}
-				} else {
+				default:
 					metadata[namespace] = metaVal
 				}
 			default:

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -499,6 +499,31 @@ func TestSpanWithAttributesAllIndexed(t *testing.T) {
 	assert.Equal(t, "val2", segment.Annotations["attr2_2"])
 }
 
+func TestSpanWithAttributesSegmentMetadata(t *testing.T) {
+	spanName := "/api/locations"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]interface{})
+	attributes["attr1@1"] = "val1"
+	attributes[awsxray.AWSXraySegmentMetadataAttributePrefix+"default"] = "{\"custom_key\": \"custom_value\"}"
+	attributes[awsxray.AWSXraySegmentMetadataAttributePrefix+"http"] = "{\"connection\":{\"reused\":false,\"was_idle\":false}}"
+	resource := constructDefaultResource()
+	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
+
+	segment, _ := MakeSegment(span, resource, nil, false, nil)
+
+	assert.NotNil(t, segment)
+	assert.Equal(t, 0, len(segment.Annotations))
+	assert.Equal(t, 2, len(segment.Metadata))
+	assert.Equal(t, "val1", segment.Metadata["default"]["attr1@1"])
+	assert.Equal(t, "custom_value", segment.Metadata["default"]["custom_key"])
+	assert.Nil(t, segment.Metadata["default"][awsxray.AWSXraySegmentMetadataAttributePrefix+"default"])
+	assert.Nil(t, segment.Metadata["default"][awsxray.AWSXraySegmentMetadataAttributePrefix+"http"])
+	assert.Equal(t, map[string]interface{}{
+		"reused":   false,
+		"was_idle": false,
+	}, segment.Metadata["http"]["connection"])
+}
+
 func TestResourceAttributesCanBeIndexed(t *testing.T) {
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -506,6 +506,7 @@ func TestSpanWithAttributesSegmentMetadata(t *testing.T) {
 	attributes["attr1@1"] = "val1"
 	attributes[awsxray.AWSXraySegmentMetadataAttributePrefix+"default"] = "{\"custom_key\": \"custom_value\"}"
 	attributes[awsxray.AWSXraySegmentMetadataAttributePrefix+"http"] = "{\"connection\":{\"reused\":false,\"was_idle\":false}}"
+	attributes[awsxray.AWSXraySegmentMetadataAttributePrefix+"non-xray-sdk"] = "retain-value"
 	resource := constructDefaultResource()
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
@@ -516,6 +517,7 @@ func TestSpanWithAttributesSegmentMetadata(t *testing.T) {
 	assert.Equal(t, 2, len(segment.Metadata))
 	assert.Equal(t, "val1", segment.Metadata["default"]["attr1@1"])
 	assert.Equal(t, "custom_value", segment.Metadata["default"]["custom_key"])
+	assert.Equal(t, "retain-value", segment.Metadata["default"][awsxray.AWSXraySegmentMetadataAttributePrefix+"non-xray-sdk"])
 	assert.Nil(t, segment.Metadata["default"][awsxray.AWSXraySegmentMetadataAttributePrefix+"default"])
 	assert.Nil(t, segment.Metadata["default"][awsxray.AWSXraySegmentMetadataAttributePrefix+"http"])
 	assert.Equal(t, map[string]interface{}{


### PR DESCRIPTION
**Description:** 
The X-Ray receiver marshals the metadata from the X-Ray SDK, but the exporter doesn't unmarshal the metadata, which results in squashed and incorrectly nested metadata. See issue for examples.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23610

**Testing:** Added unit tests.