### PR TITLE
[exporter/awsxray] Change exporter.awsxray.skiptimestampvalidation feature gate from Alpha to Beta

### DIFF
--- a/.chloggen/xray-exporter-w3c-id-beta-feature-gate.yaml
+++ b/.chloggen/xray-exporter-w3c-id-beta-feature-gate.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsxrayexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Change `exporter.awsxray.skiptimestampvalidation` feature gate from Alpha to Beta"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26553]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/awsxrayexporter/README.md
+++ b/exporter/awsxrayexporter/README.md
@@ -26,10 +26,10 @@ propagated by them using the `X-Amzn-Trace-Id` HTTP header. However, other gener
 supported by replacing fully-random Trace IDs with X-Ray formatted Trace IDs where necessary:
 
 > AWS X-Ray IDs are the same size as W3C Trace Context IDs but differ in that the first 32 bits of a Trace ID
-> is the Unix epoch time when the trace was started. Since X-Ray only allows submission of Trace IDs from the
-> past 30 days, received Trace IDs are checked and spans without a valid timestamp are dropped.
+> is the Unix epoch time when the trace was started. Note that X-Ray only allows submission of Trace IDs from
+> the past 30 days, otherwise the trace is dropped by X-Ray. The Exporter will not validate this timestamp.
 
-This means in order for spans to appear in X-Ray, the client SDK MUST use an X-Ray ID generator. For more
+This means that until X-Ray supports Trace Ids consisting of fully random bits, in order for spans to appear in X-Ray, the client SDK MUST use an X-Ray ID generator. For more
 information, see
 [configuring the X-Ray exporter](https://aws-otel.github.io/docs/getting-started/x-ray#configuring-the-aws-x-ray-exporter).
 

--- a/exporter/awsxrayexporter/awsxray_test.go
+++ b/exporter/awsxrayexporter/awsxray_test.go
@@ -56,14 +56,13 @@ func TestXrayAndW3CSpanTraceExport(t *testing.T) {
 func TestXrayAndW3CSpanTraceResourceExtraction(t *testing.T) {
 	td := constructXrayAndW3CSpanData()
 	logger, _ := zap.NewProduction()
-	assert.Len(t, extractResourceSpans(generateConfig(t), logger, td), 2, "2 spans have xay trace id")
+	assert.Len(t, extractResourceSpans(generateConfig(t), logger, td), 4, "4 spans have xray/w3c trace id")
 }
 
 func TestW3CSpanTraceResourceExtraction(t *testing.T) {
-	t.Skip("Flaky test, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9255")
 	td := constructW3CSpanData()
 	logger, _ := zap.NewProduction()
-	assert.Len(t, extractResourceSpans(generateConfig(t), logger, td), 0, "0 spans have xray trace id")
+	assert.Len(t, extractResourceSpans(generateConfig(t), logger, td), 2, "2 spans have w3c trace id")
 }
 
 func TestTelemetryEnabled(t *testing.T) {
@@ -137,7 +136,6 @@ func constructSpanData() ptrace.Traces {
 	return traces
 }
 
-// nolint:unused
 func constructW3CSpanData() ptrace.Traces {
 	resource := constructResource()
 	traces := ptrace.NewTraces()

--- a/exporter/awsxrayexporter/factory.go
+++ b/exporter/awsxrayexporter/factory.go
@@ -17,7 +17,7 @@ import (
 
 var skipTimestampValidationFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"exporter.awsxray.skiptimestampvalidation",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("Remove XRay's timestamp validation on first 32 bits of trace ID"),
 	featuregate.WithRegisterFromVersion("v0.84.0"))
 

--- a/exporter/awsxrayexporter/factory_test.go
+++ b/exporter/awsxrayexporter/factory_test.go
@@ -36,7 +36,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 			ResourceARN:           "",
 			RoleARN:               "",
 		},
-		skipTimestampValidation: false,
+		skipTimestampValidation: true,
 	}, "failed to create default config")
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Cherry-picking the following commit (scheduled for OTel `v0.86.0` release):
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/26553

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>