### PR TITLE
Update segment conversion logic

### DIFF
--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -152,9 +152,9 @@ func MakeDependencySubsegmentForLocalRootDependencySpan(span ptrace.Span, resour
 		dependencySubsegment.Links = nil
 	}
 
-	myAwsRemoteService, _ := span.Attributes().Get(awsRemoteService)
-
-	dependencySubsegment.Name = awsxray.String(myAwsRemoteService.Str())
+	if myAwsRemoteService, ok := span.Attributes().Get(awsRemoteService); ok {
+		dependencySubsegment.Name = awsxray.String(myAwsRemoteService.Str())
+	}
 
 	return dependencySubsegment, err
 }
@@ -356,7 +356,7 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 		}
 	}
 
-	if span.Kind() == ptrace.SpanKindClient || span.Kind() == ptrace.SpanKindProducer {
+	if span.Kind() == ptrace.SpanKindClient || span.Kind() == ptrace.SpanKindProducer || span.Kind() == ptrace.SpanKindConsumer {
 		if remoteServiceName, ok := attributes.Get(awsRemoteService); ok {
 			name = remoteServiceName.Str()
 		}

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -1464,7 +1464,7 @@ func TestNotLocalRootConsumer(t *testing.T) {
 	// Validate segment
 	assert.Equal(t, "subsegment", *segments[0].Type)
 	assert.Equal(t, "remote", *segments[0].Namespace)
-	assert.Equal(t, "MyService", *segments[0].Name)
+	assert.Equal(t, "myRemoteService", *segments[0].Name)
 }
 
 func TestNotLocalRootClient(t *testing.T) {


### PR DESCRIPTION
**Description:**
In this commit, we are fixing a couple small bugs missed in the previous review. First, we are adding a nil-guard when settting dependencySubsegment.Name, to avoid the (unlikely, but possible) scenario where local root dependency spans are created without awsRemoteService. Second, we are updating the common logic for setting segment.Name, which previously only looked at CLIENT/PRODUCER spans, but now needs to look at CONSUMER spans.

**Link to tracking Issue:** N/A, related to comments on https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/111

**Testing:** make succeeds

**Documentation:** N/A