### PR TITLE
Adding pod_status_unknown as a Pod condition metric and removed the pod_status_initialized metric

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -18,6 +18,7 @@ import (
 	"time"
 )
 
+// define metric names, attribute names, metric types, and units for both EKS and ECS Container Insights
 const (
 	GoPSUtilProcDirEnv = "HOST_PROC"
 
@@ -256,6 +257,9 @@ func init() {
 		StatusTerminated:           UnitCount,
 		StatusWaiting:              UnitCount,
 		StatusWaitingReasonCrashed: UnitCount,
+		StatusUnknown:              UnitCount,
+		StatusReady:                UnitCount,
+		StatusScheduled:            UnitCount,
 
 		// cluster metrics
 		NodeCount:       UnitCount,

--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -18,7 +18,6 @@ import (
 	"time"
 )
 
-// define metric names, attribute names, metric types, and units for both EKS and ECS Container Insights
 const (
 	GoPSUtilProcDirEnv = "HOST_PROC"
 
@@ -114,7 +113,6 @@ const (
 	StatusUnknown                     = "status_unknown"
 	StatusReady                       = "status_ready"
 	StatusScheduled                   = "status_scheduled"
-	StatusInitialized                 = "status_initialized"
 
 	RunningPodCount       = "number_of_running_pods"
 	RunningContainerCount = "number_of_running_containers"

--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -633,45 +633,48 @@ kubectl apply -f config.yaml
 <br/><br/> 
 
 ### Pod
-| Metric                                | Unit          |
-|---------------------------------------|---------------|
-| pod_cpu_limit                         | Millicore     |
-| pod_cpu_request                       | Millicore     |
-| pod_cpu_reserved_capacity             | Percent       |
-| pod_cpu_usage_system                  | Millicore     |
-| pod_cpu_usage_total                   | Millicore     |
-| pod_cpu_usage_user                    | Millicore     |
-| pod_cpu_utilization                   | Percent       |
-| pod_cpu_utilization_over_pod_limit    | Percent       |
-| pod_memory_cache                      | Bytes         |
-| pod_memory_failcnt                    | Count         |
-| pod_memory_hierarchical_pgfault       | Count/Second  |
-| pod_memory_hierarchical_pgmajfault    | Count/Second  |
-| pod_memory_limit                      | Bytes         |
-| pod_memory_mapped_file                | Bytes         |
-| pod_memory_max_usage                  | Bytes         |
-| pod_memory_pgfault                    | Count/Second  |
-| pod_memory_pgmajfault                 | Count/Second  |
-| pod_memory_request                    | Bytes         |
-| pod_memory_reserved_capacity          | Percent       |
-| pod_memory_rss                        | Bytes         |
-| pod_memory_swap                       | Bytes         |
-| pod_memory_usage                      | Bytes         |
-| pod_memory_utilization                | Percent       |
-| pod_memory_utilization_over_pod_limit | Percent       |
-| pod_memory_working_set                | Bytes         |
-| pod_network_rx_bytes                  | Bytes/Second  |
-| pod_network_rx_dropped                | Count/Second  |
-| pod_network_rx_errors                 | Count/Second  |
-| pod_network_rx_packets                | Count/Second  |
-| pod_network_total_bytes               | Bytes/Second  |
-| pod_network_tx_bytes                  | Bytes/Second  |
-| pod_network_tx_dropped                | Count/Second  |
-| pod_network_tx_errors                 | Count/Second  |
-| pod_network_tx_packets                | Count/Second  |
-| pod_number_of_container_restarts      | Count         | 
-| pod_number_of_containers              | Count         |   
-| pod_number_of_running_containers      | Count         |  
+| Metric                                | Unit         |
+|---------------------------------------|--------------|
+| pod_cpu_limit                         | Millicore    |
+| pod_cpu_request                       | Millicore    |
+| pod_cpu_reserved_capacity             | Percent      |
+| pod_cpu_usage_system                  | Millicore    |
+| pod_cpu_usage_total                   | Millicore    |
+| pod_cpu_usage_user                    | Millicore    |
+| pod_cpu_utilization                   | Percent      |
+| pod_cpu_utilization_over_pod_limit    | Percent      |
+| pod_memory_cache                      | Bytes        |
+| pod_memory_failcnt                    | Count        |
+| pod_memory_hierarchical_pgfault       | Count/Second |
+| pod_memory_hierarchical_pgmajfault    | Count/Second |
+| pod_memory_limit                      | Bytes        |
+| pod_memory_mapped_file                | Bytes        |
+| pod_memory_max_usage                  | Bytes        |
+| pod_memory_pgfault                    | Count/Second |
+| pod_memory_pgmajfault                 | Count/Second |
+| pod_memory_request                    | Bytes        |
+| pod_memory_reserved_capacity          | Percent      |
+| pod_memory_rss                        | Bytes        |
+| pod_memory_swap                       | Bytes        |
+| pod_memory_usage                      | Bytes        |
+| pod_memory_utilization                | Percent      |
+| pod_memory_utilization_over_pod_limit | Percent      |
+| pod_memory_working_set                | Bytes        |
+| pod_network_rx_bytes                  | Bytes/Second |
+| pod_network_rx_dropped                | Count/Second |
+| pod_network_rx_errors                 | Count/Second |
+| pod_network_rx_packets                | Count/Second |
+| pod_network_total_bytes               | Bytes/Second |
+| pod_network_tx_bytes                  | Bytes/Second |
+| pod_network_tx_dropped                | Count/Second |
+| pod_network_tx_errors                 | Count/Second |
+| pod_network_tx_packets                | Count/Second |
+| pod_number_of_container_restarts      | Count        | 
+| pod_number_of_containers              | Count        |   
+| pod_number_of_running_containers      | Count        |  
+| pod_status_ready                      | Count        |
+| pod_status_scheduled                  | Count        |
+| pod_status_unknown                    | Count        |
 
 | Resource Attribute   |
 |----------------------|

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -56,9 +56,8 @@ var (
 	}
 
 	PodConditionMetricNames = map[corev1.PodConditionType]string{
-		corev1.PodReady:       ci.MetricName(ci.TypePod, ci.StatusReady),
-		corev1.PodScheduled:   ci.MetricName(ci.TypePod, ci.StatusScheduled),
-		corev1.PodInitialized: ci.MetricName(ci.TypePod, ci.StatusInitialized),
+		corev1.PodReady:     ci.MetricName(ci.TypePod, ci.StatusReady),
+		corev1.PodScheduled: ci.MetricName(ci.TypePod, ci.StatusScheduled),
 	}
 
 	PodConditionUnknownMetric = ci.MetricName(ci.TypePod, ci.StatusUnknown)

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -53,7 +53,6 @@ var (
 		corev1.PodRunning:   ci.MetricName(ci.TypePod, ci.StatusRunning),
 		corev1.PodSucceeded: ci.MetricName(ci.TypePod, ci.StatusSucceeded),
 		corev1.PodFailed:    ci.MetricName(ci.TypePod, ci.StatusFailed),
-		corev1.PodUnknown:   ci.MetricName(ci.TypePod, ci.StatusUnknown),
 	}
 
 	PodConditionMetricNames = map[corev1.PodConditionType]string{

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -576,13 +576,11 @@ func (p *PodStore) addPodConditionMetrics(metric CIMetric, pod *corev1.Pod) {
 
 		switch condition.Status {
 		case corev1.ConditionTrue:
-			conditionKey := condition.Type
-			statusMetricName, conditionKeyValid := PodConditionMetricNames[conditionKey]
-			if conditionKeyValid {
+			if statusMetricName, ok := PodConditionMetricNames[condition.Type]; ok {
 				metric.AddField(statusMetricName, 1)
 			}
 		case corev1.ConditionUnknown:
-			if condition.Type == corev1.PodReady || condition.Type == corev1.PodScheduled {
+			if _, ok := PodConditionMetricNames[condition.Type]; ok {
 				metric.AddField(PodConditionUnknownMetric, 1)
 			}
 		}

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -423,6 +423,16 @@ func TestPodStore_addStatus_adds_all_pod_conditions_as_metrics_when_true_false_u
 	assert.Equal(t, 1, decoratedResultMetric.GetField(PodInitializedMetricName))
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodReadyMetricName))
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodScheduledMetricName))
+	assert.Equal(t, 1, decoratedResultMetric.GetField(PodUnknownMetricName))
+}
+
+func TestPodStore_addStatus_adds_all_pod_conditions_as_metrics_when_Ready_Scheduled_Condition_Unknown(t *testing.T) {
+	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric("./test_resources/all_pod_conditions_valid.json", true)
+
+	assert.Equal(t, 1, decoratedResultMetric.GetField(PodInitializedMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodReadyMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodScheduledMetricName))
+	assert.Equal(t, 1, decoratedResultMetric.GetField(PodUnknownMetricName))
 }
 
 func TestPodStore_addStatus_adds_all_pod_conditions_as_metrics_when_unexpected(t *testing.T) {

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -399,7 +399,7 @@ func TestPodStore_addStatus_adds_pod_succeeded_metric(t *testing.T) {
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodUnknownMetricName))
 }
 
-func TestPodStore_addStatus_adds_pod_unknown_metric(t *testing.T) {
+/*func TestPodStore_addStatus_adds_pod_unknown_metric(t *testing.T) {
 	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric("./test_resources/pod_in_phase_unknown.json", true)
 
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodFailedMetricName))
@@ -407,7 +407,7 @@ func TestPodStore_addStatus_adds_pod_unknown_metric(t *testing.T) {
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodRunningMetricName))
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodSucceededMetricName))
 	assert.Equal(t, 1, decoratedResultMetric.GetField(PodUnknownMetricName))
-}
+}*/
 
 func TestPodStore_addStatus_enhanced_metrics_disabled(t *testing.T) {
 	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric("./test_resources/all_pod_conditions_valid.json", false)

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -410,7 +410,7 @@ func TestPodStore_addStatus_adds_all_pod_conditions_as_metrics_when_true_false_u
 }
 
 func TestPodStore_addStatus_adds_all_pod_conditions_as_metrics_when_Ready_Scheduled_Condition_Unknown(t *testing.T) {
-	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric("./test_resources/all_pod_conditions_valid.json", true)
+	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric("./test_resources/pod_Ready_Scheduled_Condition_Unknown.json", true)
 
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodReadyMetricName))
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodScheduledMetricName))

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -339,14 +339,13 @@ func TestPodStore_addContainerCount(t *testing.T) {
 }
 
 const (
-	PodFailedMetricName      = "pod_status_failed"
-	PodPendingMetricName     = "pod_status_pending"
-	PodRunningMetricName     = "pod_status_running"
-	PodSucceededMetricName   = "pod_status_succeeded"
-	PodUnknownMetricName     = "pod_status_unknown"
-	PodReadyMetricName       = "pod_status_ready"
-	PodScheduledMetricName   = "pod_status_scheduled"
-	PodInitializedMetricName = "pod_status_initialized"
+	PodFailedMetricName    = "pod_status_failed"
+	PodPendingMetricName   = "pod_status_pending"
+	PodRunningMetricName   = "pod_status_running"
+	PodSucceededMetricName = "pod_status_succeeded"
+	PodUnknownMetricName   = "pod_status_unknown"
+	PodReadyMetricName     = "pod_status_ready"
+	PodScheduledMetricName = "pod_status_scheduled"
 )
 
 func TestPodStore_enhanced_metrics_disabled(t *testing.T) {
@@ -356,7 +355,6 @@ func TestPodStore_enhanced_metrics_disabled(t *testing.T) {
 	assert.False(t, decoratedResultMetric.HasField(PodPendingMetricName))
 	assert.False(t, decoratedResultMetric.HasField(PodRunningMetricName))
 	assert.False(t, decoratedResultMetric.HasField(PodSucceededMetricName))
-	assert.False(t, decoratedResultMetric.HasField(PodUnknownMetricName))
 }
 
 func TestPodStore_addStatus_adds_pod_failed_metric(t *testing.T) {
@@ -366,7 +364,6 @@ func TestPodStore_addStatus_adds_pod_failed_metric(t *testing.T) {
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodPendingMetricName))
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodRunningMetricName))
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodSucceededMetricName))
-	assert.Equal(t, 0, decoratedResultMetric.GetField(PodUnknownMetricName))
 }
 
 func TestPodStore_addStatus_adds_pod_pending_metric(t *testing.T) {
@@ -376,7 +373,6 @@ func TestPodStore_addStatus_adds_pod_pending_metric(t *testing.T) {
 	assert.Equal(t, 1, decoratedResultMetric.GetField(PodPendingMetricName))
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodRunningMetricName))
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodSucceededMetricName))
-	assert.Equal(t, 0, decoratedResultMetric.GetField(PodUnknownMetricName))
 }
 
 func TestPodStore_addStatus_adds_pod_running_metric(t *testing.T) {
@@ -386,7 +382,6 @@ func TestPodStore_addStatus_adds_pod_running_metric(t *testing.T) {
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodPendingMetricName))
 	assert.Equal(t, 1, decoratedResultMetric.GetField(PodRunningMetricName))
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodSucceededMetricName))
-	assert.Equal(t, 0, decoratedResultMetric.GetField(PodUnknownMetricName))
 }
 
 func TestPodStore_addStatus_adds_pod_succeeded_metric(t *testing.T) {
@@ -396,31 +391,19 @@ func TestPodStore_addStatus_adds_pod_succeeded_metric(t *testing.T) {
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodPendingMetricName))
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodRunningMetricName))
 	assert.Equal(t, 1, decoratedResultMetric.GetField(PodSucceededMetricName))
-	assert.Equal(t, 0, decoratedResultMetric.GetField(PodUnknownMetricName))
 }
-
-/*func TestPodStore_addStatus_adds_pod_unknown_metric(t *testing.T) {
-	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric("./test_resources/pod_in_phase_unknown.json", true)
-
-	assert.Equal(t, 0, decoratedResultMetric.GetField(PodFailedMetricName))
-	assert.Equal(t, 0, decoratedResultMetric.GetField(PodPendingMetricName))
-	assert.Equal(t, 0, decoratedResultMetric.GetField(PodRunningMetricName))
-	assert.Equal(t, 0, decoratedResultMetric.GetField(PodSucceededMetricName))
-	assert.Equal(t, 1, decoratedResultMetric.GetField(PodUnknownMetricName))
-}*/
 
 func TestPodStore_addStatus_enhanced_metrics_disabled(t *testing.T) {
 	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric("./test_resources/all_pod_conditions_valid.json", false)
 
-	assert.False(t, decoratedResultMetric.HasField(PodInitializedMetricName))
 	assert.False(t, decoratedResultMetric.HasField(PodReadyMetricName))
 	assert.False(t, decoratedResultMetric.HasField(PodScheduledMetricName))
+	assert.False(t, decoratedResultMetric.HasField(PodUnknownMetricName))
 }
 
 func TestPodStore_addStatus_adds_all_pod_conditions_as_metrics_when_true_false_unknown(t *testing.T) {
 	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric("./test_resources/all_pod_conditions_valid.json", true)
 
-	assert.Equal(t, 1, decoratedResultMetric.GetField(PodInitializedMetricName))
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodReadyMetricName))
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodScheduledMetricName))
 	assert.Equal(t, 1, decoratedResultMetric.GetField(PodUnknownMetricName))
@@ -429,7 +412,6 @@ func TestPodStore_addStatus_adds_all_pod_conditions_as_metrics_when_true_false_u
 func TestPodStore_addStatus_adds_all_pod_conditions_as_metrics_when_Ready_Scheduled_Condition_Unknown(t *testing.T) {
 	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric("./test_resources/all_pod_conditions_valid.json", true)
 
-	assert.Equal(t, 1, decoratedResultMetric.GetField(PodInitializedMetricName))
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodReadyMetricName))
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodScheduledMetricName))
 	assert.Equal(t, 1, decoratedResultMetric.GetField(PodUnknownMetricName))
@@ -438,9 +420,9 @@ func TestPodStore_addStatus_adds_all_pod_conditions_as_metrics_when_Ready_Schedu
 func TestPodStore_addStatus_adds_all_pod_conditions_as_metrics_when_unexpected(t *testing.T) {
 	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric("./test_resources/one_pod_condition_invalid.json", true)
 
-	assert.Equal(t, 0, decoratedResultMetric.GetField(PodInitializedMetricName))
 	assert.Equal(t, 1, decoratedResultMetric.GetField(PodReadyMetricName))
 	assert.Equal(t, 1, decoratedResultMetric.GetField(PodScheduledMetricName))
+	assert.Equal(t, 0, decoratedResultMetric.GetField(PodUnknownMetricName))
 }
 
 func TestPodStore_addStatus_enhanced_metrics(t *testing.T) {

--- a/receiver/awscontainerinsightreceiver/internal/stores/test_resources/pod_Ready_Scheduled_Condition_Unknown.json
+++ b/receiver/awscontainerinsightreceiver/internal/stores/test_resources/pod_Ready_Scheduled_Condition_Unknown.json
@@ -1,0 +1,156 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "cpu-limit",
+        "namespace": "default",
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "blockOwnerDeletion": true,
+            "controller": true,
+            "kind": "DaemonSet",
+            "name": "DaemonSetTest",
+            "uid": "36779a62-4aca-11e9-977b-0672b6c6fc94"
+          }
+        ],
+        "selfLink": "/api/v1/namespaces/default/pods/cpu-limit",
+        "uid": "764d01e1-2a2f-11e9-95ea-0a695d7ce286",
+        "resourceVersion": "5671573",
+        "creationTimestamp": "2019-02-06T16:51:34Z",
+        "labels": {
+          "app": "hello_test"
+        },
+        "annotations": {
+          "kubernetes.io/config.seen": "2019-02-19T00:06:56.109155665Z",
+          "kubernetes.io/config.source": "api"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-tlgw7",
+            "secret": {
+              "secretName": "default-token-tlgw7",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "ubuntu",
+            "image": "ubuntu",
+            "command": [
+              "/bin/bash"
+            ],
+            "args": [
+              "-c",
+              "sleep 300000000"
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              },
+              "requests": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-tlgw7",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "ip-192-168-67-127.us-west-2.compute.internal",
+        "securityContext": {
+
+        },
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          },
+          {
+            "type": "Ready",
+            "status": "Unknown",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:43Z"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": null
+          },
+          {
+            "type": "PodScheduled",
+            "status": "Unknown",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          }
+        ],
+        "hostIP": "192.168.67.127",
+        "podIP": "192.168.76.93",
+        "startTime": "2019-02-06T16:51:34Z",
+        "containerStatuses": [
+          {
+            "name": "ubuntu",
+            "state": {
+              "running": {
+                "startedAt": "2019-02-06T16:51:42Z"
+              }
+            },
+            "lastState": {
+
+            },
+            "ready": true,
+            "restartCount": 0,
+            "image": "ubuntu:latest",
+            "imageID": "docker-pullable://ubuntu@sha256:7a47ccc3bbe8a451b500d2b53104868b46d60ee8f5b35a24b41a86077c650210",
+            "containerID": "docker://637631e2634ea92c0c1aa5d24734cfe794f09c57933026592c12acafbaf6972c"
+          }
+        ],
+        "qosClass": "Guaranteed"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Adding pod_status_unknown as a Pod condition metric and removed the pod_status_initialized metric

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

Unit testing and Manual testing deploying the docker image on cluster

<img width="1488" alt="Screen Shot 2023-07-31 at 3 38 44 PM" src="https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/22948773/4c092c6b-bdd9-499c-9f9f-89c48a22f43e">



Sample CW log 

```{
    "AutoScalingGroupName": "eks-ng-9ba60313-0ec4c7bb-39c4-ad98-f12c-889c817b9234",
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName"
                ],
                [
                    "ClusterName",
                    "FullPodName",
                    "Namespace",
                    "PodName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "pod_status_scheduled"
                },
                {
                    "Name": "pod_status_ready"
                },
                {
                    "Name": "pod_number_of_containers",
                    "Unit": "Count"
                },
                {
                    "Name": "pod_status_succeeded"
                },
                {
                    "Name": "pod_number_of_running_containers",
                    "Unit": "Count"
                },
                {
                    "Name": "pod_status_unknown"
                },
                {
                    "Name": "pod_status_pending"
                },
                {
                    "Name": "pod_memory_reserved_capacity",
                    "Unit": "Percent"
                },
                {
                    "Name": "pod_number_of_container_restarts",
                    "Unit": "Count"
                },
                {
                    "Name": "pod_status_running",
                    "Unit": "Count"
                },
                {
                    "Name": "pod_cpu_reserved_capacity",
                    "Unit": "Percent"
                },
                {
                    "Name": "pod_status_failed"
                }
            ]
        },
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName"
                ],
                [
                    "ClusterName",
                    "Namespace"
                ],
                [
                    "ClusterName",
                    "FullPodName",
                    "Namespace",
                    "PodName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "pod_network_rx_bytes",
                    "Unit": "Bytes/Second"
                },
                {
                    "Name": "pod_cpu_utilization_over_pod_limit",
                    "Unit": "Percent"
                },
                {
                    "Name": "pod_memory_utilization_over_pod_limit",
                    "Unit": "Percent"
                },
                {
                    "Name": "pod_cpu_utilization",
                    "Unit": "Percent"
                },
                {
                    "Name": "pod_network_tx_bytes",
                    "Unit": "Bytes/Second"
                },
                {
                    "Name": "pod_memory_utilization",
                    "Unit": "Percent"
                }
            ]
        }
    ],
    "ClusterName": "poojardy-tupperware",
    "FullPodName": "cloudwatch-agent-d6gcj",
    "InstanceId": "i-0b5b5289090ebd0df",
    "InstanceType": "m5.large",
    "Namespace": "amazon-cloudwatch",
    "NodeName": "ip-192-168-1-168.ec2.internal",
    "PodName": "cloudwatch-agent",
    "Sources": [
        "cadvisor",
        "pod",
        "calculated"
    ],
    "Timestamp": "1690831124178",
    "Type": "Pod",
    "Version": "0",
    "kubernetes": {
        "host": "ip-192-168-1-168.ec2.internal",
        "labels": {
            "controller-revision-hash": "67f5f8dbfc",
            "name": "cloudwatch-agent",
            "pod-template-generation": "7"
        },
        "namespace_name": "amazon-cloudwatch",
        "pod_id": "879f8416-2c5f-41e1-8566-3f534e2c4ed9",
        "pod_name": "cloudwatch-agent-d6gcj",
        "pod_owners": [
            {
                "owner_kind": "DaemonSet",
                "owner_name": "cloudwatch-agent"
            }
        ]
    },
    "pod_cpu_limit": 200,
    "pod_cpu_request": 200,
    "pod_cpu_reserved_capacity": 10,
    "pod_cpu_usage_system": 0.6783516430351941,
    "pod_cpu_usage_total": 2.6885913158407555,
    "pod_cpu_usage_user": 2.035054929105582,
    "pod_cpu_utilization": 0.13442956579203777,
    "pod_cpu_utilization_over_pod_limit": 1.3442956579203778,
    "pod_memory_cache": 0,
    "pod_memory_failcnt": 0,
    "pod_memory_failures_total": 0,
    "pod_memory_hierarchical_pgfault": 0,
    "pod_memory_hierarchical_pgmajfault": 0,
    "pod_memory_limit": 209715200,
    "pod_memory_mapped_file": 0,
    "pod_memory_max_usage": 37167104,
    "pod_memory_pgfault": 0,
    "pod_memory_pgmajfault": 0,
    "pod_memory_request": 209715200,
    "pod_memory_reserved_capacity": 2.617471828948216,
    "pod_memory_rss": 34603008,
    "pod_memory_swap": 0,
    "pod_memory_usage": 35954688,
    "pod_memory_utilization": 0.4487532756739734,
    "pod_memory_utilization_over_pod_limit": 17.14453125,
    "pod_memory_working_set": 35954688,
    "pod_network_rx_bytes": 1939.6497381091524,
    "pod_network_rx_dropped": 0,
    "pod_network_rx_errors": 0,
    "pod_network_rx_packets": 2.503067470577273,
    "pod_network_total_bytes": 2460.2119214598138,
    "pod_network_tx_bytes": 520.5621833506614,
    "pod_network_tx_dropped": 0,
    "pod_network_tx_errors": 0,
    "pod_network_tx_packets": 2.533407682341846,
    "pod_number_of_container_restarts": 0,
    "pod_number_of_containers": 1,
    "pod_number_of_running_containers": 1,
    "pod_status": "Running",
    "pod_status_failed": 0,
    "pod_status_pending": 0,
    "pod_status_ready": 1,
    "pod_status_running": 1,
    "pod_status_scheduled": 1,
    "pod_status_succeeded": 0,
    "pod_status_unknown": 0
}```

**Documentation:** <Describe the documentation added.>