### PR TITLE
fix concurrent map write crash in podstore

### DIFF
--- a/internal/aws/metrics/metric_calculator.go
+++ b/internal/aws/metrics/metric_calculator.go
@@ -122,15 +122,24 @@ func NewMapWithExpiry(ttl time.Duration) *MapWithExpiry {
 }
 
 func (m *MapWithExpiry) Get(key Key) (*MetricValue, bool) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
 	v, ok := m.entries[key]
 	return v, ok
 }
 
 func (m *MapWithExpiry) Set(key Key, value MetricValue) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
 	m.entries[key] = &value
 }
 
 func (m *MapWithExpiry) CleanUp(now time.Time) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
 	for k, v := range m.entries {
 		if now.Sub(v.Timestamp) >= m.ttl {
 			delete(m.entries, k)
@@ -140,12 +149,4 @@ func (m *MapWithExpiry) CleanUp(now time.Time) {
 
 func (m *MapWithExpiry) Size() int {
 	return len(m.entries)
-}
-
-func (m *MapWithExpiry) Lock() {
-	m.lock.Lock()
-}
-
-func (m *MapWithExpiry) Unlock() {
-	m.lock.Unlock()
 }

--- a/internal/aws/metrics/metric_calculator_test.go
+++ b/internal/aws/metrics/metric_calculator_test.go
@@ -143,7 +143,7 @@ func TestMapWithExpiryConcurrency(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		for i := 0; i < 30; i++ {
+		for i := 0; i < 1000; i++ {
 			sum, _ := store.Get(Key{MetricMetadata: "sum"})
 			newSum := MetricValue{
 				RawValue: sum.RawValue.(int) + 1,
@@ -154,7 +154,7 @@ func TestMapWithExpiryConcurrency(t *testing.T) {
 	}()
 
 	go func() {
-		for i := 0; i < 30; i++ {
+		for i := 0; i < 1000; i++ {
 			sum, _ := store.Get(Key{MetricMetadata: "sum"})
 			newSum := MetricValue{
 				RawValue: sum.RawValue.(int) - 1,
@@ -164,8 +164,9 @@ func TestMapWithExpiryConcurrency(t *testing.T) {
 		wg.Done()
 	}()
 	wg.Wait()
-	sum, _ := store.Get(Key{MetricMetadata: "sum"})
-	assert.Equal(t, 0, sum.RawValue.(int))
+
+	// the objective of this test is to verify the program will not crash,
+	// the values cannot be safely or predictably be incremented/decremented without a atomic increment/decrement methods
 }
 
 type mockKey struct {

--- a/internal/aws/metrics/metric_calculator_test.go
+++ b/internal/aws/metrics/metric_calculator_test.go
@@ -144,26 +144,22 @@ func TestMapWithExpiryConcurrency(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		for i := 0; i < 30; i++ {
-			store.Lock()
 			sum, _ := store.Get(Key{MetricMetadata: "sum"})
 			newSum := MetricValue{
 				RawValue: sum.RawValue.(int) + 1,
 			}
 			store.Set(Key{MetricMetadata: "sum"}, newSum)
-			store.Unlock()
 		}
 		wg.Done()
 	}()
 
 	go func() {
 		for i := 0; i < 30; i++ {
-			store.Lock()
 			sum, _ := store.Get(Key{MetricMetadata: "sum"})
 			newSum := MetricValue{
 				RawValue: sum.RawValue.(int) - 1,
 			}
 			store.Set(Key{MetricMetadata: "sum"}, newSum)
-			store.Unlock()
 		}
 		wg.Done()
 	}()


### PR DESCRIPTION
**Description:**
Bug fix

The following crash was reported
```
fatal error: concurrent map iteration and map write

goroutine 144 [running]:
github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics.(*MapWithExpiry).CleanUp(...)
        github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics@v0.77.0/metric_calculator.go:134
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores.(*PodStore).cleanup(0xc0002ae620, {0x4ad45b0?, 0xc0003cb600?, 0x6d0fc40?})
        github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver@v0.77.0/internal/stores/podstore.go:279 +0x299
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores.(*PodStore).RefreshTick(0xc0002ae620, {0x4ad45b0, 0xc0003cb600})
        github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver@v0.77.0/internal/stores/podstore.go:203 +0xa5
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores.NewK8sDecorator.func1()
        github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver@v0.77.0/internal/stores/store.go:88 +0x11b
created by github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores.NewK8sDecorator
        github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver@v0.77.0/internal/stores/store.go:82 +0x279
```

This is coming from line
```
func (p *PodStore) cleanup(now time.Time) {
    for _, prevMeasurement := range p.prevMeasurements {
        prevMeasurement.CleanUp(now)
    }
```

This cleanup is protected by the lock.  The podstore code is weird in that it creates its own hacky lock for protecting manipulation of the cache.  This is brittle and error prone because the caller (podstore) has to be aware of when it should acquire the lock.  To simplify this, I moved the locking into the resource we actually want to protect, the metric calculator.  The metric calculator already had a lock but it was not being utilized


**Testing:** Reproduced with unit test and verified the unit test fixed the issue

**Documentation:** N/A