### PR TITLE
Skip IMDS calls for X-Ray telemetry if in LocalMode.

### DIFF
--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -59,7 +59,7 @@ func newTracesExporter(
 	xrayClient := awsxray.NewXRayClient(logger, awsConfig, set.BuildInfo, session)
 	sender := telemetry.NewNopSender()
 	if cfg.TelemetryConfig.Enabled {
-		opts := telemetry.ToOptions(cfg.TelemetryConfig, *awsSDKV2Config, &cfg.AWSSessionSettings, logger)
+		opts := telemetry.ToOptions(cfg.TelemetryConfig, awsSDKV2Config, &cfg.AWSSessionSettings, logger)
 		opts = append(opts, telemetry.WithLogger(set.Logger))
 		sender = registry.Register(set.ID, cfg.TelemetryConfig, xrayClient, opts...)
 	}


### PR DESCRIPTION
**Description:** If the configuration for the awsxrayexporter has `LocalMode` set to true, the telemetry collection should respect it and skip the IMDS calls.

> LocalMode – Set to true to skip checking for EC2 instance metadata.

https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon-configuration.html

**Testing:** Added unit tests. Fix broken unit test from https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/33