### PR TITLE
add pulse metadata flag in PLE user-agent

### DIFF
--- a/exporter/awscloudwatchlogsexporter/exporter.go
+++ b/exporter/awscloudwatchlogsexporter/exporter.go
@@ -61,7 +61,7 @@ func newCwLogsPusher(expConfig *Config, params exp.CreateSettings) (*exporter, e
 	}
 
 	// create CWLogs client with aws session config
-	svcStructuredLog := cwlogs.NewClient(params.Logger, awsConfig, params.BuildInfo, expConfig.LogGroupName, expConfig.LogRetention, expConfig.Tags, session, false)
+	svcStructuredLog := cwlogs.NewClient(params.Logger, awsConfig, params.BuildInfo, expConfig.LogGroupName, expConfig.LogRetention, expConfig.Tags, session)
 	collectorIdentifier, err := uuid.NewRandom()
 
 	if err != nil {

--- a/exporter/awsemfexporter/emf_exporter_test.go
+++ b/exporter/awsemfexporter/emf_exporter_test.go
@@ -361,3 +361,58 @@ func TestIsEnhancedContainerInsights(t *testing.T) {
 	cfg.DisableMetricExtraction = true
 	assert.False(t, isEnhancedContainerInsights(cfg))
 }
+
+func TestIsPulseApmEnabled(t *testing.T) {
+
+	tests := []struct {
+		name            string
+		metricNameSpace string
+		logGroupName    string
+		expectedResult  bool
+	}{
+		{
+			"validPulseEMF",
+			"AWS/APM",
+			"/aws/apm/eks",
+			true,
+		},
+		{
+			"invalidPulseLogsGroup",
+			"AWS/APM",
+			"/nonaws/apm/eks",
+			false,
+		},
+		{
+			"invalidPulseMetricNamespace",
+			"NonAWS/APM",
+			"/aws/apm/eks",
+			false,
+		},
+		{
+			"invalidPulseEMF",
+			"NonAWS/APM",
+			"/nonaws/apm/eks",
+			false,
+		},
+		{
+			"defaultConfig",
+			"",
+			"",
+			false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			factory := NewFactory()
+			cfg := factory.CreateDefaultConfig().(*Config)
+			if len(tc.metricNameSpace) > 0 {
+				cfg.Namespace = tc.metricNameSpace
+			}
+			if len(tc.logGroupName) > 0 {
+				cfg.LogGroupName = tc.logGroupName
+			}
+
+			assert.Equal(t, isPulseApmEnabled(cfg), tc.expectedResult)
+		})
+	}
+}

--- a/internal/aws/cwlogs/cwlog_client.go
+++ b/internal/aws/cwlogs/cwlog_client.go
@@ -39,6 +39,24 @@ type Client struct {
 	tags         map[string]*string
 	logger       *zap.Logger
 }
+type UserAgentOption func(*UserAgentFlag)
+
+type UserAgentFlag struct {
+	isEnhancedContainerInsights bool
+	isPulseApm                  bool
+}
+
+func WithEnabledContainerInsights(flag bool) UserAgentOption {
+	return func(ua *UserAgentFlag) {
+		ua.isEnhancedContainerInsights = flag
+	}
+}
+
+func WithEnabledPulseApm(flag bool) UserAgentOption {
+	return func(ua *UserAgentFlag) {
+		ua.isPulseApm = flag
+	}
+}
 
 // Create a log client based on the actual cloudwatch logs client.
 func newCloudWatchLogClient(svc cloudwatchlogsiface.CloudWatchLogsAPI, logRetention int64, tags map[string]*string, logger *zap.Logger) *Client {
@@ -50,12 +68,21 @@ func newCloudWatchLogClient(svc cloudwatchlogsiface.CloudWatchLogsAPI, logRetent
 }
 
 // NewClient create Client
-func NewClient(logger *zap.Logger, awsConfig *aws.Config, buildInfo component.BuildInfo, logGroupName string, logRetention int64, tags map[string]*string, sess *session.Session, enhancedContainerInsights bool) *Client {
+func NewClient(logger *zap.Logger, awsConfig *aws.Config, buildInfo component.BuildInfo, logGroupName string, logRetention int64, tags map[string]*string, sess *session.Session, opts ...UserAgentOption) *Client {
 	client := cloudwatchlogs.New(sess, awsConfig)
 	client.Handlers.Build.PushBackNamed(handler.NewRequestCompressionHandler([]string{"PutLogEvents"}, logger))
 	client.Handlers.Build.PushBackNamed(handler.RequestStructuredLogHandler)
-	// temporarily disable the flag
-	client.Handlers.Build.PushFrontNamed(newCollectorUserAgentHandler(buildInfo, logGroupName, enhancedContainerInsights))
+
+	// Loop through each option
+	option := &UserAgentFlag{
+		isEnhancedContainerInsights: false,
+		isPulseApm:                  false,
+	}
+	for _, opt := range opts {
+		opt(option)
+	}
+
+	client.Handlers.Build.PushFrontNamed(newCollectorUserAgentHandler(buildInfo, logGroupName, option))
 	return newCloudWatchLogClient(client, logRetention, tags, logger)
 }
 
@@ -190,13 +217,20 @@ func (client *Client) CreateStream(logGroup, streamName *string) (token string, 
 	return "", nil
 }
 
-func newCollectorUserAgentHandler(buildInfo component.BuildInfo, logGroupName string, enhancedContainerInsights bool) request.NamedHandler {
-	fn := request.MakeAddToUserAgentHandler(buildInfo.Command, buildInfo.Version)
-	if enhancedContainerInsights && enhancedContainerInsightsEKSPattern.MatchString(logGroupName) {
-		fn = request.MakeAddToUserAgentHandler(buildInfo.Command, buildInfo.Version, "EnhancedEKSContainerInsights")
-	} else if containerInsightsRegexPattern.MatchString(logGroupName) {
-		fn = request.MakeAddToUserAgentHandler(buildInfo.Command, buildInfo.Version, "ContainerInsights")
+func newCollectorUserAgentHandler(buildInfo component.BuildInfo, logGroupName string, userAgentFlag *UserAgentFlag) request.NamedHandler {
+	extraStr := ""
+
+	switch {
+	case userAgentFlag.isEnhancedContainerInsights && enhancedContainerInsightsEKSPattern.MatchString(logGroupName):
+		extraStr = "EnhancedEKSContainerInsights"
+	case containerInsightsRegexPattern.MatchString(logGroupName):
+		extraStr = "ContainerInsights"
+	case userAgentFlag.isPulseApm:
+		extraStr = "Pulse"
 	}
+
+	fn := request.MakeAddToUserAgentHandler(buildInfo.Command, buildInfo.Version, extraStr)
+
 	return request.NamedHandler{
 		Name: "otel.collector.UserAgentHandler",
 		Fn:   fn,


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Add pulse metadata flag in PLE user-agent in EMF exporter, so CWLogs backend can indicate EMF logs request type for the corresponding actions.


**Testing:** <Describe what testing was performed and which tests were added.>
UnitTest
