### PR TITLE
fix typo in control plane metric allow list

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
@@ -43,7 +43,7 @@ const (
 
 var (
 	controlPlaneMetricAllowList = []string{
-		"apiserver_storage_oapiserver_storage_objectsbjects",
+		"apiserver_storage_objects",
 		"apiserver_request_total",
 		"apiserver_request_duration_seconds.*",
 		"apiserver_admission_controller_admission_duration_seconds.*",


### PR DESCRIPTION
**Description:** There is a typo in the metric allow list

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** 
![Screen Shot 2023-08-24 at 12 25 12 PM](https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/5192710/ba9f649b-ee1f-42e1-9889-3591e3d7fad7)

**Documentation:** <Describe the documentation added.>