### PR TITLE
Add status_replicas_available/_unavailable & replicas_desired/_ready metrics for all workload types

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -102,7 +102,6 @@ const (
 	StatusCurrentNumberScheduled      = "status_current_number_scheduled"
 	StatusReplicasAvailable           = "status_replicas_available"
 	StatusReplicasUnavailable         = "status_replicas_unavailable"
-	StatusReplicas                    = "status_replicas"
 	SpecReplicas                      = "spec_replicas"
 	StatusRunning                     = "status_running"
 	StatusTerminated                  = "status_terminated"
@@ -114,6 +113,8 @@ const (
 	StatusUnknown                     = "status_unknown"
 	StatusReady                       = "status_ready"
 	StatusScheduled                   = "status_scheduled"
+	ReplicasDesired                   = "replicas_desired"
+	ReplicasReady                     = "replicas_ready"
 
 	RunningPodCount       = "number_of_running_pods"
 	RunningContainerCount = "number_of_running_containers"
@@ -245,7 +246,6 @@ func init() {
 		StatusConditionNetworkUnavailable: UnitCount,
 		StatusCapacityPods:                UnitCount,
 		StatusAllocatablePods:             UnitCount,
-		StatusReplicas:                    UnitCount,
 		StatusReplicasAvailable:           UnitCount,
 		StatusReplicasUnavailable:         UnitCount,
 		StatusNumberAvailable:             UnitCount,
@@ -253,6 +253,8 @@ func init() {
 		StatusDesiredNumberScheduled:      UnitCount,
 		StatusCurrentNumberScheduled:      UnitCount,
 		SpecReplicas:                      UnitCount,
+		ReplicasDesired:                   UnitCount,
+		ReplicasReady:                     UnitCount,
 
 		// kube-state-metrics equivalents
 		StatusRunning:              UnitCount,

--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -132,25 +132,27 @@ const (
 	DiskIOTotal              = "Total"
 
 	// Define the metric types
-	TypeCluster           = "Cluster"
-	TypeClusterService    = "ClusterService"
-	TypeClusterDeployment = "ClusterDeployment"
-	TypeClusterDaemonSet  = "ClusterDaemonSet"
-	TypeClusterNamespace  = "ClusterNamespace"
-	TypeService           = "Service"
-	TypeInstance          = "Instance" // mean EC2 Instance in ECS
-	TypeNode              = "Node"     // mean EC2 Instance in EKS
-	TypeInstanceFS        = "InstanceFS"
-	TypeNodeFS            = "NodeFS"
-	TypeInstanceNet       = "InstanceNet"
-	TypeNodeNet           = "NodeNet"
-	TypeInstanceDiskIO    = "InstanceDiskIO"
-	TypeNodeDiskIO        = "NodeDiskIO"
-	TypePod               = "Pod"
-	TypePodNet            = "PodNet"
-	TypeContainer         = "Container"
-	TypeContainerFS       = "ContainerFS"
-	TypeContainerDiskIO   = "ContainerDiskIO"
+	TypeCluster            = "Cluster"
+	TypeClusterService     = "ClusterService"
+	TypeClusterDeployment  = "ClusterDeployment"
+	TypeClusterDaemonSet   = "ClusterDaemonSet"
+	TypeClusterStatefulSet = "ClusterStatefulSet"
+	TypeClusterReplicaSet  = "ClusterReplicaSet"
+	TypeClusterNamespace   = "ClusterNamespace"
+	TypeService            = "Service"
+	TypeInstance           = "Instance" // mean EC2 Instance in ECS
+	TypeNode               = "Node"     // mean EC2 Instance in EKS
+	TypeInstanceFS         = "InstanceFS"
+	TypeNodeFS             = "NodeFS"
+	TypeInstanceNet        = "InstanceNet"
+	TypeNodeNet            = "NodeNet"
+	TypeInstanceDiskIO     = "InstanceDiskIO"
+	TypeNodeDiskIO         = "NodeDiskIO"
+	TypePod                = "Pod"
+	TypePodNet             = "PodNet"
+	TypeContainer          = "Container"
+	TypeContainerFS        = "ContainerFS"
+	TypeContainerDiskIO    = "ContainerDiskIO"
 	// Special type for pause container
 	// because containerd does not set container name pause container name to POD like docker does.
 	TypeInfraContainer = "InfraContainer"

--- a/internal/aws/containerinsight/utils.go
+++ b/internal/aws/containerinsight/utils.go
@@ -108,6 +108,8 @@ func getPrefixByMetricType(mType string) string {
 	namespace := "namespace_"
 	deployment := "deployment_"
 	daemonSet := "daemonset_"
+	statefulSet := "statefulset_"
+	replicaSet := "replicaset_"
 
 	switch mType {
 	case TypeInstance:
@@ -148,6 +150,10 @@ func getPrefixByMetricType(mType string) string {
 		prefix = deployment
 	case TypeClusterDaemonSet:
 		prefix = daemonSet
+	case TypeClusterStatefulSet:
+		prefix = statefulSet
+	case TypeClusterReplicaSet:
+		prefix = replicaSet
 	default:
 		log.Printf("E! Unexpected MetricType: %s", mType)
 	}

--- a/internal/aws/k8s/k8sclient/clientset.go
+++ b/internal/aws/k8s/k8sclient/clientset.go
@@ -427,6 +427,7 @@ func (c *K8sClient) ShutdownDaemonSetClient() {
 func (c *K8sClient) GetStatefulSetClient() StatefulSetClient {
 	var err error
 	c.ssMu.Lock()
+	defer c.ssMu.Unlock()
 	if c.statefulSet == nil || reflect.ValueOf(c.statefulSet).IsNil() {
 		c.statefulSet, err = newStatefulSetClient(c.clientSet, c.logger, statefulSetSyncCheckerOption(c.syncChecker))
 		if err != nil {
@@ -434,7 +435,6 @@ func (c *K8sClient) GetStatefulSetClient() StatefulSetClient {
 			c.statefulSet = &noOpStatefulSetClient{}
 		}
 	}
-	c.ssMu.Unlock()
 	return c.statefulSet
 }
 

--- a/internal/aws/k8s/k8sclient/deployment.go
+++ b/internal/aws/k8s/k8sclient/deployment.go
@@ -135,6 +135,7 @@ func transformFuncDeployment(obj interface{}) (interface{}, error) {
 	}
 	info.Status = &DeploymentStatus{
 		Replicas:            uint32(deployment.Status.Replicas),
+		ReadyReplicas:       uint32(deployment.Status.ReadyReplicas),
 		AvailableReplicas:   uint32(deployment.Status.AvailableReplicas),
 		UnavailableReplicas: uint32(deployment.Status.UnavailableReplicas),
 	}

--- a/internal/aws/k8s/k8sclient/deployment_info.go
+++ b/internal/aws/k8s/k8sclient/deployment_info.go
@@ -27,6 +27,7 @@ type DeploymentSpec struct {
 
 type DeploymentStatus struct {
 	Replicas            uint32
+	ReadyReplicas       uint32
 	AvailableReplicas   uint32
 	UnavailableReplicas uint32
 }

--- a/internal/aws/k8s/k8sclient/deployment_test.go
+++ b/internal/aws/k8s/k8sclient/deployment_test.go
@@ -39,7 +39,8 @@ var deploymentObjects = []runtime.Object{
 			Replicas: &desired,
 		},
 		Status: appsv1.DeploymentStatus{
-			Replicas:            5,
+			Replicas:            10,
+			ReadyReplicas:       5,
 			AvailableReplicas:   5,
 			UnavailableReplicas: 1,
 		},
@@ -55,7 +56,8 @@ var deploymentObjects = []runtime.Object{
 		},
 		Status: appsv1.DeploymentStatus{
 			Replicas:            15,
-			AvailableReplicas:   15,
+			ReadyReplicas:       10,
+			AvailableReplicas:   10,
 			UnavailableReplicas: 2,
 		},
 	},
@@ -81,7 +83,8 @@ func TestDeploymentClient(t *testing.T) {
 				Replicas: 20,
 			},
 			Status: &DeploymentStatus{
-				Replicas:            5,
+				Replicas:            10,
+				ReadyReplicas:       5,
 				AvailableReplicas:   5,
 				UnavailableReplicas: 1,
 			},
@@ -94,7 +97,8 @@ func TestDeploymentClient(t *testing.T) {
 			},
 			Status: &DeploymentStatus{
 				Replicas:            15,
-				AvailableReplicas:   15,
+				ReadyReplicas:       10,
+				AvailableReplicas:   10,
 				UnavailableReplicas: 2,
 			},
 		},

--- a/internal/aws/k8s/k8sclient/replicaset.go
+++ b/internal/aws/k8s/k8sclient/replicaset.go
@@ -46,7 +46,7 @@ func (nc *noOpReplicaSetClient) ReplicaSetToDeployment() map[string]string {
 	return map[string]string{}
 }
 
-func (nd *noOpReplicaSetClient) ReplicaSetInfos() []*ReplicaSetInfo {
+func (nc *noOpReplicaSetClient) ReplicaSetInfos() []*ReplicaSetInfo {
 	return []*ReplicaSetInfo{}
 }
 

--- a/internal/aws/k8s/k8sclient/replicaset.go
+++ b/internal/aws/k8s/k8sclient/replicaset.go
@@ -36,6 +36,7 @@ const (
 type ReplicaSetClient interface {
 	// Get the mapping between replica set and deployment
 	ReplicaSetToDeployment() map[string]string
+	ReplicaSetInfos() []*ReplicaSetInfo
 }
 
 type noOpReplicaSetClient struct {
@@ -43,6 +44,10 @@ type noOpReplicaSetClient struct {
 
 func (nc *noOpReplicaSetClient) ReplicaSetToDeployment() map[string]string {
 	return map[string]string{}
+}
+
+func (nd *noOpReplicaSetClient) ReplicaSetInfos() []*ReplicaSetInfo {
+	return []*ReplicaSetInfo{}
 }
 
 func (nc *noOpReplicaSetClient) shutdown() {
@@ -66,6 +71,7 @@ type replicaSetClient struct {
 	mu                        sync.RWMutex
 	cachedReplicaSetMap       map[string]time.Time
 	replicaSetToDeploymentMap map[string]string
+	replicaSetInfos           []*ReplicaSetInfo
 }
 
 func (c *replicaSetClient) ReplicaSetToDeployment() map[string]string {
@@ -83,15 +89,21 @@ func (c *replicaSetClient) refresh() {
 
 	objsList := c.store.List()
 
+	var replicaSetInfos []*ReplicaSetInfo
 	tmpMap := make(map[string]string)
 	for _, obj := range objsList {
-		replicaSet := obj.(*replicaSetInfo)
-	ownerLoop:
-		for _, owner := range replicaSet.owners {
-			if owner.kind == deployment && owner.name != "" {
-				tmpMap[replicaSet.name] = owner.name
-				break ownerLoop
+		replicaSet := obj.(*ReplicaSetInfo)
+		if len(replicaSet.Owners) > 0 {
+		ownerLoop:
+			for _, owner := range replicaSet.Owners {
+				if owner.kind == deployment && owner.name != "" {
+					tmpMap[replicaSet.Name] = owner.name
+					break ownerLoop
+				}
 			}
+		} else {
+			// replicaSet without owner reference is not part of a deployment
+			replicaSetInfos = append(replicaSetInfos, replicaSet)
 		}
 	}
 
@@ -108,6 +120,17 @@ func (c *replicaSetClient) refresh() {
 		c.replicaSetToDeploymentMap[k] = v
 		c.cachedReplicaSetMap[k] = lastRefreshTime
 	}
+
+	c.replicaSetInfos = replicaSetInfos
+}
+
+func (c *replicaSetClient) ReplicaSetInfos() []*ReplicaSetInfo {
+	if c.store.GetResetRefreshStatus() {
+		c.refresh()
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.replicaSetInfos
 }
 
 func newReplicaSetClient(clientSet kubernetes.Interface, logger *zap.Logger, options ...replicaSetClientOption) (*replicaSetClient, error) {
@@ -125,8 +148,6 @@ func newReplicaSetClient(clientSet kubernetes.Interface, logger *zap.Logger, opt
 	if _, err := clientSet.AppsV1().ReplicaSets(metav1.NamespaceAll).List(ctx, metav1.ListOptions{}); err != nil {
 		return nil, fmt.Errorf("cannot list ReplicaSet. err: %w", err)
 	}
-
-	c.stopChan = make(chan struct{})
 
 	c.store = NewObjStore(transformFuncReplicaSet, logger)
 
@@ -155,11 +176,19 @@ func transformFuncReplicaSet(obj interface{}) (interface{}, error) {
 	if !ok {
 		return nil, fmt.Errorf("input obj %v is not ReplicaSet type", obj)
 	}
-	info := new(replicaSetInfo)
-	info.name = replicaSet.Name
-	info.owners = []*replicaSetOwner{}
+	info := new(ReplicaSetInfo)
+	info.Name = replicaSet.Name
+	info.Namespace = replicaSet.Namespace
+	info.Owners = []*ReplicaSetOwner{}
 	for _, owner := range replicaSet.OwnerReferences {
-		info.owners = append(info.owners, &replicaSetOwner{kind: owner.Kind, name: owner.Name})
+		info.Owners = append(info.Owners, &ReplicaSetOwner{kind: owner.Kind, name: owner.Name})
+	}
+	info.Spec = &ReplicaSetSpec{
+		Replicas: uint32(*replicaSet.Spec.Replicas),
+	}
+	info.Status = &ReplicaSetStatus{
+		Replicas:          uint32(replicaSet.Status.Replicas),
+		AvailableReplicas: uint32(replicaSet.Status.AvailableReplicas),
 	}
 	return info, nil
 }

--- a/internal/aws/k8s/k8sclient/replicaset.go
+++ b/internal/aws/k8s/k8sclient/replicaset.go
@@ -189,6 +189,7 @@ func transformFuncReplicaSet(obj interface{}) (interface{}, error) {
 	info.Status = &ReplicaSetStatus{
 		Replicas:          uint32(replicaSet.Status.Replicas),
 		AvailableReplicas: uint32(replicaSet.Status.AvailableReplicas),
+		ReadyReplicas:     uint32(replicaSet.Status.ReadyReplicas),
 	}
 	return info, nil
 }

--- a/internal/aws/k8s/k8sclient/replicaset_info.go
+++ b/internal/aws/k8s/k8sclient/replicaset_info.go
@@ -34,4 +34,5 @@ type ReplicaSetSpec struct {
 type ReplicaSetStatus struct {
 	Replicas          uint32
 	AvailableReplicas uint32
+	ReadyReplicas     uint32
 }

--- a/internal/aws/k8s/k8sclient/replicaset_test.go
+++ b/internal/aws/k8s/k8sclient/replicaset_test.go
@@ -145,8 +145,8 @@ func TestReplicaSetClient(t *testing.T) {
 				Replicas: 20,
 			},
 			Status: &ReplicaSetStatus{
-				Replicas:          15,
-				AvailableReplicas: 15,
+				Replicas:          10,
+				AvailableReplicas: 10,
 			},
 		},
 	}

--- a/internal/aws/k8s/k8sclient/replicaset_test.go
+++ b/internal/aws/k8s/k8sclient/replicaset_test.go
@@ -47,6 +47,7 @@ var replicaSetArray = []runtime.Object{
 		Status: appsv1.ReplicaSetStatus{
 			Replicas:          5,
 			AvailableReplicas: 5,
+			ReadyReplicas:     5,
 		},
 	},
 	&appsv1.ReplicaSet{
@@ -68,6 +69,7 @@ var replicaSetArray = []runtime.Object{
 		Status: appsv1.ReplicaSetStatus{
 			Replicas:          5,
 			AvailableReplicas: 5,
+			ReadyReplicas:     5,
 		},
 	},
 	&appsv1.ReplicaSet{
@@ -83,6 +85,7 @@ var replicaSetArray = []runtime.Object{
 		Status: appsv1.ReplicaSetStatus{
 			Replicas:          5,
 			AvailableReplicas: 5,
+			ReadyReplicas:     5,
 		},
 	},
 	&appsv1.ReplicaSet{
@@ -98,6 +101,7 @@ var replicaSetArray = []runtime.Object{
 		Status: appsv1.ReplicaSetStatus{
 			Replicas:          10,
 			AvailableReplicas: 10,
+			ReadyReplicas:     10,
 		},
 	},
 }
@@ -151,6 +155,7 @@ func TestReplicaSetClient(t *testing.T) {
 			Status: &ReplicaSetStatus{
 				Replicas:          5,
 				AvailableReplicas: 5,
+				ReadyReplicas:     5,
 			},
 		},
 		{
@@ -163,6 +168,7 @@ func TestReplicaSetClient(t *testing.T) {
 			Status: &ReplicaSetStatus{
 				Replicas:          10,
 				AvailableReplicas: 10,
+				ReadyReplicas:     10,
 			},
 		},
 	}

--- a/internal/aws/k8s/k8sclient/replicaset_test.go
+++ b/internal/aws/k8s/k8sclient/replicaset_test.go
@@ -41,6 +41,13 @@ var replicaSetArray = []runtime.Object{
 				},
 			},
 		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &desired,
+		},
+		Status: appsv1.ReplicaSetStatus{
+			Replicas:          5,
+			AvailableReplicas: 5,
+		},
 	},
 	&appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -54,6 +61,13 @@ var replicaSetArray = []runtime.Object{
 					UID:  "219887d3-8d2e-11e9-9cbd-064a0c5a2714",
 				},
 			},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &desired,
+		},
+		Status: appsv1.ReplicaSetStatus{
+			Replicas:          5,
+			AvailableReplicas: 5,
 		},
 	},
 	&appsv1.ReplicaSet{
@@ -129,7 +143,8 @@ func TestReplicaSetClient(t *testing.T) {
 	expected := []*ReplicaSetInfo{
 		{
 			Name:      "test-replicaset-1",
-			Namespace: "test-namespace",
+			Namespace: "amazon-cloudwatch",
+			Owners:    []*ReplicaSetOwner{},
 			Spec: &ReplicaSetSpec{
 				Replicas: 20,
 			},
@@ -140,7 +155,8 @@ func TestReplicaSetClient(t *testing.T) {
 		},
 		{
 			Name:      "test-replicaset-2",
-			Namespace: "test-namespace",
+			Namespace: "amazon-cloudwatch",
+			Owners:    []*ReplicaSetOwner{},
 			Spec: &ReplicaSetSpec{
 				Replicas: 20,
 			},

--- a/internal/aws/k8s/k8sclient/statefulset.go
+++ b/internal/aws/k8s/k8sclient/statefulset.go
@@ -1,0 +1,153 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+type StatefulSetClient interface {
+	// StatefulSetInfos contains the information about each statefulSet in the cluster
+	StatefulSetInfos() []*StatefulSetInfo
+}
+
+type noOpStatefulSetClient struct {
+}
+
+func (nd *noOpStatefulSetClient) StatefulSetInfos() []*StatefulSetInfo {
+	return []*StatefulSetInfo{}
+}
+
+func (nd *noOpStatefulSetClient) shutdown() {
+}
+
+type statefulSetClientOption func(*statefulSetClient)
+
+func statefulSetSyncCheckerOption(checker initialSyncChecker) statefulSetClientOption {
+	return func(d *statefulSetClient) {
+		d.syncChecker = checker
+	}
+}
+
+type statefulSetClient struct {
+	stopChan chan struct{}
+	stopped  bool
+
+	store *ObjStore
+
+	syncChecker initialSyncChecker
+
+	mu               sync.RWMutex
+	statefulSetInfos []*StatefulSetInfo
+}
+
+func (d *statefulSetClient) refresh() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	var statefulSetInfos []*StatefulSetInfo
+	objsList := d.store.List()
+	for _, obj := range objsList {
+		statefulSet, ok := obj.(*StatefulSetInfo)
+		if !ok {
+			continue
+		}
+		statefulSetInfos = append(statefulSetInfos, statefulSet)
+	}
+
+	d.statefulSetInfos = statefulSetInfos
+}
+
+func (d *statefulSetClient) StatefulSetInfos() []*StatefulSetInfo {
+	if d.store.GetResetRefreshStatus() {
+		d.refresh()
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.statefulSetInfos
+}
+
+func newStatefulSetClient(clientSet kubernetes.Interface, logger *zap.Logger, options ...statefulSetClientOption) (*statefulSetClient, error) {
+	d := &statefulSetClient{
+		stopChan: make(chan struct{}),
+	}
+
+	for _, option := range options {
+		option(d)
+	}
+
+	ctx := context.Background()
+	if _, err := clientSet.AppsV1().StatefulSets(metav1.NamespaceAll).List(ctx, metav1.ListOptions{}); err != nil {
+		return nil, fmt.Errorf("cannot list StatefulSets. err: %w", err)
+	}
+
+	d.store = NewObjStore(transformFuncStatefulSet, logger)
+	lw := createStatefulSetListWatch(clientSet, metav1.NamespaceAll)
+	reflector := cache.NewReflector(lw, &appsv1.StatefulSet{}, d.store, 0)
+
+	go reflector.Run(d.stopChan)
+
+	if d.syncChecker != nil {
+		// check the init sync for potential connection issue
+		d.syncChecker.Check(reflector, "StatefulSet initial sync timeout")
+	}
+
+	return d, nil
+}
+
+func (d *statefulSetClient) shutdown() {
+	close(d.stopChan)
+	d.stopped = true
+}
+
+func transformFuncStatefulSet(obj interface{}) (interface{}, error) {
+	statefulSet, ok := obj.(*appsv1.StatefulSet)
+	if !ok {
+		return nil, fmt.Errorf("input obj %v is not StatefulSet type", obj)
+	}
+	info := new(StatefulSetInfo)
+	info.Name = statefulSet.Name
+	info.Namespace = statefulSet.Namespace
+	info.Spec = &StatefulSetSpec{
+		Replicas: uint32(*statefulSet.Spec.Replicas),
+	}
+	info.Status = &StatefulSetStatus{
+		Replicas:          uint32(statefulSet.Status.Replicas),
+		AvailableReplicas: uint32(statefulSet.Status.AvailableReplicas),
+	}
+	return info, nil
+}
+
+func createStatefulSetListWatch(client kubernetes.Interface, ns string) cache.ListerWatcher {
+	ctx := context.Background()
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return client.AppsV1().StatefulSets(ns).List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return client.AppsV1().StatefulSets(ns).Watch(ctx, opts)
+		},
+	}
+}

--- a/internal/aws/k8s/k8sclient/statefulset.go
+++ b/internal/aws/k8s/k8sclient/statefulset.go
@@ -136,6 +136,7 @@ func transformFuncStatefulSet(obj interface{}) (interface{}, error) {
 	info.Status = &StatefulSetStatus{
 		Replicas:          uint32(statefulSet.Status.Replicas),
 		AvailableReplicas: uint32(statefulSet.Status.AvailableReplicas),
+		ReadyReplicas:     uint32(statefulSet.Status.ReadyReplicas),
 	}
 	return info, nil
 }

--- a/internal/aws/k8s/k8sclient/statefulset_info.go
+++ b/internal/aws/k8s/k8sclient/statefulset_info.go
@@ -14,24 +14,18 @@
 
 package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
 
-type ReplicaSetInfo struct {
+type StatefulSetInfo struct {
 	Name      string
 	Namespace string
-	Owners    []*ReplicaSetOwner
-	Spec      *ReplicaSetSpec
-	Status    *ReplicaSetStatus
+	Spec      *StatefulSetSpec
+	Status    *StatefulSetStatus
 }
 
-type ReplicaSetOwner struct {
-	kind string
-	name string
-}
-
-type ReplicaSetSpec struct {
+type StatefulSetSpec struct {
 	Replicas uint32
 }
 
-type ReplicaSetStatus struct {
+type StatefulSetStatus struct {
 	Replicas          uint32
 	AvailableReplicas uint32
 }

--- a/internal/aws/k8s/k8sclient/statefulset_info.go
+++ b/internal/aws/k8s/k8sclient/statefulset_info.go
@@ -28,4 +28,5 @@ type StatefulSetSpec struct {
 type StatefulSetStatus struct {
 	Replicas          uint32
 	AvailableReplicas uint32
+	ReadyReplicas     uint32
 }

--- a/internal/aws/k8s/k8sclient/statefulset_test.go
+++ b/internal/aws/k8s/k8sclient/statefulset_test.go
@@ -88,8 +88,8 @@ func TestStatefulSetClient(t *testing.T) {
 				Replicas: 20,
 			},
 			Status: &StatefulSetStatus{
-				Replicas:          15,
-				AvailableReplicas: 15,
+				Replicas:          10,
+				AvailableReplicas: 10,
 			},
 		},
 	}

--- a/internal/aws/k8s/k8sclient/statefulset_test.go
+++ b/internal/aws/k8s/k8sclient/statefulset_test.go
@@ -39,6 +39,7 @@ var statefulSetObjects = []runtime.Object{
 		Status: appsv1.StatefulSetStatus{
 			Replicas:          5,
 			AvailableReplicas: 5,
+			ReadyReplicas:     5,
 		},
 	},
 	&appsv1.StatefulSet{
@@ -53,6 +54,7 @@ var statefulSetObjects = []runtime.Object{
 		Status: appsv1.StatefulSetStatus{
 			Replicas:          10,
 			AvailableReplicas: 10,
+			ReadyReplicas:     10,
 		},
 	},
 }
@@ -79,6 +81,7 @@ func TestStatefulSetClient(t *testing.T) {
 			Status: &StatefulSetStatus{
 				Replicas:          5,
 				AvailableReplicas: 5,
+				ReadyReplicas:     5,
 			},
 		},
 		{
@@ -90,6 +93,7 @@ func TestStatefulSetClient(t *testing.T) {
 			Status: &StatefulSetStatus{
 				Replicas:          10,
 				AvailableReplicas: 10,
+				ReadyReplicas:     10,
 			},
 		},
 	}

--- a/internal/aws/k8s/k8sclient/statefulset_test.go
+++ b/internal/aws/k8s/k8sclient/statefulset_test.go
@@ -1,0 +1,109 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package k8sclient
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var statefulSetObjects = []runtime.Object{
+	&appsv1.StatefulSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-statefulset-1",
+			Namespace: "test-namespace",
+			UID:       types.UID("test-statefulset-1-uid"),
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &desired,
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:          5,
+			AvailableReplicas: 5,
+		},
+	},
+	&appsv1.StatefulSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-statefulset-2",
+			Namespace: "test-namespace",
+			UID:       types.UID("test-statefulset-2-uid"),
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &desired,
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:          10,
+			AvailableReplicas: 10,
+		},
+	},
+}
+
+func TestStatefulSetClient(t *testing.T) {
+	setOption := statefulSetSyncCheckerOption(&mockReflectorSyncChecker{})
+
+	fakeClientSet := fake.NewSimpleClientset(statefulSetObjects...)
+	client, _ := newStatefulSetClient(fakeClientSet, zap.NewNop(), setOption)
+
+	statefulSets := make([]interface{}, len(statefulSetObjects))
+	for i := range statefulSetObjects {
+		statefulSets[i] = statefulSetObjects[i]
+	}
+	assert.NoError(t, client.store.Replace(statefulSets, ""))
+
+	expected := []*StatefulSetInfo{
+		{
+			Name:      "test-statefulset-1",
+			Namespace: "test-namespace",
+			Spec: &StatefulSetSpec{
+				Replicas: 20,
+			},
+			Status: &StatefulSetStatus{
+				Replicas:          5,
+				AvailableReplicas: 5,
+			},
+		},
+		{
+			Name:      "test-statefulset-2",
+			Namespace: "test-namespace",
+			Spec: &StatefulSetSpec{
+				Replicas: 20,
+			},
+			Status: &StatefulSetStatus{
+				Replicas:          15,
+				AvailableReplicas: 15,
+			},
+		},
+	}
+	actual := client.StatefulSetInfos()
+	sort.Slice(actual, func(i, j int) bool {
+		return actual[i].Name < actual[j].Name
+	})
+	assert.Equal(t, expected, actual)
+	client.shutdown()
+	assert.True(t, client.stopped)
+}
+
+func TestTransformFuncStatefulSet(t *testing.T) {
+	info, err := transformFuncStatefulSet(nil)
+	assert.Nil(t, info)
+	assert.NotNil(t, err)
+}

--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -456,9 +456,11 @@ kubectl apply -f config.yaml
 <br/><br/>
 
 ### Cluster ReplicaSet
-| Metric                       | Unit  |
-|------------------------------|-------|
-| status_replicas_available    | Count |
+| Metric                     | Unit  |
+|----------------------------|-------|
+| replicaset_spec_replicas   | Count |
+| replicaset_status_replicas | Count |
+| status_replicas_available  | Count |
 
 <br/><br/>
 | Resource Attribute |
@@ -475,9 +477,11 @@ kubectl apply -f config.yaml
 
 <br/><br/>
 ### Cluster StatefulSet
-| Metric                        | Unit  |
-|-------------------------------|-------|
-| status_replicas_available     | Count |
+| Metric                      | Unit  |
+|-----------------------------|-------|
+| statefulset_spec_replicas   | Count |
+| statefulset_status_replicas | Count |
+| status_replicas_available   | Count |
 
 
 <br/><br/>

--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -430,12 +430,12 @@ kubectl apply -f config.yaml
 <br/><br/> 
 
 ### Cluster Deployment
-| Metric                        | Unit  |
-|-------------------------------|-------|
-| deployment_spec_replicas      | Count |
-| deployment_status_replicas    | Count |
-| status_replicas_available     | Count |
-| status_replicas_unavailable   | Count |
+| Metric                      | Unit  |
+|-----------------------------|-------|
+| replicas_desired            | Count |
+| replicas_ready              | Count |
+| status_replicas_available   | Count |
+| status_replicas_unavailable | Count |
 
 
 <br/><br/>
@@ -456,11 +456,11 @@ kubectl apply -f config.yaml
 <br/><br/>
 
 ### Cluster ReplicaSet
-| Metric                     | Unit  |
-|----------------------------|-------|
-| replicaset_spec_replicas   | Count |
-| replicaset_status_replicas | Count |
-| status_replicas_available  | Count |
+| Metric                    | Unit  |
+|---------------------------|-------|
+| replicas_desired          | Count |
+| replicas_ready            | Count |
+| status_replicas_available | Count |
 
 <br/><br/>
 | Resource Attribute |
@@ -479,8 +479,8 @@ kubectl apply -f config.yaml
 ### Cluster StatefulSet
 | Metric                      | Unit  |
 |-----------------------------|-------|
-| statefulset_spec_replicas   | Count |
-| statefulset_status_replicas | Count |
+| replicas_desired            | Count |
+| replicas_ready              | Count |
 | status_replicas_available   | Count |
 
 
@@ -501,12 +501,12 @@ kubectl apply -f config.yaml
 <br/><br/>
 
 ### Cluster DaemonSet
-| Metric                                    | Unit  |
-|-------------------------------------------|-------|
-| daemonset_status_number_available         | Count |
-| daemonset_status_number_unavailable       | Count |
-| daemonset_status_desired_number_scheduled | Count |
-| daemonset_status_current_number_scheduled | Count |
+| Metric                    | Unit  |
+|---------------------------|-------|
+| replicas_desired          | Count |
+| replicas_ready            | Count |
+| status_number_available   | Count |
+| status_number_unavailable | Count |
 
 
 <br/><br/>

--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -97,7 +97,7 @@ rules:
     resources: ["pods", "nodes", "endpoints"]
     verbs: ["list", "watch"]
   - apiGroups: ["apps"]
-    resources: ["replicasets", "daemonsets", "deployments"]
+    resources: ["replicasets", "daemonsets", "deployments", "statefulsets"]
     verbs: ["list", "watch"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
@@ -430,12 +430,12 @@ kubectl apply -f config.yaml
 <br/><br/> 
 
 ### Cluster Deployment
-| Metric                                 | Unit  |
-|----------------------------------------|-------|
-| deployment_spec_replicas               | Count |
-| deployment_status_replicas             | Count |
-| deployment_status_replicas_available   | Count |
-| deployment_status_replicas_unavailable | Count |
+| Metric                        | Unit  |
+|-------------------------------|-------|
+| deployment_spec_replicas      | Count |
+| deployment_status_replicas    | Count |
+| status_replicas_available     | Count |
+| status_replicas_unavailable   | Count |
 
 
 <br/><br/>
@@ -453,6 +453,47 @@ kubectl apply -f config.yaml
 
 
 <br/><br/>
+<br/><br/>
+
+### Cluster ReplicaSet
+| Metric                       | Unit  |
+|------------------------------|-------|
+| status_replicas_available    | Count |
+
+<br/><br/>
+| Resource Attribute |
+|--------------------|
+| ClusterName        |
+| NodeName           |
+| Namespace          |
+| PodName            |
+| Type               |
+| Timestamp          |
+| Version            |
+| Sources            |
+| kubernetes         |
+
+<br/><br/>
+### Cluster StatefulSet
+| Metric                        | Unit  |
+|-------------------------------|-------|
+| status_replicas_available     | Count |
+
+
+<br/><br/>
+| Resource Attribute |
+|--------------------|
+| ClusterName        |
+| NodeName           |
+| Namespace          |
+| PodName            |
+| Type               |
+| Timestamp          |
+| Version            |
+| Sources            |
+| kubernetes         |
+
+
 <br/><br/>
 
 ### Cluster DaemonSet

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
@@ -241,9 +241,9 @@ func (k *K8sAPIServer) getStatefulSetMetrics(clusterName, timestampNs string) []
 	statefulSets := k.leaderElection.statefulSetClient.StatefulSetInfos()
 	for _, statefulSet := range statefulSets {
 		fields := map[string]interface{}{
-			ci.MetricName(ci.TypeClusterDeployment, ci.SpecReplicas):   statefulSet.Spec.Replicas,            // statefulset_spec_replicas
-			ci.MetricName(ci.TypeClusterDeployment, ci.StatusReplicas): statefulSet.Status.Replicas,          // statefulset_status_replicas
-			ci.StatusReplicasAvailable:                                 statefulSet.Status.AvailableReplicas, // status_replicas_available
+			ci.MetricName(ci.TypeClusterStatefulSet, ci.SpecReplicas):   statefulSet.Spec.Replicas,            // statefulset_spec_replicas
+			ci.MetricName(ci.TypeClusterStatefulSet, ci.StatusReplicas): statefulSet.Status.Replicas,          // statefulset_status_replicas
+			ci.StatusReplicasAvailable:                                  statefulSet.Status.AvailableReplicas, // status_replicas_available
 		}
 		attributes := map[string]string{
 			ci.ClusterNameKey: clusterName,
@@ -268,8 +268,8 @@ func (k *K8sAPIServer) getReplicaSetMetrics(clusterName, timestampNs string) []p
 	replicaSets := k.leaderElection.replicaSetClient.ReplicaSetInfos()
 	for _, replicaSet := range replicaSets {
 		fields := map[string]interface{}{
-			ci.MetricName(ci.TypeClusterDeployment, ci.SpecReplicas):   replicaSet.Spec.Replicas,            // replicaset_spec_replicas
-			ci.MetricName(ci.TypeClusterDeployment, ci.StatusReplicas): replicaSet.Status.Replicas,          // replicaset_status_replicas
+			ci.MetricName(ci.TypeClusterReplicaSet, ci.SpecReplicas):   replicaSet.Spec.Replicas,            // replicaset_spec_replicas
+			ci.MetricName(ci.TypeClusterReplicaSet, ci.StatusReplicas): replicaSet.Status.Replicas,          // replicaset_status_replicas
 			ci.StatusReplicasAvailable:                                 replicaSet.Status.AvailableReplicas, // status_replicas_available
 		}
 		attributes := map[string]string{

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
@@ -155,10 +155,10 @@ func (k *K8sAPIServer) getDeploymentMetrics(clusterName, timestampNs string) []p
 	deployments := k.leaderElection.deploymentClient.DeploymentInfos()
 	for _, deployment := range deployments {
 		fields := map[string]interface{}{
-			ci.MetricName(ci.TypeClusterDeployment, ci.SpecReplicas):   deployment.Spec.Replicas,              // deployment_spec_replicas
-			ci.MetricName(ci.TypeClusterDeployment, ci.StatusReplicas): deployment.Status.Replicas,            // deployment_status_replicas
-			ci.StatusReplicasAvailable:                                 deployment.Status.AvailableReplicas,   // status_replicas_available
-			ci.StatusReplicasUnavailable:                               deployment.Status.UnavailableReplicas, // status_replicas_unavailable
+			ci.ReplicasDesired:           deployment.Spec.Replicas,              // replicas_desired
+			ci.ReplicasReady:             deployment.Status.ReadyReplicas,       // replicas_ready
+			ci.StatusReplicasAvailable:   deployment.Status.AvailableReplicas,   // status_replicas_available
+			ci.StatusReplicasUnavailable: deployment.Status.UnavailableReplicas, // status_replicas_unavailable
 		}
 		attributes := map[string]string{
 			ci.ClusterNameKey: clusterName,
@@ -185,10 +185,10 @@ func (k *K8sAPIServer) getDaemonSetMetrics(clusterName, timestampNs string) []pm
 	daemonSets := k.leaderElection.daemonSetClient.DaemonSetInfos()
 	for _, daemonSet := range daemonSets {
 		fields := map[string]interface{}{
-			ci.MetricName(ci.TypeClusterDaemonSet, ci.StatusNumberAvailable):        daemonSet.Status.NumberAvailable,        // daemonset_status_number_available
-			ci.MetricName(ci.TypeClusterDaemonSet, ci.StatusNumberUnavailable):      daemonSet.Status.NumberUnavailable,      // daemonset_status_number_unavailable
-			ci.MetricName(ci.TypeClusterDaemonSet, ci.StatusDesiredNumberScheduled): daemonSet.Status.DesiredNumberScheduled, // daemonset_status_desired_number_scheduled
-			ci.MetricName(ci.TypeClusterDaemonSet, ci.StatusCurrentNumberScheduled): daemonSet.Status.CurrentNumberScheduled, // daemonset_status_current_number_scheduled
+			ci.StatusReplicasAvailable:   daemonSet.Status.NumberAvailable,        // status_replicas_available
+			ci.StatusReplicasUnavailable: daemonSet.Status.NumberUnavailable,      // status_replicas_unavailable
+			ci.ReplicasDesired:           daemonSet.Status.DesiredNumberScheduled, // replicas_desired
+			ci.ReplicasReady:             daemonSet.Status.CurrentNumberScheduled, // replicas_ready
 		}
 		attributes := map[string]string{
 			ci.ClusterNameKey: clusterName,
@@ -241,9 +241,9 @@ func (k *K8sAPIServer) getStatefulSetMetrics(clusterName, timestampNs string) []
 	statefulSets := k.leaderElection.statefulSetClient.StatefulSetInfos()
 	for _, statefulSet := range statefulSets {
 		fields := map[string]interface{}{
-			ci.MetricName(ci.TypeClusterStatefulSet, ci.SpecReplicas):   statefulSet.Spec.Replicas,            // statefulset_spec_replicas
-			ci.MetricName(ci.TypeClusterStatefulSet, ci.StatusReplicas): statefulSet.Status.Replicas,          // statefulset_status_replicas
-			ci.StatusReplicasAvailable:                                  statefulSet.Status.AvailableReplicas, // status_replicas_available
+			ci.ReplicasDesired:         statefulSet.Spec.Replicas,            // replicas_desired
+			ci.ReplicasReady:           statefulSet.Status.ReadyReplicas,     // replicas_ready
+			ci.StatusReplicasAvailable: statefulSet.Status.AvailableReplicas, // status_replicas_available
 		}
 		attributes := map[string]string{
 			ci.ClusterNameKey: clusterName,
@@ -268,9 +268,9 @@ func (k *K8sAPIServer) getReplicaSetMetrics(clusterName, timestampNs string) []p
 	replicaSets := k.leaderElection.replicaSetClient.ReplicaSetInfos()
 	for _, replicaSet := range replicaSets {
 		fields := map[string]interface{}{
-			ci.MetricName(ci.TypeClusterReplicaSet, ci.SpecReplicas):   replicaSet.Spec.Replicas,            // replicaset_spec_replicas
-			ci.MetricName(ci.TypeClusterReplicaSet, ci.StatusReplicas): replicaSet.Status.Replicas,          // replicaset_status_replicas
-			ci.StatusReplicasAvailable:                                 replicaSet.Status.AvailableReplicas, // status_replicas_available
+			ci.ReplicasDesired:         replicaSet.Spec.Replicas,            // replicas_desired
+			ci.ReplicasReady:           replicaSet.Status.ReadyReplicas,     // replicas_ready
+			ci.StatusReplicasAvailable: replicaSet.Status.AvailableReplicas, // status_replicas_available
 		}
 		attributes := map[string]string{
 			ci.ClusterNameKey: clusterName,

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
@@ -72,6 +72,7 @@ func NewK8sAPIServer(cnp clusterNameProvider, logger *zap.Logger, leaderElection
 
 // GetMetrics returns an array of metrics
 func (k *K8sAPIServer) GetMetrics() []pmetric.Metrics {
+	k.logger.Info("========================= hsookim: k8apiserver: GetMetrics")
 	var result []pmetric.Metrics
 
 	// don't generate any metrics if the current collector is not the leader

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
@@ -244,10 +244,11 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 			Name:      "deployment1",
 			Namespace: "kube-system",
 			Spec: &k8sclient.DeploymentSpec{
-				Replicas: 10,
+				Replicas: 11,
 			},
 			Status: &k8sclient.DeploymentStatus{
 				Replicas:            11,
+				ReadyReplicas:       10,
 				AvailableReplicas:   9,
 				UnavailableReplicas: 2,
 			},
@@ -270,10 +271,11 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 			Name:      "replicaset1",
 			Namespace: "kube-system",
 			Spec: &k8sclient.ReplicaSetSpec{
-				Replicas: 10,
+				Replicas: 9,
 			},
 			Status: &k8sclient.ReplicaSetStatus{
 				Replicas:          5,
+				ReadyReplicas:     4,
 				AvailableReplicas: 3,
 			},
 		},
@@ -287,6 +289,7 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 			},
 			Status: &k8sclient.StatefulSetStatus{
 				Replicas:          3,
+				ReadyReplicas:     4,
 				AvailableReplicas: 1,
 			},
 		},
@@ -321,8 +324,10 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 		tags: map[Service:service2 Timestamp:1557291396709 Type:ClusterService], fields: map[service_number_of_running_pods:1],
 		tags: map[Service:service1 Timestamp:1557291396709 Type:ClusterService], fields: map[service_number_of_running_pods:1],
 		tags: map[Namespace:default Timestamp:1557291396709 Type:ClusterNamespace], fields: map[namespace_number_of_running_pods:2],
-		tags: map[PodName:deployment1 Namespace:kube-system Timestamp:1557291396709 Type:ClusterDeployment], fields: map[deployment_spec_replicas:10 deployment_status_replicas:11 deployment_status_replicas_available:9 deployment_status_replicas_unavailable:2],
-		tags: map[PodName:daemonset1 Namespace:kube-system Timestamp:1557291396709 Type:ClusterDaemonSet], fields: map[daemonset_status_number_available:10 daemonset_status_number_unavailable:4 daemonset_status_desired_number_scheduled:7 daemonset_status_current_number_scheduled:6],
+		tags: map[PodName:deployment1 Namespace:kube-system Timestamp:1557291396709 Type:ClusterDeployment], fields: map[replicas_desired:11 replicas_ready:10 status_replicas_available:9 status_replicas_unavailable:2],
+		tags: map[PodName:daemonset1 Namespace:kube-system Timestamp:1557291396709 Type:ClusterDaemonSet], fields: map[status_replicas_available:10 status_replicas_unavailable:4 replicas_desired:7 replicas_ready:6],
+		tags: map[PodName:replicaset1 Namespace:kube-system Timestamp:1557291396709 Type:ClusterDaemonSet], fields: map[status_replicas_available:3 replicas_desired:9 replicas_ready:4],
+		tags: map[PodName:statefulset1 Namespace:kube-system Timestamp:1557291396709 Type:ClusterDaemonSet], fields: map[status_replicas_available:1 replicas_desired:10 replicas_ready:4],
 	*/
 	for _, metric := range metrics {
 		assert.Equal(t, "cluster-name", getStringAttrVal(metric, ci.ClusterNameKey))
@@ -341,31 +346,31 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 			assertMetricValueEqual(t, metric, "namespace_number_of_running_pods", int64(2))
 			assert.Equal(t, "default", getStringAttrVal(metric, ci.K8sNamespace))
 		case ci.TypeClusterDeployment:
-			assertMetricValueEqual(t, metric, "deployment_spec_replicas", int64(10))
-			assertMetricValueEqual(t, metric, "deployment_status_replicas", int64(11))
+			assertMetricValueEqual(t, metric, "replicas_desired", int64(11))
+			assertMetricValueEqual(t, metric, "replicas_ready", int64(10))
 			assertMetricValueEqual(t, metric, "status_replicas_available", int64(9))
 			assertMetricValueEqual(t, metric, "status_replicas_unavailable", int64(2))
 			assert.Equal(t, "kube-system", getStringAttrVal(metric, ci.K8sNamespace))
 			assert.Equal(t, "deployment1", getStringAttrVal(metric, ci.PodNameKey))
 			assert.Equal(t, "ClusterDeployment", getStringAttrVal(metric, ci.MetricType))
 		case ci.TypeClusterDaemonSet:
-			assertMetricValueEqual(t, metric, "daemonset_status_number_available", int64(10))
-			assertMetricValueEqual(t, metric, "daemonset_status_number_unavailable", int64(4))
-			assertMetricValueEqual(t, metric, "daemonset_status_desired_number_scheduled", int64(7))
-			assertMetricValueEqual(t, metric, "daemonset_status_current_number_scheduled", int64(6))
+			assertMetricValueEqual(t, metric, "replicas_desired", int64(7))
+			assertMetricValueEqual(t, metric, "replicas_ready", int64(6))
+			assertMetricValueEqual(t, metric, "status_replicas_available", int64(10))
+			assertMetricValueEqual(t, metric, "status_replicas_unavailable", int64(4))
 			assert.Equal(t, "kube-system", getStringAttrVal(metric, ci.K8sNamespace))
 			assert.Equal(t, "daemonset1", getStringAttrVal(metric, ci.PodNameKey))
 			assert.Equal(t, "ClusterDaemonSet", getStringAttrVal(metric, ci.MetricType))
 		case ci.TypeClusterReplicaSet:
-			assertMetricValueEqual(t, metric, "replicaset_spec_replicas", int64(10))
-			assertMetricValueEqual(t, metric, "replicaset_status_replicas", int64(5))
+			assertMetricValueEqual(t, metric, "replicas_desired", int64(9))
+			assertMetricValueEqual(t, metric, "replicas_ready", int64(4))
 			assertMetricValueEqual(t, metric, "status_replicas_available", int64(3))
 			assert.Equal(t, "kube-system", getStringAttrVal(metric, ci.K8sNamespace))
 			assert.Equal(t, "replicaset1", getStringAttrVal(metric, ci.PodNameKey))
 			assert.Equal(t, "ClusterReplicaSet", getStringAttrVal(metric, ci.MetricType))
 		case ci.TypeClusterStatefulSet:
-			assertMetricValueEqual(t, metric, "statefulset_spec_replicas", int64(10))
-			assertMetricValueEqual(t, metric, "statefulset_status_replicas", int64(3))
+			assertMetricValueEqual(t, metric, "replicas_desired", int64(10))
+			assertMetricValueEqual(t, metric, "replicas_ready", int64(4))
 			assertMetricValueEqual(t, metric, "status_replicas_available", int64(1))
 			assert.Equal(t, "kube-system", getStringAttrVal(metric, ci.K8sNamespace))
 			assert.Equal(t, "statefulset1", getStringAttrVal(metric, ci.PodNameKey))

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/leaderelection.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/leaderelection.go
@@ -48,12 +48,14 @@ type LeaderElection struct {
 	leaderLockName               string
 	leaderLockUsingConfigMapOnly bool
 
-	k8sClient        K8sClient // *k8sclient.K8sClient
-	epClient         k8sclient.EpClient
-	nodeClient       k8sclient.NodeClient
-	podClient        k8sclient.PodClient
-	deploymentClient k8sclient.DeploymentClient
-	daemonSetClient  k8sclient.DaemonSetClient
+	k8sClient         K8sClient // *k8sclient.K8sClient
+	epClient          k8sclient.EpClient
+	nodeClient        k8sclient.NodeClient
+	podClient         k8sclient.PodClient
+	deploymentClient  k8sclient.DeploymentClient
+	daemonSetClient   k8sclient.DaemonSetClient
+	statefulSetClient k8sclient.StatefulSetClient
+	replicaSetClient  k8sclient.ReplicaSetClient
 
 	// the following can be set to mocks in testing
 	broadcaster eventBroadcaster
@@ -80,6 +82,8 @@ type K8sClient interface {
 	GetPodClient() k8sclient.PodClient
 	GetDeploymentClient() k8sclient.DeploymentClient
 	GetDaemonSetClient() k8sclient.DaemonSetClient
+	GetStatefulSetClient() k8sclient.StatefulSetClient
+	GetReplicaSetClient() k8sclient.ReplicaSetClient
 	ShutdownNodeClient()
 	ShutdownPodClient()
 }
@@ -211,6 +215,8 @@ func (le *LeaderElection) startLeaderElection(ctx context.Context, lock resource
 					le.epClient = le.k8sClient.GetEpClient()
 					le.deploymentClient = le.k8sClient.GetDeploymentClient()
 					le.daemonSetClient = le.k8sClient.GetDaemonSetClient()
+					le.statefulSetClient = le.k8sClient.GetStatefulSetClient()
+					le.replicaSetClient = le.k8sClient.GetReplicaSetClient()
 					le.mu.Unlock()
 
 					if le.isLeadingC != nil {

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -635,6 +635,10 @@ func TestGetJobNamePrefix(t *testing.T) {
 
 type mockReplicaSetInfo1 struct{}
 
+func (m *mockReplicaSetInfo1) ReplicaSetInfos() []*k8sclient.ReplicaSetInfo {
+	return []*k8sclient.ReplicaSetInfo{}
+}
+
 func (m *mockReplicaSetInfo1) ReplicaSetToDeployment() map[string]string {
 	return map[string]string{}
 }
@@ -646,6 +650,10 @@ func (m *mockK8sClient1) GetReplicaSetClient() k8sclient.ReplicaSetClient {
 }
 
 type mockReplicaSetInfo2 struct{}
+
+func (m *mockReplicaSetInfo2) ReplicaSetInfos() []*k8sclient.ReplicaSetInfo {
+	return []*k8sclient.ReplicaSetInfo{}
+}
 
 func (m *mockReplicaSetInfo2) ReplicaSetToDeployment() map[string]string {
 	return map[string]string{"DeploymentTest-sftrz2785": "DeploymentTest"}


### PR DESCRIPTION
**Description:** 
- Add new `status_replicas_available/unavailable` metrics at stateful & replicaset types. 
- Add new `replicas_desired/_ready` metrics for all workload types
- Rename existing metrics that are duplicates of newly added ones
- Drop workload type prefix (`deployment_`) from exisitng status_replicas metrics
- Note that for the service account running the agent/collector pod, the role its bound to should grant list and watch permissions to `apps/replicasets` and `apps/statefulsets`.

**Testing:**
- Update/added unit tests
- Manually tested the changes on a dev cluster. 
**status_replicas_available/_unavailable**
![Screen Shot 2023-07-31 at 3 11 24 PM](https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/884273/62abd18a-2751-45b6-a97c-ee831be07860)
**replicas_desired/_ready**
![Screen Shot 2023-08-04 at 1 10 56 PM](https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/884273/4d211046-1e4b-4817-bf2d-54d2d501df2f)
`Deployment`
```
{
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "status_replicas_unavailable",
                    "Unit": "Count"
                }
            ]
        },
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "replicas_desired",
                    "Unit": "Count"
                },
                {
                    "Name": "replicas_ready",
                    "Unit": "Count"
                }
            ]
        },
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "status_replicas_available",
                    "Unit": "Count"
                }
            ]
        }
    ],
    "ClusterName": "tupperware",
    "Namespace": "kube-system",
    "NodeName": "ip-172-31-11-202.us-west-2.compute.internal",
    "PodName": "coredns",
    "Sources": [
        "apiserver"
    ],
    "Timestamp": "1691168418773",
    "Type": "ClusterDeployment",
    "Version": "0",
    "replicas_desired": 2,
    "replicas_ready": 2,
    "status_replicas_available": 2,
    "status_replicas_unavailable": 0
}
```
`DaemonSet`
```
{
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "replicas_desired",
                    "Unit": "Count"
                },
                {
                    "Name": "replicas_ready",
                    "Unit": "Count"
                }
            ]
        },
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "status_replicas_available",
                    "Unit": "Count"
                }
            ]
        },
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "status_replicas_unavailable",
                    "Unit": "Count"
                }
            ]
        }
    ],
    "ClusterName": "tupperware",
    "Namespace": "kube-system",
    "NodeName": "ip-172-31-11-202.us-west-2.compute.internal",
    "PodName": "aws-node",
    "Sources": [
        "apiserver"
    ],
    "Timestamp": "1691168418773",
    "Type": "ClusterDaemonSet",
    "Version": "0",
    "replicas_desired": 1,
    "replicas_ready": 1,
    "status_replicas_available": 1,
    "status_replicas_unavailable": 0
}
```
`StatefulSet`
```
{
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "status_replicas_available",
                    "Unit": "Count"
                }
            ]
        },
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "replicas_desired",
                    "Unit": "Count"
                },
                {
                    "Name": "replicas_ready",
                    "Unit": "Count"
                }
            ]
        }
    ],
    "ClusterName": "tupperware",
    "Namespace": "amazon-cloudwatch",
    "NodeName": "ip-172-31-11-202.us-west-2.compute.internal",
    "PodName": "hello-world-st",
    "Sources": [
        "apiserver"
    ],
    "Timestamp": "1691168418773",
    "Type": "ClusterStatefulSet",
    "Version": "0",
    "replicas_desired": 1,
    "replicas_ready": 0,
    "status_replicas_available": 0
}
```
`ReplicaSet`
```
{
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "status_replicas_available",
                    "Unit": "Count"
                }
            ]
        },
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "replicas_ready",
                    "Unit": "Count"
                },
                {
                    "Name": "replicas_desired",
                    "Unit": "Count"
                }
            ]
        }
    ],
    "ClusterName": "tupperware",
    "Namespace": "amazon-cloudwatch",
    "NodeName": "ip-172-31-11-202.us-west-2.compute.internal",
    "PodName": "hello-world-rs",
    "Sources": [
        "apiserver"
    ],
    "Timestamp": "1691168418773",
    "Type": "ClusterReplicaSet",
    "Version": "0",
    "replicas_desired": 1,
    "replicas_ready": 1,
    "status_replicas_available": 1
}
```

**Documentation:** <Describe the documentation added.>