### PR TITLE
Create new stanza encoding instance for each thread

### DIFF
--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -140,12 +140,12 @@ func (c Config) buildManager(logger *zap.SugaredLogger, emit EmitFunc, factory s
 
 	var hs *headerSettings
 	if c.Header != nil {
-		enc, err := c.Splitter.EncodingConfig.Build()
+		enc, err := helper.LookupEncoding(c.Splitter.EncodingConfig.Encoding)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create encoding: %w", err)
 		}
 
-		hs, err = c.Header.buildHeaderSettings(enc.Encoding)
+		hs, err = c.Header.buildHeaderSettings(enc)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build header config: %w", err)
 		}
@@ -222,7 +222,7 @@ func (c Config) validate() error {
 		return errors.New("`max_batches` must not be negative")
 	}
 
-	_, err := c.Splitter.EncodingConfig.Build()
+	_, err := helper.LookupEncoding(c.Splitter.EncodingConfig.Encoding)
 	if err != nil {
 		return err
 	}

--- a/pkg/stanza/fileconsumer/reader_factory.go
+++ b/pkg/stanza/fileconsumer/reader_factory.go
@@ -130,11 +130,11 @@ func (b *readerBuilder) build() (r *Reader, err error) {
 		r.splitFunc = r.lineSplitFunc
 	}
 
-	enc, err := b.encodingConfig.Build()
+	enc, err := helper.LookupEncoding(b.encodingConfig.Encoding)
 	if err != nil {
 		return
 	}
-	r.encoding = enc
+	r.encoding = helper.NewEncoding(enc)
 
 	if b.file != nil {
 		r.file = b.file

--- a/pkg/stanza/fileconsumer/reader_test.go
+++ b/pkg/stanza/fileconsumer/reader_test.go
@@ -182,12 +182,13 @@ func TestHeaderFingerprintIncluded(t *testing.T) {
 		},
 	}
 
-	enc, err := helper.EncodingConfig{
+	cfg := helper.EncodingConfig{
 		Encoding: "utf-8",
-	}.Build()
+	}
+	enc, err := helper.LookupEncoding(cfg.Encoding)
 	require.NoError(t, err)
 
-	h, err := headerConf.buildHeaderSettings(enc.Encoding)
+	h, err := headerConf.buildHeaderSettings(enc)
 	require.NoError(t, err)
 	f.headerSettings = h
 

--- a/pkg/stanza/fileconsumer/splitter_factory.go
+++ b/pkg/stanza/fileconsumer/splitter_factory.go
@@ -38,12 +38,12 @@ func newMultilineSplitterFactory(splitter helper.SplitterConfig) *multilineSplit
 
 // Build builds Multiline Splitter struct
 func (factory *multilineSplitterFactory) Build(maxLogSize int) (bufio.SplitFunc, error) {
-	enc, err := factory.EncodingConfig.Build()
+	enc, err := helper.LookupEncoding(factory.EncodingConfig.Encoding)
 	if err != nil {
 		return nil, err
 	}
 	flusher := factory.Flusher.Build()
-	splitter, err := factory.Multiline.Build(enc.Encoding, false, factory.PreserveLeadingWhitespaces, factory.PreserveTrailingWhitespaces, flusher, maxLogSize)
+	splitter, err := factory.Multiline.Build(enc, false, factory.PreserveLeadingWhitespaces, factory.PreserveTrailingWhitespaces, flusher, maxLogSize)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/helper/encoding.go
+++ b/pkg/stanza/operator/helper/encoding.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/text/transform"
 )
 
-// NewBasicConfig creates a new Encoding config
+// NewEncodingConfig creates a new Encoding config
 func NewEncodingConfig() EncodingConfig {
 	return EncodingConfig{
 		Encoding: "utf-8",
@@ -45,28 +45,27 @@ func (c EncodingConfig) Build() (Encoding, error) {
 	}
 
 	return Encoding{
-		Encoding:     enc,
-		decodeBuffer: make([]byte, 1<<12),
-		decoder:      enc.NewDecoder(),
+		Encoding: enc,
+		decoder:  enc.NewDecoder(),
 	}, nil
 }
 
 type Encoding struct {
-	Encoding     encoding.Encoding
-	decoder      *encoding.Decoder
-	decodeBuffer []byte
+	Encoding encoding.Encoding
+	decoder  *encoding.Decoder
 }
 
 // Decode converts the bytes in msgBuf to utf-8 from the configured encoding
 func (e *Encoding) Decode(msgBuf []byte) ([]byte, error) {
+	decodeBuffer := make([]byte, 1<<12)
 	for {
 		e.decoder.Reset()
-		nDst, _, err := e.decoder.Transform(e.decodeBuffer, msgBuf, true)
+		nDst, _, err := e.decoder.Transform(decodeBuffer, msgBuf, true)
 		if err == nil {
-			return e.decodeBuffer[:nDst], nil
+			return decodeBuffer[:nDst], nil
 		}
 		if errors.Is(err, transform.ErrShortDst) {
-			e.decodeBuffer = make([]byte, len(e.decodeBuffer)*2)
+			decodeBuffer = make([]byte, len(decodeBuffer)*2)
 			continue
 		}
 		return nil, fmt.Errorf("transform encoding: %w", err)

--- a/pkg/stanza/operator/helper/encoding.go
+++ b/pkg/stanza/operator/helper/encoding.go
@@ -37,35 +37,30 @@ type EncodingConfig struct {
 	Encoding string `mapstructure:"encoding,omitempty"`
 }
 
-// Build will build an Encoding operator.
-func (c EncodingConfig) Build() (Encoding, error) {
-	enc, err := lookupEncoding(c.Encoding)
-	if err != nil {
-		return Encoding{}, err
-	}
-
-	return Encoding{
-		Encoding: enc,
-		decoder:  enc.NewDecoder(),
-	}, nil
+type Encoding struct {
+	Encoding     encoding.Encoding
+	decoder      *encoding.Decoder
+	decodeBuffer []byte
 }
 
-type Encoding struct {
-	Encoding encoding.Encoding
-	decoder  *encoding.Decoder
+func NewEncoding(enc encoding.Encoding) Encoding {
+	return Encoding{
+		Encoding:     enc,
+		decoder:      enc.NewDecoder(),
+		decodeBuffer: make([]byte, 1<<12),
+	}
 }
 
 // Decode converts the bytes in msgBuf to utf-8 from the configured encoding
 func (e *Encoding) Decode(msgBuf []byte) ([]byte, error) {
-	decodeBuffer := make([]byte, 1<<12)
 	for {
 		e.decoder.Reset()
-		nDst, _, err := e.decoder.Transform(decodeBuffer, msgBuf, true)
+		nDst, _, err := e.decoder.Transform(e.decodeBuffer, msgBuf, true)
 		if err == nil {
-			return decodeBuffer[:nDst], nil
+			return e.decodeBuffer[:nDst], nil
 		}
 		if errors.Is(err, transform.ErrShortDst) {
-			decodeBuffer = make([]byte, len(decodeBuffer)*2)
+			e.decodeBuffer = make([]byte, len(e.decodeBuffer)*2)
 			continue
 		}
 		return nil, fmt.Errorf("transform encoding: %w", err)
@@ -83,7 +78,7 @@ var encodingOverrides = map[string]encoding.Encoding{
 	"":         unicode.UTF8,
 }
 
-func lookupEncoding(enc string) (encoding.Encoding, error) {
+func LookupEncoding(enc string) (encoding.Encoding, error) {
 	if e, ok := encodingOverrides[strings.ToLower(enc)]; ok {
 		return e, nil
 	}
@@ -98,7 +93,7 @@ func lookupEncoding(enc string) (encoding.Encoding, error) {
 }
 
 func IsNop(enc string) bool {
-	e, err := lookupEncoding(enc)
+	e, err := LookupEncoding(enc)
 	if err != nil {
 		return false
 	}

--- a/pkg/stanza/operator/helper/splitter.go
+++ b/pkg/stanza/operator/helper/splitter.go
@@ -36,19 +36,19 @@ func NewSplitterConfig() SplitterConfig {
 
 // Build builds Splitter struct
 func (c *SplitterConfig) Build(flushAtEOF bool, maxLogSize int) (*Splitter, error) {
-	enc, err := c.EncodingConfig.Build()
+	enc, err := LookupEncoding(c.EncodingConfig.Encoding)
 	if err != nil {
 		return nil, err
 	}
 
 	flusher := c.Flusher.Build()
-	splitFunc, err := c.Multiline.Build(enc.Encoding, flushAtEOF, c.PreserveLeadingWhitespaces, c.PreserveTrailingWhitespaces, flusher, maxLogSize)
+	splitFunc, err := c.Multiline.Build(enc, flushAtEOF, c.PreserveLeadingWhitespaces, c.PreserveTrailingWhitespaces, flusher, maxLogSize)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Splitter{
-		Encoding:  enc,
+		Encoding:  NewEncoding(enc),
 		Flusher:   flusher,
 		SplitFunc: splitFunc,
 	}, nil


### PR DESCRIPTION
**Description:** The shared buffer in the stanza decoder was causing a concurrency issue where the buffer would get updated by multiple separate threads. This meant that some messages were getting corrupted after decoding and some messages were getting completely replaced. This resulted in duplicates and invalid logs getting passed through the collector.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/24980

**Testing:** Reproduced the issue with a generator that established multiple TCP connections and sent to the tcplogreceiver concurrently. No longer seeing the issue after changing the `helper.Encoding` instantiation to each thread instead of using a shared one.