### PR TITLE
omit TLS client setting

### DIFF
--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -35,7 +35,7 @@ type HTTPClientSettings struct {
 	Endpoint string `mapstructure:"endpoint"`
 
 	// TLSSetting struct exposes TLS client configuration.
-	TLSSetting configtls.TLSClientSetting `mapstructure:"tls"`
+	TLSSetting configtls.TLSClientSetting `mapstructure:"tls,omitempty"`
 
 	// ReadBufferSize for HTTP client. See http.Transport.ReadBufferSize.
 	ReadBufferSize int `mapstructure:"read_buffer_size"`


### PR DESCRIPTION
**Description:** 
Omit TLS settings to remove panic from null pointer

Marshalling this leads to the config.yaml having redacted certs for the resource detection processor, which causes the agent to panic from a null pointer exception.
