### PR TITLE
Pod age

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -117,14 +117,14 @@ const (
 	ReplicasDesired                   = "replicas_desired"
 	ReplicasReady                     = "replicas_ready"
 
-	RunningPodCount       = "number_of_running_pods"
-	RunningContainerCount = "number_of_running_containers"
-	ContainerCount        = "number_of_containers"
-	NodeCount             = "node_count"
-	FailedNodeCount       = "failed_node_count"
-	ContainerRestartCount = "number_of_container_restarts"
-	RunningTaskCount      = "number_of_running_tasks"
-
+	RunningPodCount          = "number_of_running_pods"
+	RunningContainerCount    = "number_of_running_containers"
+	ContainerCount           = "number_of_containers"
+	NodeCount                = "node_count"
+	FailedNodeCount          = "failed_node_count"
+	ContainerRestartCount    = "number_of_container_restarts"
+	RunningTaskCount         = "number_of_running_tasks"
+	Age                      = "age"
 	DiskIOServiceBytesPrefix = "diskio_io_service_bytes_"
 	DiskIOServicedPrefix     = "diskio_io_serviced_"
 	DiskIOAsync              = "Async"
@@ -162,6 +162,7 @@ const (
 	// unit
 	UnitBytes       = "Bytes"
 	UnitMegaBytes   = "Megabytes"
+	UnitSeconds     = "Seconds"
 	UnitNanoSecond  = "Nanoseconds"
 	UnitBytesPerSec = "Bytes/Second"
 	UnitCount       = "Count"
@@ -280,5 +281,6 @@ func init() {
 		ContainerCount:        UnitCount,
 		ContainerRestartCount: UnitCount,
 		RunningTaskCount:      UnitCount,
+		Age:                   UnitSeconds,
 	}
 }

--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -735,6 +735,12 @@ kubectl apply -f config.yaml
 | pod_status_ready                      | Count        |
 | pod_status_scheduled                  | Count        |
 | pod_status_unknown                    | Count        |
+| pod_status_failed                     | Count        |
+| pod_status_pending                    | Count        |
+| pod_status_running                    | Count        |
+| pod_status_succeeded                  | Count        |
+| pod_age                               | Seconds      |
+
 
 | Resource Attribute   |
 |----------------------|

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -478,6 +478,8 @@ func (p *PodStore) addStatus(metric CIMetric, pod *corev1.Pod) {
 		if p.includeEnhancedMetrics {
 			p.addPodStatusMetrics(metric, pod)
 			p.addPodConditionMetrics(metric, pod)
+			podAge := time.Since(pod.CreationTimestamp.Time)
+			metric.AddField(ci.MetricName(ci.TypePod, ci.Age), podAge.Seconds())
 		}
 
 		var curContainerRestarts int

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -346,6 +346,7 @@ const (
 	PodUnknownMetricName   = "pod_status_unknown"
 	PodReadyMetricName     = "pod_status_ready"
 	PodScheduledMetricName = "pod_status_scheduled"
+	PodAgeMetricName       = "pod_age"
 )
 
 func TestPodStore_enhanced_metrics_disabled(t *testing.T) {
@@ -391,6 +392,14 @@ func TestPodStore_addStatus_adds_pod_succeeded_metric(t *testing.T) {
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodPendingMetricName))
 	assert.Equal(t, 0, decoratedResultMetric.GetField(PodRunningMetricName))
 	assert.Equal(t, 1, decoratedResultMetric.GetField(PodSucceededMetricName))
+}
+
+func TestPodStore_addStatus_pod_age(t *testing.T) {
+	decoratedResultMetric := runAddStatusToGetDecoratedCIMetric("./test_resources/pod_in_phase_succeeded.json", true)
+	year := time.Hour * 24 * 365
+
+	assert.Greater(t, decoratedResultMetric.GetField(PodAgeMetricName), 3*year.Seconds())
+	assert.Less(t, decoratedResultMetric.GetField(PodAgeMetricName), 100*year.Seconds())
 }
 
 func TestPodStore_addStatus_enhanced_metrics_disabled(t *testing.T) {


### PR DESCRIPTION
**Description:** Add pod age metric

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Tested end-to-end

old pod (~3 days old)
![Screen Shot 2023-08-24 at 3 27 23 PM](https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/5192710/7b7c8d7e-b331-4acb-a47f-0d5af6eb9b37)

new pod (<5 minutes old).  The log is from when it was a few seconds old
![Screen Shot 2023-08-24 at 3 41 58 PM](https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/5192710/ca5083e3-e608-4d5c-ac8c-36ef0a361068)

**Documentation:** updated readme