### PR TITLE
Modify confighttp and resourcedetection packages to allow for apm translations 

### DIFF
--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -32,7 +32,7 @@ type HTTPClientSettings struct {
 	Endpoint string `mapstructure:"endpoint"`
 
 	// TLSSetting struct exposes TLS client configuration.
-	TLSSetting configtls.TLSClientSetting `mapstructure:"tls"`
+	TLSSetting configtls.TLSClientSetting `mapstructure:"tls,omitempty"`
 
 	// ReadBufferSize for HTTP client. See http.Transport.ReadBufferSize.
 	ReadBufferSize int `mapstructure:"read_buffer_size"`
@@ -49,7 +49,7 @@ type HTTPClientSettings struct {
 	Headers map[string]configopaque.String `mapstructure:"headers"`
 
 	// Custom Round Tripper to allow for individual components to intercept HTTP requests
-	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error)
+	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error) `mapstructure:"-"`
 
 	// Auth configuration for outgoing HTTP calls.
 	Auth *configauth.Authentication `mapstructure:"auth"`

--- a/exporter/lokiexporter/factory_test.go
+++ b/exporter/lokiexporter/factory_test.go
@@ -21,6 +21,7 @@ const (
 func TestExporter_new(t *testing.T) {
 	t.Run("with valid config", func(t *testing.T) {
 		config := &Config{
+
 			HTTPClientSettings: confighttp.HTTPClientSettings{
 				Endpoint: validEndpoint,
 			},

--- a/processor/resourcedetectionprocessor/go.mod
+++ b/processor/resourcedetectionprocessor/go.mod
@@ -126,6 +126,8 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/e
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders => ../../internal/metadataproviders
 
+replace go.opentelemetry.io/collector/config/confighttp => ../../config/confighttp
+
 retract (
 	v0.76.2
 	v0.76.1

--- a/processor/resourcedetectionprocessor/go.sum
+++ b/processor/resourcedetectionprocessor/go.sum
@@ -397,8 +397,6 @@ go.opentelemetry.io/collector/config/configauth v0.84.1-0.20230908201109-ab3d6c5
 go.opentelemetry.io/collector/config/configauth v0.84.1-0.20230908201109-ab3d6c5b6470/go.mod h1:qBSucdTToS7wjtlFWMLFgw0e28IMvR+y+YHEeUMGf94=
 go.opentelemetry.io/collector/config/configcompression v0.84.1-0.20230908201109-ab3d6c5b6470 h1:H3hw9nBKiahm/fYU4nZytkZsqU+fwXwYDodOO4/I2r8=
 go.opentelemetry.io/collector/config/configcompression v0.84.1-0.20230908201109-ab3d6c5b6470/go.mod h1:LaavoxZsro5lL7qh1g9DMifG0qixWPEecW18Qr8bpag=
-go.opentelemetry.io/collector/config/confighttp v0.84.1-0.20230908201109-ab3d6c5b6470 h1:r93l0jZH/52k6Etzk3s0emCbzZNHZHRkD4AZQVVBXnI=
-go.opentelemetry.io/collector/config/confighttp v0.84.1-0.20230908201109-ab3d6c5b6470/go.mod h1:YUrduvwwO7zNGS9V2VrVof2R6liY/TekAyF+tkaRJm4=
 go.opentelemetry.io/collector/config/configopaque v0.84.1-0.20230908201109-ab3d6c5b6470 h1:t6LXR0S4c3FfXGJ/hbwqdHeX7I4G6TOc83SPqGCkKPE=
 go.opentelemetry.io/collector/config/configopaque v0.84.1-0.20230908201109-ab3d6c5b6470/go.mod h1:TPCHaU+QXiEV+JXbgyr6mSErTI9chwQyasDVMdJr3eY=
 go.opentelemetry.io/collector/config/configtelemetry v0.84.1-0.20230908201109-ab3d6c5b6470 h1:KM7Uu6d35GfDEhtB3e0/fuV31gCIk2qqT2Ppq1FLAqA=


### PR DESCRIPTION
**Description:** 
The upstream version of the confighttp package causes issues with apm translations(specifically the `resourcedetectionprocessor` translations):
 - The `CustomRoundTripper` field is of type function and thus cannot be marshalled. We omit it from marshalling in this change. 
 - The default value for `TLSSetting` for the confighttp package causes a null pointer exception during translation. This change omits it from marshalling if default.
 
 Modified go.mod of the resource detection processor to use our version of the confighttp package.

**Testing:** Unit tests functioning as before