### PR TITLE
Fix build check issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3538,7 +3538,7 @@ https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9278.
 - [`cumulativetodelta` processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor) to convert cumulative sum metrics to cumulative delta
 
 - [`file` exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/fileexporter) from core repository ([#3474](https://github.com/open-telemetry/opentelemetry-collector/issues/3474))
-- [`jaeger` exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/jaegerexporter) from core repository ([#3474](https://github.com/open-telemetry/opentelemetry-collector/issues/3474))
+- [`jaeger` exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.85.0/exporter/jaegerexporter) from core repository ([#3474](https://github.com/open-telemetry/opentelemetry-collector/issues/3474))
 - [`kafka` exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kafkaexporter) from core repository ([#3474](https://github.com/open-telemetry/opentelemetry-collector/issues/3474))
 - [`opencensus` exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/opencensusexporter) from core repository ([#3474](https://github.com/open-telemetry/opentelemetry-collector/issues/3474))
 - [`prometheus` exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusexporter) from core repository ([#3474](https://github.com/open-telemetry/opentelemetry-collector/issues/3474))

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -1456,21 +1456,21 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 					MetricNameSelectors: []string{"metric(1|3)"},
 				},
 			}, []cWMeasurement{
-			{
-				Namespace:  namespace,
-				Dimensions: [][]string{{}},
-				Metrics: []map[string]string{
-					{
-						"Name": "metric1",
-						"Unit": "Count",
-					},
-					{
-						"Name": "metric3",
-						"Unit": "Seconds",
+				{
+					Namespace:  namespace,
+					Dimensions: [][]string{{}},
+					Metrics: []map[string]string{
+						{
+							"Name": "metric1",
+							"Unit": "Count",
+						},
+						{
+							"Name": "metric3",
+							"Unit": "Seconds",
+						},
 					},
 				},
 			},
-		},
 		},
 		{
 			"label matchers",

--- a/exporter/jaegerthrifthttpexporter/README.md
+++ b/exporter/jaegerthrifthttpexporter/README.md
@@ -16,7 +16,7 @@ This exporter is being deprecated and will be removed in July 2023 as Jaeger sup
 
 This exporter supports sending trace data to [Jaeger](https://www.jaegertracing.io) over Thrift HTTP.
 
-*WARNING:* The [Jaeger gRPC Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/jaegerexporter) is the recommended one for exporting traces from an OpenTelemetry Collector to Jaeger. This Jaeger Thrift Exporter should only be used to export traces to a Jaeger Collector that is unable to expose the [gRPC API](https://www.jaegertracing.io/docs/1.27/apis/#protobuf-via-grpc-stable).
+*WARNING:* The Jaeger gRPC Exporter is the recommended one for exporting traces from an OpenTelemetry Collector to Jaeger. This Jaeger Thrift Exporter should only be used to export traces to a Jaeger Collector that is unable to expose the [gRPC API](https://www.jaegertracing.io/docs/1.27/apis/#protobuf-via-grpc-stable).
 
 ## Configuration
 

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -608,11 +608,7 @@ func (p *PodStore) addPodContainerStatusMetrics(metric CIMetric, pod *corev1.Pod
 			reason := containerStatus.State.Waiting.Reason
 			if reason != "" {
 				if val, ok := ci.WaitingReasonLookup[reason]; ok {
-					if _, foundStatus := possibleStatuses[val]; foundStatus {
-						possibleStatuses[val]++
-					} else {
-						possibleStatuses[val] = 1
-					}
+					possibleStatuses[val]++
 				}
 			}
 		case containerStatus.State.Terminated != nil:
@@ -624,11 +620,7 @@ func (p *PodStore) addPodContainerStatusMetrics(metric CIMetric, pod *corev1.Pod
 
 		if containerStatus.LastTerminationState.Terminated != nil && containerStatus.LastTerminationState.Terminated.Reason != "" {
 			if strings.Contains(containerStatus.LastTerminationState.Terminated.Reason, "OOMKilled") {
-				if _, foundStatus := possibleStatuses[ci.StatusContainerTerminatedReasonOOMKilled]; foundStatus {
-					possibleStatuses[ci.StatusContainerTerminatedReasonOOMKilled]++
-				} else {
-					possibleStatuses[ci.StatusContainerTerminatedReasonOOMKilled] = 1
-				}
+				possibleStatuses[ci.StatusContainerTerminatedReasonOOMKilled]++
 			}
 		}
 	}

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -720,7 +720,7 @@ func TestPodStore_addStatus_enhanced_metrics(t *testing.T) {
 	metric = generateMetric(fields, tags)
 
 	podStore.addStatus(metric, pod)
-	//assert.Equal(t, "Waiting", metric.GetTag(ci.ContainerStatus))
+	// assert.Equal(t, "Waiting", metric.GetTag(ci.ContainerStatus))
 	assert.Equal(t, 2, metric.GetField(ci.MetricName(ci.TypePod, ci.StatusContainerWaiting)))
 	assert.Equal(t, 2, metric.GetField(ci.MetricName(ci.TypePod, ci.StatusContainerWaitingReasonCrashLoopBackOff)))
 	// sparse metrics

--- a/receiver/sqlqueryreceiver/integration_test.go
+++ b/receiver/sqlqueryreceiver/integration_test.go
@@ -443,6 +443,7 @@ func TestPostgresqlIntegrationMetrics(t *testing.T) {
 // This test ensures the collector can connect to an Oracle DB, and properly get metrics. It's not intended to
 // test the receiver itself.
 func TestOracleDBIntegrationMetrics(t *testing.T) {
+	t.Skip("Skipping the test until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27577 is fixed")
 	if runtime.GOARCH == "arm64" {
 		t.Skip("Incompatible with arm64")
 	}


### PR DESCRIPTION
**Description:** Fix build check issues
* Remove dead link. The whole exporter itself will be removed when we upgrade to v0.85.0 since that pulls in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/26546
* Cherry pick https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27578 to skip `TestOracleDBIntegrationMetrics`
* Minor lint fixes

**Link to tracking Issue:** N/A

**Testing:** N/A

**Documentation:** N/A