### PR TITLE
add metadata to user-agent string indicating customer is configured f…

### DIFF
--- a/exporter/awscloudwatchlogsexporter/exporter.go
+++ b/exporter/awscloudwatchlogsexporter/exporter.go
@@ -72,7 +72,7 @@ func newCwLogsPusher(expConfig *Config, params exp.CreateSettings) (*exporter, e
 	}
 
 	// create CWLogs client with aws session config
-	svcStructuredLog := cwlogs.NewClient(params.Logger, awsConfig, params.BuildInfo, expConfig.LogGroupName, expConfig.LogRetention, session)
+	svcStructuredLog := cwlogs.NewClient(params.Logger, awsConfig, params.BuildInfo, expConfig.LogGroupName, expConfig.LogRetention, session, false)
 	collectorIdentifier, err := uuid.NewRandom()
 
 	if err != nil {

--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -75,10 +75,13 @@ type Config struct {
 	// TODO: we can support directing output to a file (in the future) while customer specifies a file path here.
 	OutputDestination string `mapstructure:"output_destination"`
 
-	// EKSFargateContainerInsightsEnabled is an option to reformat certin metric labels so that they take the form of a high level object
+	// EKSFargateContainerInsightsEnabled is an option to reformat certain metric labels so that they take the form of a high level object
 	// The end result will make the labels look like those coming out of ECS and be more easily injected into cloudwatch
 	// Note that at the moment in order to use this feature the value "kubernetes" must also be added to the ParseJSONEncodedAttributeValues array in order to be used
 	EKSFargateContainerInsightsEnabled bool `mapstructure:"eks_fargate_container_insights_enabled"`
+
+	// EnhancedContainerInsights indicates payloads will include enhanced container insights metrics
+	EnhancedContainerInsights bool `mapstructure:"enhanced_container_insights"`
 
 	// DisableMetricExtraction is an option to disable the extraction of metrics from the EMF logs.
 	// Setting this to true essentially skips generating and setting the _aws / CloudWatchMetrics section of the EMF log, thus effectively

--- a/exporter/awsemfexporter/config_test.go
+++ b/exporter/awsemfexporter/config_test.go
@@ -133,6 +133,28 @@ func TestLoadConfig(t *testing.T) {
 				logger:                  zap.NewNop(),
 			},
 		},
+		{
+			id: component.NewIDWithName(typeStr, "enhanced_container_insights"),
+			expected: &Config{
+				AWSSessionSettings: awsutil.AWSSessionSettings{
+					NumberOfWorkers:       8,
+					Endpoint:              "",
+					RequestTimeoutSeconds: 30,
+					MaxRetries:            2,
+					NoVerifySSL:           false,
+					ProxyAddress:          "",
+					Region:                "",
+					RoleARN:               "",
+				},
+				LogGroupName:              "",
+				LogStreamName:             "",
+				DimensionRollupOption:     "ZeroAndSingleDimensionRollup",
+				OutputDestination:         "cloudwatch",
+				Version:                   "1",
+				EnhancedContainerInsights: true,
+				logger:                    zap.NewNop(),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -66,7 +66,7 @@ func newEmfExporter(config *Config, set exporter.CreateSettings) (*emfExporter, 
 	}
 
 	// create CWLogs client with aws session config
-	svcStructuredLog := cwlogs.NewClient(set.Logger, awsConfig, set.BuildInfo, config.LogGroupName, config.LogRetention, session)
+	svcStructuredLog := cwlogs.NewClient(set.Logger, awsConfig, set.BuildInfo, config.LogGroupName, config.LogRetention, session, isEnhancedContainerInsights(config))
 	collectorIdentifier, err := uuid.NewRandom()
 
 	if err != nil {
@@ -197,4 +197,8 @@ func wrapErrorIfBadRequest(err error) error {
 		return consumererror.NewPermanent(err)
 	}
 	return err
+}
+
+func isEnhancedContainerInsights(config *Config) bool {
+	return config.EnhancedContainerInsights && !config.DisableMetricExtraction
 }

--- a/exporter/awsemfexporter/emf_exporter_test.go
+++ b/exporter/awsemfexporter/emf_exporter_test.go
@@ -641,3 +641,16 @@ func TestNewEmfExporterWithoutConfig(t *testing.T) {
 	assert.Nil(t, exp)
 	assert.Equal(t, settings.Logger, expCfg.logger)
 }
+
+func TestIsEnhancedContainerInsights(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.EnhancedContainerInsights = true
+	cfg.DisableMetricExtraction = false
+	assert.True(t, isEnhancedContainerInsights(cfg))
+	cfg.EnhancedContainerInsights = false
+	assert.False(t, isEnhancedContainerInsights(cfg))
+	cfg.EnhancedContainerInsights = true
+	cfg.DisableMetricExtraction = true
+	assert.False(t, isEnhancedContainerInsights(cfg))
+}

--- a/exporter/awsemfexporter/testdata/config.yaml
+++ b/exporter/awsemfexporter/testdata/config.yaml
@@ -15,3 +15,5 @@ awsemf/metric_descriptors:
       overwrite: true
 awsemf/disable_metric_extraction:
   disable_metric_extraction: true
+awsemf/enhanced_container_insights:
+  enhanced_container_insights: true

--- a/internal/aws/cwlogs/cwlog_client.go
+++ b/internal/aws/cwlogs/cwlog_client.go
@@ -38,8 +38,8 @@ const (
 )
 
 var (
-	containerInsightsRegexPattern       = regexp.MustCompile("^/aws/.*containerinsights/.*/(performance|prometheus)$")
-	enhancedContainerInsightsEKSPattern = regexp.MustCompile("^/aws/containerinsights/\\S+/performance$")
+	containerInsightsRegexPattern       = regexp.MustCompile(`^/aws/.*containerinsights/.*/(performance|prometheus)$`)
+	enhancedContainerInsightsEKSPattern = regexp.MustCompile(`^/aws/containerinsights/\S+/performance$`)
 )
 
 // Possible exceptions are combination of common errors (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/CommonErrors.html)

--- a/internal/aws/cwlogs/cwlog_client_test.go
+++ b/internal/aws/cwlogs/cwlog_client_test.go
@@ -570,12 +570,13 @@ func TestUserAgent(t *testing.T) {
 			component.BuildInfo{Command: "opentelemetry-collector-contrib", Version: "1.0"},
 			"/aws/containerinsights/eks-cluster-name/performance",
 			true,
-			"opentelemetry-collector-contrib/1.0 (EnhancedContainerInsights)",
+			"opentelemetry-collector-contrib/1.0 (EnhancedEKSContainerInsights)",
 		},
 		{
 			"negative - enhanced container insights ECS",
 			component.BuildInfo{Command: "opentelemetry-collector-contrib", Version: "1.0"},
-			"/aws/containerinsights/eks-cluster-name/performance",
+			// this is an ECS path, enhanced CI is not supported
+			"/aws/ecs/containerinsights/ecs-cluster-name/performance",
 			true,
 			"opentelemetry-collector-contrib/1.0 (ContainerInsights)",
 		},
@@ -584,7 +585,7 @@ func TestUserAgent(t *testing.T) {
 	session, _ := session.NewSession()
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cwlog := NewClient(logger, &aws.Config{}, tc.buildInfo, tc.logGroupName, 0, session, false)
+			cwlog := NewClient(logger, &aws.Config{}, tc.buildInfo, tc.logGroupName, 0, session, tc.enhancedContainerInsights)
 			logClient := cwlog.svc.(*cloudwatchlogs.CloudWatchLogs)
 
 			req := request.New(aws.Config{}, metadata.ClientInfo{}, logClient.Handlers, nil, &request.Operation{

--- a/internal/aws/cwlogs/cwlog_client_test.go
+++ b/internal/aws/cwlogs/cwlog_client_test.go
@@ -517,45 +517,66 @@ func TestUserAgent(t *testing.T) {
 	logger := zap.NewNop()
 
 	tests := []struct {
-		name                 string
-		buildInfo            component.BuildInfo
-		logGroupName         string
-		expectedUserAgentStr string
+		name                      string
+		buildInfo                 component.BuildInfo
+		logGroupName              string
+		enhancedContainerInsights bool
+		expectedUserAgentStr      string
 	}{
 		{
 			"emptyLogGroup",
 			component.BuildInfo{Command: "opentelemetry-collector-contrib", Version: "1.0"},
 			"",
+			false,
 			"opentelemetry-collector-contrib/1.0",
 		},
 		{
 			"buildInfoCommandUsed",
 			component.BuildInfo{Command: "test-collector-contrib", Version: "1.0"},
 			"",
+			false,
 			"test-collector-contrib/1.0",
 		},
 		{
 			"non container insights",
 			component.BuildInfo{Command: "opentelemetry-collector-contrib", Version: "1.1"},
 			"test-group",
+			false,
 			"opentelemetry-collector-contrib/1.1",
 		},
 		{
 			"container insights EKS",
 			component.BuildInfo{Command: "opentelemetry-collector-contrib", Version: "1.0"},
 			"/aws/containerinsights/eks-cluster-name/performance",
+			false,
 			"opentelemetry-collector-contrib/1.0 (ContainerInsights)",
 		},
 		{
 			"container insights ECS",
 			component.BuildInfo{Command: "opentelemetry-collector-contrib", Version: "1.0"},
 			"/aws/ecs/containerinsights/ecs-cluster-name/performance",
+			false,
 			"opentelemetry-collector-contrib/1.0 (ContainerInsights)",
 		},
 		{
 			"container insights prometheus",
 			component.BuildInfo{Command: "opentelemetry-collector-contrib", Version: "1.0"},
 			"/aws/containerinsights/cluster-name/prometheus",
+			false,
+			"opentelemetry-collector-contrib/1.0 (ContainerInsights)",
+		},
+		{
+			"enhanced container insights EKS",
+			component.BuildInfo{Command: "opentelemetry-collector-contrib", Version: "1.0"},
+			"/aws/containerinsights/eks-cluster-name/performance",
+			true,
+			"opentelemetry-collector-contrib/1.0 (EnhancedContainerInsights)",
+		},
+		{
+			"negative - enhanced container insights ECS",
+			component.BuildInfo{Command: "opentelemetry-collector-contrib", Version: "1.0"},
+			"/aws/containerinsights/eks-cluster-name/performance",
+			true,
 			"opentelemetry-collector-contrib/1.0 (ContainerInsights)",
 		},
 	}
@@ -563,7 +584,7 @@ func TestUserAgent(t *testing.T) {
 	session, _ := session.NewSession()
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cwlog := NewClient(logger, &aws.Config{}, tc.buildInfo, tc.logGroupName, 0, session)
+			cwlog := NewClient(logger, &aws.Config{}, tc.buildInfo, tc.logGroupName, 0, session, false)
 			logClient := cwlog.svc.(*cloudwatchlogs.CloudWatchLogs)
 
 			req := request.New(aws.Config{}, metadata.ClientInfo{}, logClient.Handlers, nil, &request.Operation{


### PR DESCRIPTION
**Description:** Adding a config flag for the emf exporter that will tweak the user agent string for enhanced container insights

The `matchEnhancedContainerInsightsPattern` is intentionally more strict because enhanced is only supported in EKS, not ECS

**Testing:** I added some test code and verified I saw the expected log messages.


```
	client.Handlers.Build.PushFrontNamed(newCollectorUserAgentHandler(buildInfo, logGroupName, enhancedContainerInsights))

	svc := newCloudWatchLogClient(client, logRetention, logger)
	svc.logger.Warn("CHAD - NewClient", zap.String("logGroupName", logGroupName), zap.Bool("enhanced", enhancedContainerInsights))

	if enhancedContainerInsights && matchEnhancedContainerInsightsPattern(logGroupName) {
		svc.logger.Warn("CHAD - NewClient - ENHANCED")
	} else if matchContainerInsightsPattern(logGroupName) {
		svc.logger.Warn("CHAD - NewClient - regular")
	} else {
		svc.logger.Warn("CHAD - none of the above")
	}
```

```
2023-08-15T20:23:37.046Z	warn	cwlogs@v0.79.0/cwlog_client.go:68	CHAD - NewClient	{"kind": "exporter", "data_type": "metrics", "name": "awsemf/containerinsights", "logGroupName": "/aws/containerinsights/{ClusterName}/performance", "enhanced": true}
2023-08-15T20:23:37.046Z	warn	cwlogs@v0.79.0/cwlog_client.go:71	CHAD - NewClient - ENHANCED	{"kind": "exporter", "data_type": "metrics", "name": "awsemf/containerinsights"}
```

**Documentation:** N/A