### PR TITLE
Segment split

### DIFF
--- a/.chloggen/aws_exporter_localrootspans.yaml
+++ b/.chloggen/aws_exporter_localrootspans.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsxrayexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: AWS X-Ray exporter to make local root spans a segment for internal/service spans and subsegment + segment for client/producer/consumer spans.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [102]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -105,7 +105,7 @@ func extractResourceSpans(config component.Config, logger *zap.Logger, td ptrace
 		for j := 0; j < rspans.ScopeSpans().Len(); j++ {
 			spans := rspans.ScopeSpans().At(j).Spans()
 			for k := 0; k < spans.Len(); k++ {
-				documentsForSpan, localErr := translator.MakeSegmentDocumentStrings(
+				documentsForSpan, localErr := translator.MakeSegmentDocuments(
 					spans.At(k), resource,
 					config.(*Config).IndexedAttributes,
 					config.(*Config).IndexAllAttributes,

--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -105,17 +105,21 @@ func extractResourceSpans(config component.Config, logger *zap.Logger, td ptrace
 		for j := 0; j < rspans.ScopeSpans().Len(); j++ {
 			spans := rspans.ScopeSpans().At(j).Spans()
 			for k := 0; k < spans.Len(); k++ {
-				document, localErr := translator.MakeSegmentDocumentString(
+				documentsForSpan, localErr := translator.MakeSegmentDocumentStrings(
 					spans.At(k), resource,
 					config.(*Config).IndexedAttributes,
 					config.(*Config).IndexAllAttributes,
 					config.(*Config).LogGroupNames,
 					config.(*Config).skipTimestampValidation)
+
 				if localErr != nil {
 					logger.Debug("Error translating span.", zap.Error(localErr))
 					continue
 				}
-				documents = append(documents, &document)
+
+				for _, v := range documentsForSpan {
+					documents = append(documents, &v)
+				}
 			}
 		}
 	}

--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -117,8 +117,8 @@ func extractResourceSpans(config component.Config, logger *zap.Logger, td ptrace
 					continue
 				}
 
-				for _, v := range documentsForSpan {
-					documents = append(documents, &v)
+				for l := range documentsForSpan {
+					documents = append(documents, &documentsForSpan[l])
 				}
 			}
 		}

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -36,9 +36,13 @@ const (
 
 // x-ray only span attributes - https://github.com/open-telemetry/opentelemetry-java-contrib/pull/802
 const (
-	awsLocalService  = "aws.local.service"
-	awsRemoteService = "aws.remote.service"
-	awsSpanKind      = "aws.span.kind"
+	awsLocalService    = "aws.local.service"
+	awsRemoteService   = "aws.remote.service"
+	awsLocalOperation  = "aws.local.operation"
+	awsRemoteOperation = "aws.remote.operation"
+	remoteTarget       = "remoteTarget"
+	awsSpanKind        = "aws.span.kind"
+	k8sRemoteNamespace = "K8s.RemoteNamespace"
 )
 
 var (
@@ -66,10 +70,10 @@ const (
 )
 
 var removeAnnotationsFromServiceSegment = []string{
-	"aws.remote.service",
-	"aws.remote.operation",
-	"remote.target",
-	"K8s.RemoteNamespace",
+	awsRemoteService,
+	awsRemoteOperation,
+	remoteTarget,
+	k8sRemoteNamespace,
 }
 
 var (

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -91,11 +91,11 @@ func MakeSegmentDocuments(span ptrace.Span, resource pcommon.Resource, indexedAt
 	return nil, err
 }
 
-// HasDependencySubsegment We will move to using isRemote once the collector supports deserializing it. Until then, we will rely on aws.span.kind.
 func HasDependencySubsegment(span ptrace.Span) bool {
 	return (span.Kind() != ptrace.SpanKindServer) && (span.Kind() != ptrace.SpanKindInternal)
 }
 
+// IsLocalRoot We will move to using isRemote once the collector supports deserializing it. Until then, we will rely on aws.span.kind.
 func IsLocalRoot(span ptrace.Span) bool {
 	if myAwsSpanKind, ok := span.Attributes().Get(awsSpanKind); ok {
 		if localRoot == myAwsSpanKind.Str() {

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -91,118 +91,119 @@ func MakeSegmentDocuments(span ptrace.Span, resource pcommon.Resource, indexedAt
 	return nil, err
 }
 
-// MakeSegmentsFromSpan creates one or more segments from a span
-func MakeSegmentsFromSpan(span ptrace.Span, resource pcommon.Resource, indexedAttrs []string, indexAllAttrs bool, logGroupNames []string, skipTimestampValidation bool) ([]*awsxray.Segment, error) {
-	var isLocalRoot = false
+// HasDependencySubsegment We will move to using isRemote once the collector supports deserializing it. Until then, we will rely on aws.span.kind.
+func HasDependencySubsegment(span ptrace.Span) bool {
+	return (span.Kind() != ptrace.SpanKindServer) && (span.Kind() != ptrace.SpanKindInternal)
+}
 
+func IsLocalRoot(span ptrace.Span) bool {
 	if myAwsSpanKind, ok := span.Attributes().Get(awsSpanKind); ok {
 		if localRoot == myAwsSpanKind.Str() {
-			isLocalRoot = true
+			return true
 		}
 	}
 
-	if !isLocalRoot {
-		segment, err := MakeSegment(span, resource, indexedAttrs, indexAllAttrs, logGroupNames, skipTimestampValidation)
+	return false
+}
 
-		if err != nil {
-			return nil, err
-		}
+func CreateDependencySubsegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []string, indexAllAttrs bool, logGroupNames []string, skipTimestampValidation bool, serviceSegmentID pcommon.SpanID) (*awsxray.Segment, error) {
+	var dependencySpan = ptrace.NewSpan()
+	span.CopyTo(dependencySpan)
 
-		return []*awsxray.Segment{segment}, nil
+	dependencySpan.SetParentSpanID(serviceSegmentID)
+
+	dependencySubsegment, err := MakeSegment(dependencySpan, resource, indexedAttrs, indexAllAttrs, logGroupNames, skipTimestampValidation)
+
+	if err != nil {
+		return nil, err
 	}
 
-	var hasDependency = (span.Kind() != ptrace.SpanKindServer) && (span.Kind() != ptrace.SpanKindInternal)
-	var segments []*awsxray.Segment
+	// Set the name
+	if myAwsRemoteService, ok := span.Attributes().Get(awsRemoteService); ok {
+		dependencySubsegment.Name = awsxray.String(myAwsRemoteService.Str())
+	}
 
-	var serviceSegmentID = newSegmentID()
+	// Make this a subsegment
+	dependencySubsegment.Type = awsxray.String("subsegment")
 
-	// If it is a dependency, then we need to create a subsegment
-	if hasDependency {
-		var dependencySpan ptrace.Span = ptrace.NewSpan()
-		span.CopyTo(dependencySpan)
+	if dependencySubsegment.Namespace == nil {
+		dependencySubsegment.Namespace = awsxray.String("remote")
+	}
 
-		dependencySpan.SetParentSpanID(serviceSegmentID)
+	// Remove span links from consumer spans
+	if span.Kind() == ptrace.SpanKindConsumer {
+		dependencySubsegment.Links = nil
+	}
 
-		dependencySubsegment, err := MakeSegment(dependencySpan, resource, indexedAttrs, indexAllAttrs, logGroupNames, skipTimestampValidation)
+	return dependencySubsegment, err
+}
 
-		if err != nil {
-			return nil, err
-		}
+func CreateServiceSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []string, indexAllAttrs bool, logGroupNames []string, skipTimestampValidation bool, serviceSegmentID pcommon.SpanID) (*awsxray.Segment, error) {
+	// We always create a segment for the service
+	var serviceSpan ptrace.Span = ptrace.NewSpan()
+	span.CopyTo(serviceSpan)
 
-		// Set the name
-		if myAwsRemoteService, ok := span.Attributes().Get(awsRemoteService); ok {
-			dependencySubsegment.Name = awsxray.String(myAwsRemoteService.Str())
-		}
+	// Set the span id to the one internally generated
+	serviceSpan.SetSpanID(serviceSegmentID)
 
-		// Make this a subsegment
-		dependencySubsegment.Type = awsxray.String("subsegment")
+	removeAnnotations := []string{
+		"aws.remote.service",
+		"aws.remote.operation",
+		"remote.target",
+		"K8s.RemoteNamespace",
+	}
 
-		// Remove span links from consumer spans
-		if span.Kind() == ptrace.SpanKindConsumer {
-			dependencySubsegment.Links = nil
-		}
+	for _, v := range removeAnnotations {
+		serviceSpan.Attributes().Remove(v)
+	}
 
-		segments = append(segments, dependencySubsegment)
+	serviceSegment, err := MakeSegment(serviceSpan, resource, indexedAttrs, indexAllAttrs, logGroupNames, skipTimestampValidation)
 
-		// We always create a segment for the service
-		var serviceSpan ptrace.Span = ptrace.NewSpan()
-		span.CopyTo(serviceSpan)
+	if err != nil {
+		return nil, err
+	}
 
-		// Set the span id to the one internally generated
-		serviceSpan.SetSpanID(serviceSegmentID)
+	// Set the name
+	if myAwsLocalService, ok := span.Attributes().Get(awsLocalService); ok {
+		serviceSegment.Name = awsxray.String(myAwsLocalService.Str())
+	}
 
-		removeAnnotations := []string{
-			"aws.remote.service",
-			"aws.remote.operation",
-			"remote.target",
-			"K8s.RemoteNamespace",
-		}
+	// Remove the HTTP field
+	serviceSegment.HTTP = nil
 
-		for _, v := range removeAnnotations {
-			serviceSpan.Attributes().Remove(v)
-		}
+	// Remove AWS subsegment fields
+	serviceSegment.AWS.Operation = nil
+	serviceSegment.AWS.AccountID = nil
+	serviceSegment.AWS.RemoteRegion = nil
+	serviceSegment.AWS.RequestID = nil
+	serviceSegment.AWS.QueueURL = nil
+	serviceSegment.AWS.TableName = nil
+	serviceSegment.AWS.TableNames = nil
 
-		serviceSegment, err := MakeSegment(serviceSpan, resource, indexedAttrs, indexAllAttrs, logGroupNames, skipTimestampValidation)
-
-		// Set the name
-		if myAwsLocalService, ok := span.Attributes().Get(awsLocalService); ok {
-			serviceSegment.Name = awsxray.String(myAwsLocalService.Str())
-		}
-
-		// Remove the HTTP field
-		serviceSegment.HTTP = nil
-
-		// Remove AWS subsegment fields
-		serviceSegment.AWS.Operation = nil
-		serviceSegment.AWS.AccountID = nil
-		serviceSegment.AWS.RemoteRegion = nil
-		serviceSegment.AWS.RequestID = nil
-		serviceSegment.AWS.QueueURL = nil
-		serviceSegment.AWS.TableName = nil
-		serviceSegment.AWS.TableNames = nil
-
-		// Delete all metadata that does not start with 'otel.resource.'
-		for _, metaDataEntry := range serviceSegment.Metadata {
-			for key := range metaDataEntry {
-				if !strings.HasPrefix(key, "otel.resource.") {
-					delete(metaDataEntry, key)
-				}
+	// Delete all metadata that does not start with 'otel.resource.'
+	for _, metaDataEntry := range serviceSegment.Metadata {
+		for key := range metaDataEntry {
+			if !strings.HasPrefix(key, "otel.resource.") {
+				delete(metaDataEntry, key)
 			}
 		}
-
-		// Make it a segment
-		serviceSegment.Type = nil
-
-		// Remove span links from non-consumer spans
-		if span.Kind() != ptrace.SpanKindConsumer {
-			serviceSegment.Links = nil
-		}
-
-		segments = append(segments, serviceSegment)
-
-		return segments, err
 	}
 
+	// Make it a segment
+	serviceSegment.Type = nil
+
+	// Remote namespace
+	serviceSegment.Namespace = nil
+
+	// Remove span links from non-consumer spans
+	if span.Kind() != ptrace.SpanKindConsumer {
+		serviceSegment.Links = nil
+	}
+
+	return serviceSegment, nil
+}
+
+func CreateServiceSegmentWithoutDependency(span ptrace.Span, resource pcommon.Resource, indexedAttrs []string, indexAllAttrs bool, logGroupNames []string, skipTimestampValidation bool) ([]*awsxray.Segment, error) {
 	segment, err := MakeSegment(span, resource, indexedAttrs, indexAllAttrs, logGroupNames, skipTimestampValidation)
 
 	if err != nil {
@@ -212,7 +213,48 @@ func MakeSegmentsFromSpan(span ptrace.Span, resource pcommon.Resource, indexedAt
 	// Make internal spans a segment
 	segment.Type = nil
 
+	return []*awsxray.Segment{segment}, err
+}
+
+func CreateNonLocalRootSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []string, indexAllAttrs bool, logGroupNames []string, skipTimestampValidation bool) ([]*awsxray.Segment, error) {
+	segment, err := MakeSegment(span, resource, indexedAttrs, indexAllAttrs, logGroupNames, skipTimestampValidation)
+
+	if err != nil {
+		return nil, err
+	}
+
 	return []*awsxray.Segment{segment}, nil
+}
+
+// MakeSegmentsFromSpan creates one or more segments from a span
+func MakeSegmentsFromSpan(span ptrace.Span, resource pcommon.Resource, indexedAttrs []string, indexAllAttrs bool, logGroupNames []string, skipTimestampValidation bool) ([]*awsxray.Segment, error) {
+	if !IsLocalRoot(span) {
+		return CreateNonLocalRootSegment(span, resource, indexedAttrs, indexAllAttrs, logGroupNames, skipTimestampValidation)
+	}
+
+	if !HasDependencySubsegment(span) {
+		return CreateServiceSegmentWithoutDependency(span, resource, indexedAttrs, indexAllAttrs, logGroupNames, skipTimestampValidation)
+	}
+
+	// If it is a local root span and a dependency span, we need to make a segment and subsegment representing the local service and remote service, respectively.
+	var serviceSegmentID = newSegmentID()
+	var segments []*awsxray.Segment
+
+	// Make Dependency Subsegment
+	dependencySubsegment, err := CreateDependencySubsegment(span, resource, indexedAttrs, indexAllAttrs, logGroupNames, skipTimestampValidation, serviceSegmentID)
+	if err != nil {
+		return nil, err
+	}
+	segments = append(segments, dependencySubsegment)
+
+	// Make Service Segment
+	serviceSegment, err := CreateServiceSegment(span, resource, indexedAttrs, indexAllAttrs, logGroupNames, skipTimestampValidation, serviceSegmentID)
+	if err != nil {
+		return nil, err
+	}
+	segments = append(segments, serviceSegment)
+
+	return segments, err
 }
 
 // MakeSegmentDocumentString converts an OpenTelemetry Span to an X-Ray Segment and then serialzies to JSON
@@ -280,7 +322,7 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 	// X-Ray segment names are service names, unlike span names which are methods. Try to find a service name.
 
 	// support x-ray specific service name attributes as segment name if it exists
-	if span.Kind() == ptrace.SpanKindServer || span.Kind() == ptrace.SpanKindConsumer {
+	if span.Kind() == ptrace.SpanKindServer {
 		if localServiceName, ok := attributes.Get(awsLocalService); ok {
 			name = localServiceName.Str()
 		}
@@ -293,7 +335,7 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 		}
 	}
 
-	if span.Kind() == ptrace.SpanKindClient || span.Kind() == ptrace.SpanKindProducer {
+	if span.Kind() == ptrace.SpanKindClient || span.Kind() == ptrace.SpanKindProducer || span.Kind() == ptrace.SpanKindConsumer {
 		if remoteServiceName, ok := attributes.Get(awsRemoteService); ok {
 			name = remoteServiceName.Str()
 		}
@@ -372,16 +414,6 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 
 	if namespace == "" && span.Kind() == ptrace.SpanKindClient {
 		namespace = "remote"
-	}
-
-	if (span.Kind() == ptrace.SpanKindClient ||
-		span.Kind() == ptrace.SpanKindConsumer ||
-		span.Kind() == ptrace.SpanKindProducer) &&
-		segmentType == "subsegment" &&
-		namespace == "" {
-		if _, ok := span.Attributes().Get(awsRemoteService); ok {
-			namespace = "remote"
-		}
 	}
 
 	return &awsxray.Segment{

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -140,11 +140,6 @@ func MakeDependencySubsegmentForLocalRootDependencySpan(span ptrace.Span, resour
 		return nil, err
 	}
 
-	// Set the name
-	if myAwsRemoteService, ok := span.Attributes().Get(awsRemoteService); ok {
-		dependencySubsegment.Name = awsxray.String(myAwsRemoteService.Str())
-	}
-
 	// Make this a subsegment
 	dependencySubsegment.Type = awsxray.String("subsegment")
 

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -1492,7 +1492,7 @@ func TestNotLocalRootInternal(t *testing.T) {
 	assert.Equal(t, "MyInternalService", *segments[0].Name)
 }
 
-func TestNotLocalRoot(t *testing.T) {
+func TestNotLocalRootConsumer(t *testing.T) {
 	spanName := "destination receive"
 	resource := constructDefaultResource()
 	parentSpanID := newSegmentID()
@@ -1517,6 +1517,7 @@ func TestNotLocalRoot(t *testing.T) {
 	assert.Equal(t, 1, len(segments))
 	assert.Nil(t, err)
 
+	// Validate subsegment
 	assert.Equal(t, "subsegment", *segments[0].Type)
 	assert.Equal(t, "myLocalService", *segments[0].Name)
 	assert.Equal(t, parentSpanID.String(), *segments[0].ParentID)

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -1094,7 +1094,7 @@ func TestLocalRootConsumer(t *testing.T) {
 	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKVersion, "1.20.0")
 	resource.Attributes().PutStr(conventions.AttributeTelemetryAutoVersion, "1.2.3")
 
-	span := constructConsumerSpan(parentSpanID, spanName, 0, "OK", attributes)
+	span := constructConsumerSpan(parentSpanID, spanName, 200, "OK", attributes)
 
 	spanLink := span.Links().AppendEmpty()
 	spanLink.SetTraceID(newTraceID())
@@ -1178,7 +1178,7 @@ func TestLocalRootConsumerAWSNamespace(t *testing.T) {
 	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKVersion, "1.20.0")
 	resource.Attributes().PutStr(conventions.AttributeTelemetryAutoVersion, "1.2.3")
 
-	span := constructConsumerSpan(parentSpanID, spanName, 0, "OK", attributes)
+	span := constructConsumerSpan(parentSpanID, spanName, 200, "OK", attributes)
 
 	spanLink := span.Links().AppendEmpty()
 	spanLink.SetTraceID(newTraceID())
@@ -1212,7 +1212,7 @@ func TestLocalRootClient(t *testing.T) {
 	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKVersion, "1.20.0")
 	resource.Attributes().PutStr(conventions.AttributeTelemetryAutoVersion, "1.2.3")
 
-	span := constructClientSpan(parentSpanID, spanName, 0, "OK", attributes)
+	span := constructClientSpan(parentSpanID, spanName, 200, "OK", attributes)
 
 	spanLink := span.Links().AppendEmpty()
 	spanLink.SetTraceID(newTraceID())
@@ -1293,7 +1293,7 @@ func TestLocalRootProducer(t *testing.T) {
 	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKVersion, "1.20.0")
 	resource.Attributes().PutStr(conventions.AttributeTelemetryAutoVersion, "1.2.3")
 
-	span := constructProducerSpan(parentSpanID, spanName, 0, "OK", attributes)
+	span := constructProducerSpan(parentSpanID, spanName, 200, "OK", attributes)
 
 	spanLink := span.Links().AppendEmpty()
 	spanLink.SetTraceID(newTraceID())
@@ -1374,7 +1374,7 @@ func TestLocalRootServer(t *testing.T) {
 	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKVersion, "1.20.0")
 	resource.Attributes().PutStr(conventions.AttributeTelemetryAutoVersion, "1.2.3")
 
-	span := constructServerSpan(parentSpanID, spanName, 0, "OK", attributes)
+	span := constructServerSpan(parentSpanID, spanName, 200, "OK", attributes)
 
 	spanLink := span.Links().AppendEmpty()
 	spanLink.SetTraceID(newTraceID())
@@ -1425,7 +1425,7 @@ func TestLocalRootInternal(t *testing.T) {
 	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKVersion, "1.20.0")
 	resource.Attributes().PutStr(conventions.AttributeTelemetryAutoVersion, "1.2.3")
 
-	span := constructInternalSpan(parentSpanID, spanName, 0, "OK", attributes)
+	span := constructInternalSpan(parentSpanID, spanName, 200, "OK", attributes)
 
 	spanLink := span.Links().AppendEmpty()
 	spanLink.SetTraceID(newTraceID())
@@ -1475,7 +1475,7 @@ func TestNotLocalRootInternal(t *testing.T) {
 	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKVersion, "1.20.0")
 	resource.Attributes().PutStr(conventions.AttributeTelemetryAutoVersion, "1.2.3")
 
-	span := constructInternalSpan(parentSpanID, spanName, 0, "OK", attributes)
+	span := constructInternalSpan(parentSpanID, spanName, 200, "OK", attributes)
 
 	spanLink := span.Links().AppendEmpty()
 	spanLink.SetTraceID(newTraceID())
@@ -1505,7 +1505,7 @@ func TestNotLocalRootConsumer(t *testing.T) {
 	attributes["aws.local.service"] = "myLocalService"
 	attributes["myAnnotationKey"] = "myAnnotationValue"
 
-	span := constructConsumerSpan(parentSpanID, spanName, 0, "OK", attributes)
+	span := constructConsumerSpan(parentSpanID, spanName, 503, "java.lang.NullPointerException", attributes)
 
 	spanLink := span.Links().AppendEmpty()
 	spanLink.SetTraceID(newTraceID())

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -1030,7 +1030,7 @@ func TestConsumerSpanWithAwsRemoteServiceName(t *testing.T) {
 	attributes[conventions.AttributeHTTPHost] = "payment.amazonaws.com"
 	attributes[conventions.AttributeHTTPTarget] = "/"
 	attributes[conventions.AttributeRPCService] = "ABC"
-	attributes[awsLocalService] = "ConsumerService"
+	attributes[awsRemoteService] = "ConsumerService"
 
 	resource := constructDefaultResource()
 	span := constructConsumerSpan(parentSpanID, spanName, 0, "OK", attributes)
@@ -1268,7 +1268,7 @@ func TestLocalRootClient(t *testing.T) {
 	assert.Equal(t, "1.20.0", *segments[1].AWS.XRay.SDKVersion)
 	assert.Equal(t, true, *segments[1].AWS.XRay.AutoInstrumentation)
 	assert.Nil(t, segments[1].AWS.Operation)
-	assert.Equal(t, "remote", *segments[1].Namespace)
+	assert.Nil(t, segments[1].Namespace)
 
 	// Checks these values are the same for both
 	assert.Equal(t, segments[0].StartTime, segments[1].StartTime)
@@ -1519,7 +1519,7 @@ func TestNotLocalRootConsumer(t *testing.T) {
 
 	// Validate subsegment
 	assert.Equal(t, "subsegment", *segments[0].Type)
-	assert.Equal(t, "myLocalService", *segments[0].Name)
+	assert.Equal(t, "myRemoteService", *segments[0].Name)
 	assert.Equal(t, parentSpanID.String(), *segments[0].ParentID)
 	assert.Equal(t, 1, len(segments[0].Links))
 }

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -1024,19 +1024,11 @@ func TestConsumerSpanWithAwsRemoteServiceName(t *testing.T) {
 	spanName := "ABC.payment"
 	parentSpanID := newSegmentID()
 	user := "testingT"
-	attributes := make(map[string]interface{})
-	attributes[conventions.AttributeHTTPMethod] = "POST"
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeHTTPHost] = "payment.amazonaws.com"
-	attributes[conventions.AttributeHTTPTarget] = "/"
-	attributes[conventions.AttributeRPCService] = "ABC"
+	attributes := getBasicAttributes()
 	attributes[awsRemoteService] = "ConsumerService"
 
 	resource := constructDefaultResource()
 	span := constructConsumerSpan(parentSpanID, spanName, 0, "Ok", attributes)
-
-	segment, _ := MakeSegment(span, resource, nil, false, nil, false)
-	assert.Equal(t, "ConsumerService", *segment.Name)
 
 	jsonStr, err := MakeSegmentDocumentString(span, resource, nil, false, nil, false)
 
@@ -1213,7 +1205,7 @@ func TestLocalRootConsumer(t *testing.T) {
 	assert.Equal(t, segments[0].EndTime, segments[1].EndTime)
 }
 
-func TestLocalRootConsumerProcess(t *testing.T) {
+func TestNonLocalRootConsumerProcess(t *testing.T) {
 	spanName := "destination operation"
 	resource := getBasicResource()
 	parentSpanID := newSegmentID()
@@ -1472,7 +1464,7 @@ func TestNotLocalRootConsumer(t *testing.T) {
 	// Validate segment
 	assert.Equal(t, "subsegment", *segments[0].Type)
 	assert.Equal(t, "remote", *segments[0].Namespace)
-	assert.Equal(t, "myRemoteService", *segments[0].Name)
+	assert.Equal(t, "MyService", *segments[0].Name)
 }
 
 func TestNotLocalRootClient(t *testing.T) {

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -1167,7 +1167,7 @@ func TestLocalRootConsumerProcess(t *testing.T) {
 	attributes[conventions.AttributeHTTPMethod] = "POST"
 	attributes[conventions.AttributeMessagingOperation] = "receive"
 	attributes["otel.resource.attributes"] = "service.name=myTest"
-	attributes["aws.span.kind"] = "LOCAL_ROOT"
+	attributes["aws.span.kind"] = "Consumer"
 	attributes["aws.local.service"] = "myLocalService"
 	attributes["myAnnotationKey"] = "myAnnotationValue"
 	attributes[awsxray.AWSOperationAttribute] = "UpdateItem"
@@ -1203,7 +1203,7 @@ func TestLocalRootConsumerProcess(t *testing.T) {
 	assert.Equal(t, 1, len(segments[0].Annotations))
 	assert.Equal(t, "myAnnotationValue", segments[0].Annotations["myAnnotationKey"])
 	assert.Equal(t, 4, len(segments[0].Metadata["default"]))
-	assert.Equal(t, "LOCAL_ROOT", segments[0].Metadata["default"]["aws.span.kind"])
+	assert.Equal(t, "Consumer", segments[0].Metadata["default"]["aws.span.kind"])
 	assert.Equal(t, "myLocalService", segments[0].Metadata["default"]["aws.local.service"])
 	assert.Equal(t, "receive", segments[0].Metadata["default"]["messaging.operation"])
 	assert.Equal(t, "service.name=myTest", segments[0].Metadata["default"]["otel.resource.attributes"])

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -1033,7 +1033,7 @@ func TestConsumerSpanWithAwsRemoteServiceName(t *testing.T) {
 	attributes[awsRemoteService] = "ConsumerService"
 
 	resource := constructDefaultResource()
-	span := constructConsumerSpan(parentSpanID, spanName, 0, "OK", attributes)
+	span := constructConsumerSpan(parentSpanID, spanName, 0, "Ok", attributes)
 
 	segment, _ := MakeSegment(span, resource, nil, false, nil, false)
 	assert.Equal(t, "ConsumerService", *segment.Name)
@@ -1136,6 +1136,8 @@ func validateLocalRootServiceSegment(t *testing.T, segment *awsxray.Segment, spa
 	assert.Nil(t, segment.AWS.RequestID)
 	assert.Nil(t, segment.AWS.QueueURL)
 	assert.Nil(t, segment.AWS.TableName)
+	assert.Nil(t, segment.Namespace)
+
 	assert.Nil(t, segment.Namespace)
 }
 
@@ -1318,7 +1320,7 @@ func TestLocalRootProducer(t *testing.T) {
 
 	attributes := getBasicAttributes()
 
-	span := constructProducerSpan(parentSpanID, spanName, 200, "OK", attributes)
+	span := constructProducerSpan(parentSpanID, spanName, 200, "Ok", attributes)
 
 	addSpanLink(span)
 
@@ -1469,7 +1471,7 @@ func TestNotLocalRootConsumer(t *testing.T) {
 
 	// Validate segment
 	assert.Equal(t, "subsegment", *segments[0].Type)
-	//assert.Equal(t, "remote", *segments[0].Namespace)
+	assert.Equal(t, "remote", *segments[0].Namespace)
 	assert.Equal(t, "myRemoteService", *segments[0].Name)
 }
 
@@ -1493,6 +1495,7 @@ func TestNotLocalRootClient(t *testing.T) {
 
 	// Validate segment
 	assert.Equal(t, "subsegment", *segments[0].Type)
+	assert.Equal(t, "remote", *segments[0].Namespace)
 	assert.Equal(t, "myRemoteService", *segments[0].Name)
 }
 
@@ -1516,6 +1519,7 @@ func TestNotLocalRootProducer(t *testing.T) {
 
 	// Validate segment
 	assert.Equal(t, "subsegment", *segments[0].Type)
+	assert.Equal(t, "remote", *segments[0].Namespace)
 	assert.Equal(t, "myRemoteService", *segments[0].Name)
 }
 
@@ -1541,6 +1545,7 @@ func TestNotLocalRootServer(t *testing.T) {
 
 	// Validate segment
 	assert.Nil(t, segments[0].Type)
+	assert.Nil(t, segments[0].Namespace)
 	assert.Equal(t, "myLocalService", *segments[0].Name)
 }
 


### PR DESCRIPTION
Description:
We are adjusting the segment creation to accommodate local root spans.

If a span is a not a local root, then we keep existing behavior.
If it is a local root then:

If it is an Internal or Server span, then promote it to a segment.
Else we will split it into a segment and subsegment. The segment will represent the service operation and the subsegment will represent the dependency (service A calls service B).
Testing:
Unit Testing

Documentation:
None