### PR TITLE
Node status condition unknown metric

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -94,6 +94,7 @@ const (
 	StatusConditionMemoryPressure     = "status_condition_memory_pressure"
 	StatusConditionPIDPressure        = "status_condition_pid_pressure"
 	StatusConditionNetworkUnavailable = "status_condition_network_unavailable"
+	StatusConditionUnknown            = "status_condition_unknown"
 	StatusCapacityPods                = "status_capacity_pods"
 	StatusAllocatablePods             = "status_allocatable_pods"
 	StatusNumberAvailable             = "status_number_available"
@@ -241,6 +242,7 @@ func init() {
 		StatusConditionMemoryPressure:     UnitCount,
 		StatusConditionPIDPressure:        UnitCount,
 		StatusConditionNetworkUnavailable: UnitCount,
+		StatusConditionUnknown:            UnitCount,
 		StatusCapacityPods:                UnitCount,
 		StatusAllocatablePods:             UnitCount,
 		StatusReplicas:                    UnitCount,

--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -523,6 +523,7 @@ kubectl apply -f config.yaml
 | node_status_condition_memory_pressure     | Count        |
 | node_status_condition_disk_pressure       | Count        |
 | node_status_condition_network_unavailable | Count        |
+| node_status_condition_unknown             | Count        |
 | node_status_capacity_pods                 | Count        |
 | node_status_allocatable_pods              | Count        |
 

--- a/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo.go
@@ -116,12 +116,24 @@ func (n *nodeInfo) getNodeStatusAllocatablePods() (uint64, bool) {
 
 func (n *nodeInfo) getNodeStatusCondition(conditionType v1.NodeConditionType) (uint64, bool) {
 	if nodeConditions, ok := n.provider.NodeToConditionsMap()[n.nodeName]; ok {
-		if conditionType, ok := nodeConditions[conditionType]; ok {
-			if conditionType == v1.ConditionTrue {
+		if conditionStatus, ok := nodeConditions[conditionType]; ok {
+			if conditionStatus == v1.ConditionTrue {
 				return 1, true
 			}
 			return 0, true // v1.ConditionFalse or v1.ConditionUnknown
 		}
+	}
+	return 0, false
+}
+
+func (n *nodeInfo) getNodeConditionUnknown() (uint64, bool) {
+	if nodeConditions, ok := n.provider.NodeToConditionsMap()[n.nodeName]; ok {
+		for _, conditionStatus := range nodeConditions {
+			if conditionStatus == v1.ConditionUnknown {
+				return 1, true
+			}
+		}
+		return 0, true
 	}
 	return 0, false
 }

--- a/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo_test.go
@@ -136,3 +136,20 @@ func TestGetNodeStatusCondition(t *testing.T) {
 	assert.False(t, valid)
 	assert.Equal(t, uint64(0), nodeStatusCondition)
 }
+
+func TestGetNodeConditionUnknown(t *testing.T) {
+	nodeInfo := newNodeInfo("testNode1", &mockNodeInfoProvider{}, zap.NewNop())
+	nodeStatusCondition, valid := nodeInfo.getNodeConditionUnknown()
+	assert.True(t, valid)
+	assert.Equal(t, uint64(1), nodeStatusCondition)
+
+	nodeInfo = newNodeInfo("testNode2", &mockNodeInfoProvider{}, zap.NewNop())
+	nodeStatusCondition, valid = nodeInfo.getNodeConditionUnknown()
+	assert.True(t, valid)
+	assert.Equal(t, uint64(0), nodeStatusCondition)
+
+	nodeInfo = newNodeInfo("testNodeNonExistent", &mockNodeInfoProvider{}, zap.NewNop())
+	nodeStatusCondition, valid = nodeInfo.getNodeStatusCondition(v1.NodeReady)
+	assert.False(t, valid)
+	assert.Equal(t, uint64(0), nodeStatusCondition)
+}

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -369,6 +369,9 @@ func (p *PodStore) decorateNode(metric CIMetric) {
 		if nodeStatusConditionNetworkUnavailable, ok := p.nodeInfo.getNodeStatusCondition(corev1.NodeNetworkUnavailable); ok {
 			metric.AddField(ci.MetricName(ci.TypeNode, ci.StatusConditionNetworkUnavailable), nodeStatusConditionNetworkUnavailable)
 		}
+		if nodeStatusConditionUnknown, ok := p.nodeInfo.getNodeConditionUnknown(); ok {
+			metric.AddField(ci.MetricName(ci.TypeNode, ci.StatusConditionUnknown), nodeStatusConditionUnknown)
+		}
 	}
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -876,6 +876,7 @@ func TestPodStore_decorateNode(t *testing.T) {
 	assert.False(t, metric.HasField("node_status_condition_memory_pressure"))
 	assert.False(t, metric.HasField("node_status_condition_pid_pressure"))
 	assert.False(t, metric.HasField("node_status_condition_network_unavailable"))
+	assert.False(t, metric.HasField("node_status_condition_unknown"))
 
 	assert.False(t, metric.HasField("node_status_capacity_pods"))
 	assert.False(t, metric.HasField("node_status_allocatable_pods"))
@@ -888,6 +889,7 @@ func TestPodStore_decorateNode(t *testing.T) {
 	assert.Equal(t, uint64(0), metric.GetField("node_status_condition_memory_pressure").(uint64))
 	assert.Equal(t, uint64(0), metric.GetField("node_status_condition_pid_pressure").(uint64))
 	assert.Equal(t, uint64(0), metric.GetField("node_status_condition_network_unavailable").(uint64))
+	assert.Equal(t, uint64(1), metric.GetField("node_status_condition_unknown").(uint64))
 
 	assert.Equal(t, uint64(5), metric.GetField("node_status_capacity_pods").(uint64))
 	assert.Equal(t, uint64(15), metric.GetField("node_status_allocatable_pods").(uint64))


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Added node_status_condition_unknown metric

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
Unit testing and manual testing on EKS cluster

<img width="1484" alt="Screen Shot 2023-08-03 at 1 41 31 PM" src="https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/22948773/d3bbb9b1-bced-4597-a23e-8c56db2ce579">

Log Event
```
{
    "AutoScalingGroupName": "eks-ng-9ba60313-0ec4c7bb-39c4-ad98-f12c-889c817b9234",
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName",
                    "InstanceId",
                    "NodeName"
                ],
                [
                    "ClusterName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "node_memory_utilization",
                    "Unit": "Percent"
                },
                {
                    "Name": "node_memory_reserved_capacity",
                    "Unit": "Percent"
                },
                {
                    "Name": "node_number_of_running_pods",
                    "Unit": "Count"
                },
                {
                    "Name": "node_number_of_running_containers",
                    "Unit": "Count"
                },
                {
                    "Name": "node_cpu_usage_total"
                },
                {
                    "Name": "node_cpu_limit"
                },
                {
                    "Name": "node_network_total_bytes",
                    "Unit": "Bytes/Second"
                },
                {
                    "Name": "node_memory_limit",
                    "Unit": "Bytes"
                },
                {
                    "Name": "node_status_condition_ready",
                    "Unit": "Count"
                },
                {
                    "Name": "node_status_condition_memory_pressure",
                    "Unit": "Count"
                },
                {
                    "Name": "node_cpu_reserved_capacity",
                    "Unit": "Percent"
                },
                {
                    "Name": "node_status_condition_unknown",
                    "Unit": "Count"
                },
                {
                    "Name": "node_memory_working_set",
                    "Unit": "Bytes"
                },
                {
                    "Name": "node_cpu_utilization",
                    "Unit": "Percent"
                },
                {
                    "Name": "node_status_condition_disk_pressure",
                    "Unit": "Count"
                },
                {
                    "Name": "node_status_capacity_pods",
                    "Unit": "Count"
                },
                {
                    "Name": "node_status_allocatable_pods",
                    "Unit": "Count"
                },
                {
                    "Name": "node_status_condition_pid_pressure",
                    "Unit": "Count"
                }
            ]
        }
    ],
    "ClusterName": "poojardy-tupperware",
    "InstanceId": "i-0b5b5289090ebd0df",
    "InstanceType": "m5.large",
    "NodeName": "ip-192-168-1-168.ec2.internal",
    "Sources": [
        "cadvisor",
        "/proc",
        "pod",
        "calculated"
    ],
    "Timestamp": "1691083362920",
    "Type": "Node",
    "Version": "0",
    "kubernetes": {
        "host": "ip-192-168-1-168.ec2.internal"
    },
    "node_cpu_limit": 2000,
    "node_cpu_request": 525,
    "node_cpu_reserved_capacity": 26.25,
    "node_cpu_usage_system": 12.938149192203467,
    "node_cpu_usage_total": 34.665348013875345,
    "node_cpu_usage_user": 16.350408319817568,
    "node_cpu_utilization": 1.7332674006937672,
    "node_memory_cache": 3241463808,
    "node_memory_failcnt": 0,
    "node_memory_failures_total": 0,
    "node_memory_hierarchical_pgfault": 0,
    "node_memory_hierarchical_pgmajfault": 0,
    "node_memory_limit": 8012128256,
    "node_memory_mapped_file": 360087552,
    "node_memory_max_usage": 3551842304,
    "node_memory_pgfault": 0,
    "node_memory_pgmajfault": 0,
    "node_memory_request": 356515840,
    "node_memory_reserved_capacity": 4.449702109211967,
    "node_memory_rss": 226725888,
    "node_memory_swap": 0,
    "node_memory_usage": 3468189696,
    "node_memory_utilization": 11.440447914866729,
    "node_memory_working_set": 916623360,
    "node_network_rx_bytes": 4506.86920251361,
    "node_network_rx_dropped": 0,
    "node_network_rx_errors": 0,
    "node_network_rx_packets": 21.753151938539894,
    "node_network_total_bytes": 11801.909555947066,
    "node_network_tx_bytes": 7295.040353433456,
    "node_network_tx_dropped": 0,
    "node_network_tx_errors": 0,
    "node_network_tx_packets": 22.70574094499883,
    "node_number_of_running_containers": 5,
    "node_number_of_running_pods": 5,
    "node_status_allocatable_pods": 29,
    "node_status_capacity_pods": 29,
    "node_status_condition_disk_pressure": 0,
    "node_status_condition_memory_pressure": 0,
    "node_status_condition_pid_pressure": 0,
    "node_status_condition_ready": 1,
    "node_status_condition_unknown": 0
}```


**Documentation:** <Describe the documentation added.>