### PR TITLE
do not emit enhanced metrics unless we are already emitting control plane metrics

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/stores/store.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/store.go
@@ -54,7 +54,7 @@ type K8sDecorator struct {
 	addContainerNameMetricLabel bool
 }
 
-func NewK8sDecorator(ctx context.Context, tagService bool, prefFullPodName bool, addFullPodNameMetricLabel bool, addContainerNameMetricLabel bool, logger *zap.Logger) (*K8sDecorator, error) {
+func NewK8sDecorator(ctx context.Context, tagService bool, prefFullPodName bool, addFullPodNameMetricLabel bool, addContainerNameMetricLabel bool, includeEnhancedMetrics bool, logger *zap.Logger) (*K8sDecorator, error) {
 	hostIP := os.Getenv("HOST_IP")
 	if hostIP == "" {
 		return nil, errors.New("environment variable HOST_IP is not set in k8s deployment config")
@@ -65,7 +65,7 @@ func NewK8sDecorator(ctx context.Context, tagService bool, prefFullPodName bool,
 		addContainerNameMetricLabel: addContainerNameMetricLabel,
 	}
 
-	podstore, err := NewPodStore(hostIP, prefFullPodName, addFullPodNameMetricLabel, logger)
+	podstore, err := NewPodStore(hostIP, prefFullPodName, addFullPodNameMetricLabel, includeEnhancedMetrics, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -78,7 +78,7 @@ func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host compone
 	}
 
 	if acir.config.ContainerOrchestrator == ci.EKS {
-		k8sDecorator, err := stores.NewK8sDecorator(ctx, acir.config.TagService, acir.config.PrefFullPodName, acir.config.AddFullPodNameMetricLabel, acir.config.AddContainerNameMetricLabel, acir.settings.Logger)
+		k8sDecorator, err := stores.NewK8sDecorator(ctx, acir.config.TagService, acir.config.PrefFullPodName, acir.config.AddFullPodNameMetricLabel, acir.config.AddContainerNameMetricLabel, acir.config.EnableControlPlaneMetrics, acir.settings.Logger)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The enhanced metric feature was emitting extra data to the EMF logs even when the enhanced feature (granularity 2+) was not enabled.  The metrics weren't being enabled but there was concern that the extra data could impact customers bills.  This is a two-way door that can be enabled in line with any potential "enhanced" feature changes

Basically I introduced a new flag `includeEnhancedMetrics` that is only set when control plane metrics is set

This does add extra nesting / wrapping in the middle of methods.  Another option would be to create some sort of filter that is executed after each loop

**Testing:** 

I ran the latest on my test cluster and confirmed we are collecting less data:
diff:
```
4c4
<     "InstanceId": "i-092efe5a5dcb6bb29",
---
>     "InstanceId": "i-09d36e7403af61a5d",
6,9c6,8
<     "Namespace": "eks-sample-app",
<     "NodeName": "ip-192-168-20-219.us-east-2.compute.internal",
<     "PodName": "eks-sample-linux-deployment",
<     "Service": "eks-sample-linux-service",
---
>     "Namespace": "kube-system",
>     "NodeName": "ip-192-168-80-250.us-east-2.compute.internal",
>     "PodName": "ebs-csi-node",
15c14
<     "Timestamp": "1689187095984",
---
>     "Timestamp": "1689185305974",
18,19c17,19
<     "container_cpu_usage_system": 0,
<     "container_cpu_usage_total": 0,
---
>     "container_cpu_request": 10,
>     "container_cpu_usage_system": 0.13859144361691775,
>     "container_cpu_usage_total": 0.14481131673329012,
21c21
<     "container_cpu_utilization": 0,
---
>     "container_cpu_utilization": 0.007240565836664507,
23c23
<     "container_memory_cache": 0,
---
>     "container_memory_cache": 12029952,
25,26c25,26
<     "container_memory_failures_total": 0,
<     "container_memory_hierarchical_pgfault": 0,
---
>     "container_memory_failures_total": 20.580829377112284,
>     "container_memory_hierarchical_pgfault": 20.580829377112284,
28,30c28,31
<     "container_memory_mapped_file": 0,
<     "container_memory_max_usage": 3059712,
<     "container_memory_pgfault": 0,
---
>     "container_memory_limit": 268435456,
>     "container_memory_mapped_file": 10678272,
>     "container_memory_max_usage": 20885504,
>     "container_memory_pgfault": 20.580829377112284,
32c33,34
<     "container_memory_rss": 1892352,
---
>     "container_memory_request": 41943040,
>     "container_memory_rss": 3383296,
34,36c36,39
<     "container_memory_usage": 2682880,
<     "container_memory_utilization": 0.03312110542574274,
<     "container_memory_working_set": 2682880,
---
>     "container_memory_usage": 16048128,
>     "container_memory_utilization": 0.1800535252813656,
>     "container_memory_utilization_over_container_limit": 5.3741455078125,
>     "container_memory_working_set": 14426112,
37a41,44
>     "container_status_running": 1,
>     "container_status_terminated": 0,
>     "container_status_waiting": 0,
>     "container_status_waiting_reason_crashed": 0,
39c46
<         "container_name": "nginx",
---
>         "container_name": "node-driver-registrar",
41c48
<             "container_id": "9db6a44704dd0a66881a8ba74d21fa01b718852c46c9497111b1fcd7990e344e"
---
>             "container_id": "bd651f7f3e78e73fb7c46e407e0bdc5bc6f5414100226d564a5953a1754a263e"
43c50
<         "host": "ip-192-168-20-219.us-east-2.compute.internal",
---
>         "host": "ip-192-168-80-250.us-east-2.compute.internal",
45,46c52,58
<             "app": "eks-sample-linux-app",
<             "pod-template-hash": "7f646d456c"
---
>             "app": "ebs-csi-node",
>             "app.kubernetes.io/component": "csi-driver",
>             "app.kubernetes.io/managed-by": "EKS",
>             "app.kubernetes.io/name": "aws-ebs-csi-driver",
>             "app.kubernetes.io/version": "1.19.0",
>             "controller-revision-hash": "598cb9675c",
>             "pod-template-generation": "1"
48,50c60,62
<         "namespace_name": "eks-sample-app",
<         "pod_id": "a7a48666-f6b1-4af5-bdca-8b4515665a74",
<         "pod_name": "eks-sample-linux-deployment-7f646d456c-dn59m",
---
>         "namespace_name": "kube-system",
>         "pod_id": "7426b713-bffb-4ed8-a6ed-bb8511de4bfc",
>         "pod_name": "ebs-csi-node-wr5bb",
53,54c65,66
<                 "owner_kind": "Deployment",
<                 "owner_name": "eks-sample-linux-deployment"
---
>                 "owner_kind": "DaemonSet",
>                 "owner_name": "ebs-csi-node"
56,57c68
<         ],
<         "service_name": "eks-sample-linux-service"
---
>         ]
```

**Documentation:** N/A