### PR TITLE
Adding apiserver_storage_list_duration_seconds at cluster and resource level

### DIFF
--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -415,7 +415,6 @@ kubectl apply -f config.yaml
 |-----------------------------|-------|
 | etcd_db_total_size_in_bytes | bytes |
 
-
 <br/><br/>
 | Resource Attribute |
 |--------------------|
@@ -428,6 +427,21 @@ kubectl apply -f config.yaml
 | Sources            |
 
 <br/><br/> 
+
+### Cluster Resources
+| Metric                                  | Unit    |
+|-----------------------------------------|---------|
+| apiserver_storage_list_duration_seconds | Seconds |
+
+<br/><br/>
+| Resource Attribute |
+|--------------------|
+| ClusterName        |
+| NodeName           |
+| Type               |
+| Timestamp          |
+| Version            |
+| Sources            |
 
 ### Cluster Deployment
 | Metric                                 | Unit  |

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
@@ -51,6 +51,7 @@ var (
 		"rest_client_requests_total",
 		"etcd_request_duration_seconds.*",
 		"etcd_db_total_size_in_bytes.*",
+		"apiserver_storage_list_duration_seconds.*"
 	}
 )
 


### PR DESCRIPTION

**Description:** 
Adding the apiserver_storage_list_duration_seconds metric

**Testing:** 
RESOURCE LEVEL
<img width="1484" alt="Screen Shot 2023-08-04 at 15 16 23" src="https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/44349099/4371ad1a-2b38-4777-8edf-6a2890428564">

CLUSTER LEVEL
<img width="1480" alt="Screen Shot 2023-08-04 at 15 17 01" src="https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/44349099/61402e95-2e9e-4efc-8086-6fadf960bcf7">
