### PR TITLE
type and Type are overloaded in container insights emf output, remap …

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
@@ -132,6 +132,16 @@ func NewPrometheusScraper(opts PrometheusScraperOpts) (*PrometheusScraper, error
 				Regex:        relabel.MustNewRegexp(controlPlaneMetricsAllowRegex),
 				Action:       relabel.Keep,
 			},
+			// type conflicts with the log Type in the container insights output format, it needs to be replaced and dropped
+			{
+				Regex:       relabel.MustNewRegexp("^type$"),
+				Replacement: "kubernetes_type",
+				Action:      relabel.LabelMap,
+			},
+			{
+				Regex:  relabel.MustNewRegexp("^type$"),
+				Action: relabel.LabelDrop,
+			},
 		},
 	}
 

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
@@ -119,7 +119,7 @@ func NewPrometheusScraper(opts PrometheusScraperOpts) (*PrometheusScraper, error
 							"Version":          model.LabelValue("0"),
 							"Sources":          model.LabelValue("[\"apiserver\"]"),
 							"NodeName":         model.LabelValue(os.Getenv("HOST_NAME")),
-							"Type":             model.LabelValue("control_plane"),
+							"Type":             model.LabelValue("ControlPlane"),
 						},
 					},
 				},

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper_test.go
@@ -223,7 +223,7 @@ func TestNewPrometheusScraperEndToEnd(t *testing.T) {
 							"Version":          model.LabelValue("0"),
 							"Sources":          model.LabelValue("[\"apiserver\"]"),
 							"NodeName":         model.LabelValue("test"),
-							"Type":             model.LabelValue("control_plane"),
+							"Type":             model.LabelValue("ControlPlane"),
 						},
 					},
 				},

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper_test.go
@@ -56,6 +56,7 @@ type mockConsumer struct {
 	t                *testing.T
 	up               *bool
 	httpConnected    *bool
+	relabeled        *bool
 	rpcDurationTotal *bool
 }
 
@@ -74,6 +75,10 @@ func (m mockConsumer) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) er
 		if metric.Name() == "http_connected_total" {
 			assert.Equal(m.t, float64(15), metric.Sum().DataPoints().At(0).DoubleValue())
 			*m.httpConnected = true
+
+			_, relabeled := metric.Sum().DataPoints().At(0).Attributes().Get("kubernetes_port")
+			_, originalLabel := metric.Sum().DataPoints().At(0).Attributes().Get("port")
+			*m.relabeled = relabeled && !originalLabel
 		}
 		if metric.Name() == "rpc_duration_total" {
 			*m.rpcDurationTotal = true
@@ -149,12 +154,14 @@ func TestNewPrometheusScraperEndToEnd(t *testing.T) {
 
 	upPtr := false
 	httpPtr := false
+	relabeledPtr := false
 	rpcDurationTotalPtr := false
 
 	consumer := mockConsumer{
 		t:                t,
 		up:               &upPtr,
 		httpConnected:    &httpPtr,
+		relabeled:        &relabeledPtr,
 		rpcDurationTotal: &rpcDurationTotalPtr,
 	}
 
@@ -229,6 +236,16 @@ func TestNewPrometheusScraperEndToEnd(t *testing.T) {
 				Regex:        relabel.MustNewRegexp("http_connected_total"),
 				Action:       relabel.Keep,
 			},
+			{
+				// type conflicts with the log Type in the container insights output format
+				Regex:       relabel.MustNewRegexp("^port$"),
+				Replacement: "kubernetes_port",
+				Action:      relabel.LabelMap,
+			},
+			{
+				Regex:  relabel.MustNewRegexp("^port"),
+				Action: relabel.LabelDrop,
+			},
 		},
 	}
 
@@ -260,5 +277,6 @@ func TestNewPrometheusScraperEndToEnd(t *testing.T) {
 
 	assert.True(t, *consumer.up)
 	assert.True(t, *consumer.httpConnected)
+	assert.True(t, *consumer.relabeled)
 	assert.False(t, *consumer.rpcDurationTotal) // this will get filtered out by our metric relabel config
 }


### PR DESCRIPTION
**Description:** There are "dupe" type and Type fields in the container insights output.  This is particularly confusing when using containerInsights, which munges the type and Type fields together.

To resolve we can remap type to kubernetes_type

Issue identified by Luca Bruno

I also changed the `control_plane` type string to `ControlPlane` to match our existing pattern

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** 

![Screen Shot 2023-08-23 at 4 36 21 PM](https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/5192710/893fde52-25ad-456f-8674-36c969f7282e)

**Documentation:** N/A