### PR TITLE
Add fallback shared config files for credential ordering.

### DIFF
--- a/internal/aws/awsutil/shared_config.go
+++ b/internal/aws/awsutil/shared_config.go
@@ -1,0 +1,95 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsutil // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil"
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+)
+
+const (
+	envAwsSdkLoadConfig = "AWS_SDK_LOAD_CONFIG"
+	// nolint:gosec
+	envAwsSharedCredentialsFile = "AWS_SHARED_CREDENTIALS_FILE"
+	envAwsSharedConfigFile      = "AWS_CONFIG_FILE"
+)
+
+// getFallbackSharedConfigFiles follows the same logic as the AWS SDK but takes a getUserHomeDir
+// function.
+func getFallbackSharedConfigFiles(userHomeDirProvider func() string) []string {
+	var sharedCredentialsFile, sharedConfigFile string
+	setFromEnvVal(&sharedCredentialsFile, envAwsSharedCredentialsFile)
+	setFromEnvVal(&sharedConfigFile, envAwsSharedConfigFile)
+	if sharedCredentialsFile == "" {
+		sharedCredentialsFile = defaultSharedCredentialsFile(userHomeDirProvider())
+	}
+	if sharedConfigFile == "" {
+		sharedConfigFile = defaultSharedConfig(userHomeDirProvider())
+	}
+	var cfgFiles []string
+	enableSharedConfig, _ := strconv.ParseBool(os.Getenv(envAwsSdkLoadConfig))
+	if enableSharedConfig {
+		cfgFiles = append(cfgFiles, sharedConfigFile)
+	}
+	return append(cfgFiles, sharedCredentialsFile)
+}
+
+func setFromEnvVal(dst *string, keys ...string) {
+	for _, k := range keys {
+		if v := os.Getenv(k); len(v) != 0 {
+			*dst = v
+			break
+		}
+	}
+}
+
+func defaultSharedCredentialsFile(dir string) string {
+	return filepath.Join(dir, ".aws", "credentials")
+}
+
+func defaultSharedConfig(dir string) string {
+	return filepath.Join(dir, ".aws", "config")
+}
+
+// backwardsCompatibleUserHomeDir provides the home directory based on
+// environment variables.
+//
+// Based on v1.44.106 of the AWS SDK.
+func backwardsCompatibleUserHomeDir() string {
+	home, _ := os.UserHomeDir()
+	return home
+}
+
+// currentUserHomeDir attempts to use the environment variables before falling
+// back on the current user's home directory.
+//
+// Based on v1.44.332 of the AWS SDK.
+func currentUserHomeDir() string {
+	var home string
+
+	home = backwardsCompatibleUserHomeDir()
+	if len(home) > 0 {
+		return home
+	}
+
+	currUser, _ := user.Current()
+	if currUser != nil {
+		home = currUser.HomeDir
+	}
+
+	return home
+}

--- a/internal/aws/awsutil/shared_config_test.go
+++ b/internal/aws/awsutil/shared_config_test.go
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFallbackSharedConfigFiles(t *testing.T) {
+	noOpGetUserHomeDir := func() string { return "home" }
+	t.Setenv(envAwsSdkLoadConfig, "true")
+	t.Setenv(envAwsSharedCredentialsFile, "credentials")
+	t.Setenv(envAwsSharedConfigFile, "config")
+
+	got := getFallbackSharedConfigFiles(noOpGetUserHomeDir)
+	assert.Equal(t, []string{"config", "credentials"}, got)
+
+	t.Setenv(envAwsSdkLoadConfig, "false")
+	got = getFallbackSharedConfigFiles(noOpGetUserHomeDir)
+	assert.Equal(t, []string{"credentials"}, got)
+
+	t.Setenv(envAwsSdkLoadConfig, "true")
+	t.Setenv(envAwsSharedCredentialsFile, "")
+	t.Setenv(envAwsSharedConfigFile, "")
+
+	got = getFallbackSharedConfigFiles(noOpGetUserHomeDir)
+	assert.Equal(t, []string{defaultSharedConfig("home"), defaultSharedCredentialsFile("home")}, got)
+}


### PR DESCRIPTION
**Description:** 
The AWS SDK implementation for getting the user home directory for the default shared config files changed from purely environment variables ([v1.44.106](https://github.com/aws/aws-sdk-go/blob/v1.44.106/internal/shareddefaults/shared_config.go#L33)) to a fallback on getting it from the OS in [more recent versions](https://github.com/aws/aws-sdk-go/blame/v1.44.332/internal/shareddefaults/shared_config.go#L32). This change breaks the credential ordering when running as root with systemd. In the previous version, the environment variables would not resolve properly and would result in the SDK trying to use `.aws/credentials` rather than `/root/.aws/credentials`, which would allow it to fallthrough to the EC2RoleProvider.

Sets the fallback shared config files using the backwards compatible user home directory provider. Logs a warning if the EC2RoleProvider is used and the new user home directory provider would have found valid files.

**Link to tracking Issue:** See https://github.com/aws/amazon-cloudwatch-agent/pull/834

**Testing:** Did manual testing by running `aws configure` for the root user and running a standard config.

```
2023-09-06T15:52:40.061Z	debug	awsutil@v0.79.0/conn.go:377	Fallback shared config file(s)	{"kind": "exporter", "data_type": "logs", "name": "awscloudwatchlogs/emf_logs", "files": [".aws/credentials"]}
2023-09-06T15:52:40.063Z	debug	awsutil@v0.79.0/conn.go:401	Using credential from session	{"kind": "exporter", "data_type": "logs", "name": "awscloudwatchlogs/emf_logs", "access-key": "<ACCESSKEY>", "provider": "EC2RoleProvider"}
2023-09-06T15:52:40.063Z	warn	awsutil@v0.79.0/conn.go:412	Unused shared config file(s) found.	{"kind": "exporter", "data_type": "logs", "name": "awscloudwatchlogs/emf_logs", "files": ["/root/.aws/credentials"]}
```

**Documentation:** N/A