### PR TITLE
Omit MultiLineBuilder variable if empty

### DIFF
--- a/pkg/stanza/operator/input/tcp/tcp.go
+++ b/pkg/stanza/operator/input/tcp/tcp.go
@@ -69,15 +69,17 @@ type Config struct {
 
 // BaseConfig is the detailed configuration of a tcp input operator.
 type BaseConfig struct {
-	MaxLogSize       helper.ByteSize             `mapstructure:"max_log_size,omitempty"`
-	ListenAddress    string                      `mapstructure:"listen_address,omitempty"`
-	TLS              *configtls.TLSServerSetting `mapstructure:"tls,omitempty"`
-	AddAttributes    bool                        `mapstructure:"add_attributes,omitempty"`
-	OneLogPerPacket  bool                        `mapstructure:"one_log_per_packet,omitempty"`
-	Encoding         string                      `mapstructure:"encoding,omitempty"`
-	Multiline        tokenize.MultilineConfig    `mapstructure:"multiline,omitempty"`
-	TrimConfig       trim.Config                 `mapstructure:",squash"`
-	MultiLineBuilder MultiLineBuilderFunc        `mapstructure:"multilinebuilder,omitempty"`
+	MaxLogSize      helper.ByteSize             `mapstructure:"max_log_size,omitempty"`
+	ListenAddress   string                      `mapstructure:"listen_address,omitempty"`
+	TLS             *configtls.TLSServerSetting `mapstructure:"tls,omitempty"`
+	AddAttributes   bool                        `mapstructure:"add_attributes,omitempty"`
+	OneLogPerPacket bool                        `mapstructure:"one_log_per_packet,omitempty"`
+	Encoding        string                      `mapstructure:"encoding,omitempty"`
+	Multiline       tokenize.MultilineConfig    `mapstructure:"multiline,omitempty"`
+	TrimConfig      trim.Config                 `mapstructure:",squash"`
+	// omitempty for temporary fix since MultilineBuilder breaks yaml encoding due to being func type.
+	// multilinebuilder should never be used, but Opentelemetry unit test requires a name for any config.
+	MultiLineBuilder MultiLineBuilderFunc `mapstructure:"multilinebuilder,omitempty"`
 }
 
 type MultiLineBuilderFunc func(enc encoding.Encoding) (bufio.SplitFunc, error)

--- a/pkg/stanza/operator/input/tcp/tcp.go
+++ b/pkg/stanza/operator/input/tcp/tcp.go
@@ -77,7 +77,7 @@ type BaseConfig struct {
 	Encoding         string                      `mapstructure:"encoding,omitempty"`
 	Multiline        tokenize.MultilineConfig    `mapstructure:"multiline,omitempty"`
 	TrimConfig       trim.Config                 `mapstructure:",squash"`
-	MultiLineBuilder MultiLineBuilderFunc        `mapstructure:"omitempty"`
+	MultiLineBuilder MultiLineBuilderFunc        `mapstructure:"multilinebuilder,omitempty"`
 }
 
 type MultiLineBuilderFunc func(enc encoding.Encoding) (bufio.SplitFunc, error)

--- a/pkg/stanza/operator/input/tcp/tcp.go
+++ b/pkg/stanza/operator/input/tcp/tcp.go
@@ -77,7 +77,7 @@ type BaseConfig struct {
 	Encoding         string                      `mapstructure:"encoding,omitempty"`
 	Multiline        tokenize.MultilineConfig    `mapstructure:"multiline,omitempty"`
 	TrimConfig       trim.Config                 `mapstructure:",squash"`
-	MultiLineBuilder MultiLineBuilderFunc
+	MultiLineBuilder MultiLineBuilderFunc        `mapstructure:",omitempty"`
 }
 
 type MultiLineBuilderFunc func(enc encoding.Encoding) (bufio.SplitFunc, error)

--- a/pkg/stanza/operator/input/tcp/tcp.go
+++ b/pkg/stanza/operator/input/tcp/tcp.go
@@ -77,7 +77,7 @@ type BaseConfig struct {
 	Encoding         string                      `mapstructure:"encoding,omitempty"`
 	Multiline        tokenize.MultilineConfig    `mapstructure:"multiline,omitempty"`
 	TrimConfig       trim.Config                 `mapstructure:",squash"`
-	MultiLineBuilder MultiLineBuilderFunc        `mapstructure:",omitempty"`
+	MultiLineBuilder MultiLineBuilderFunc        `mapstructure:"omitempty"`
 }
 
 type MultiLineBuilderFunc func(enc encoding.Encoding) (bufio.SplitFunc, error)


### PR DESCRIPTION
**Description:** 
Upstream added a new variable `MultiLineBuilder` which was originally part of the `Multiline` variable that will be omitted if empty. Since `MultiLineBuilder` is a func type, yaml encoder cannot marshal it thus causing issues when creating the yaml file.

**Testing:** 
Relying on unit test. Also tested on agent side.