### PR TITLE
update readme with suggested ClusterRole rules

### DIFF
--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -97,7 +97,7 @@ rules:
     resources: ["pods", "nodes", "endpoints"]
     verbs: ["list", "watch"]
   - apiGroups: ["apps"]
-    resources: ["replicasets"]
+    resources: ["replicasets", "daemonsets", "deployments"]
     verbs: ["list", "watch"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
@@ -112,6 +112,8 @@ rules:
     resources: ["configmaps"]
     resourceNames: ["otel-container-insight-clusterleader"]
     verbs: ["get","update"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get", "list", "watch"]
 
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
**Description:**
Update README with updated suggestion for ClusterRole rules

**Testing:** I deployed the following and I confirmed the expected metrics were still flowing in my test cluster

```
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: cloudwatch-agent-role
rules:
  - apiGroups: [""]
    resources: ["pods", "nodes", "endpoints"]
    verbs: ["list", "watch"]
  - apiGroups: ["apps"]
    resources: ["replicasets", "daemonsets", "deployments"]
    verbs: ["list", "watch"]
  - apiGroups: ["batch"]
    resources: ["jobs"]
    verbs: ["list", "watch"]
  - apiGroups: [""]
    resources: ["nodes/proxy"]
    verbs: ["get"]
  - apiGroups: [""]
    resources: ["nodes/stats", "configmaps", "events"]
    verbs: ["create"]
  - apiGroups: [""]
    resources: ["configmaps"]
    resourceNames: ["cwagent-clusterleader"]
    verbs: ["get","update"]
  - nonResourceURLs: ["/metrics"]
    verbs: ["get", "list", "watch"]
```

![Screen Shot 2023-07-19 at 1 19 06 PM](https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/5192710/6c24804d-b407-4fa9-afbf-08d428c2d125)
![Screen Shot 2023-07-19 at 1 19 18 PM](https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/5192710/afe41c3a-5266-4ce8-bfa8-e1b8e118dc1f)
![Screen Shot 2023-07-19 at 1 29 29 PM](https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/5192710/80dd443c-fc3b-4fa2-8d4f-830c2a18f9aa)


**Documentation:** See commit