### PR TITLE
[exporter/awsemf] Renaming APM/Pulse to AppSignals

### DIFF
--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -154,12 +154,12 @@ func (config *Config) IsEnhancedContainerInsights() bool {
 	// return config.EnhancedContainerInsights && !config.DisableMetricExtraction
 }
 
-func (config *Config) IsPulseApmEnabled() bool {
+func (config *Config) IsAppSignalsEnabled() bool {
 	if config.LogGroupName == "" || config.Namespace == "" {
 		return false
 	}
 
-	if config.Namespace == pulseMetricNamespace && strings.HasPrefix(config.LogGroupName, pulseLogGroupNamePrefix) {
+	if config.Namespace == appSignalsMetricNamespace && strings.HasPrefix(config.LogGroupName, appSignalsLogGroupNamePrefix) {
 		return true
 	}
 

--- a/exporter/awsemfexporter/config_test.go
+++ b/exporter/awsemfexporter/config_test.go
@@ -328,7 +328,7 @@ func TestIsEnhancedContainerInsights(t *testing.T) {
 	assert.False(t, cfg.IsEnhancedContainerInsights())
 }
 
-func TestIsPulseApmEnabled(t *testing.T) {
+func TestIsAppSignalsEnabled(t *testing.T) {
 	tests := []struct {
 		name            string
 		metricNameSpace string
@@ -336,27 +336,27 @@ func TestIsPulseApmEnabled(t *testing.T) {
 		expectedResult  bool
 	}{
 		{
-			"validPulseEMF",
-			"AWS/APM",
-			"/aws/apm/eks",
+			"validAppSignalsEMF",
+			"AppSignals",
+			"/aws/appsignals/eks",
 			true,
 		},
 		{
-			"invalidPulseLogsGroup",
-			"AWS/APM",
-			"/nonaws/apm/eks",
+			"invalidAppSignalsLogsGroup",
+			"AppSignals",
+			"/nonaws/appsignals/eks",
 			false,
 		},
 		{
-			"invalidPulseMetricNamespace",
-			"NonAWS/APM",
-			"/aws/apm/eks",
+			"invalidAppSignalsMetricNamespace",
+			"NonAppSignals",
+			"/aws/appsignals/eks",
 			false,
 		},
 		{
-			"invalidPulseEMF",
-			"NonAWS/APM",
-			"/nonaws/apm/eks",
+			"invalidAppSignalsEMF",
+			"NonAppSignals",
+			"/nonaws/appsignals/eks",
 			false,
 		},
 		{
@@ -377,7 +377,7 @@ func TestIsPulseApmEnabled(t *testing.T) {
 				cfg.LogGroupName = tc.logGroupName
 			}
 
-			assert.Equal(t, cfg.IsPulseApmEnabled(), tc.expectedResult)
+			assert.Equal(t, cfg.IsAppSignalsEnabled(), tc.expectedResult)
 		})
 	}
 }

--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -29,9 +29,9 @@ const (
 	outputDestinationCloudWatch = "cloudwatch"
 	outputDestinationStdout     = "stdout"
 
-	// Pulse EMF config
-	pulseMetricNamespace    = "AWS/APM"
-	pulseLogGroupNamePrefix = "/aws/apm/"
+	// AppSignals EMF config
+	appSignalsMetricNamespace    = "AppSignals"
+	appSignalsLogGroupNamePrefix = "/aws/appsignals/"
 )
 
 type emfExporter struct {
@@ -69,7 +69,7 @@ func newEmfExporter(config *Config, set exporter.CreateSettings) (*emfExporter, 
 		config.Tags,
 		session,
 		cwlogs.WithEnabledContainerInsights(config.IsEnhancedContainerInsights()),
-		cwlogs.WithEnabledPulseApm(config.IsPulseApmEnabled()),
+		cwlogs.WithEnabledAppSignals(config.IsAppSignalsEnabled()),
 	)
 	collectorIdentifier, err := uuid.NewRandom()
 

--- a/internal/aws/cwlogs/cwlog_client.go
+++ b/internal/aws/cwlogs/cwlog_client.go
@@ -43,7 +43,7 @@ type UserAgentOption func(*UserAgentFlag)
 
 type UserAgentFlag struct {
 	isEnhancedContainerInsights bool
-	isPulseApm                  bool
+	isAppSignals                bool
 }
 
 func WithEnabledContainerInsights(flag bool) UserAgentOption {
@@ -52,9 +52,9 @@ func WithEnabledContainerInsights(flag bool) UserAgentOption {
 	}
 }
 
-func WithEnabledPulseApm(flag bool) UserAgentOption {
+func WithEnabledAppSignals(flag bool) UserAgentOption {
 	return func(ua *UserAgentFlag) {
-		ua.isPulseApm = flag
+		ua.isAppSignals = flag
 	}
 }
 
@@ -76,7 +76,7 @@ func NewClient(logger *zap.Logger, awsConfig *aws.Config, buildInfo component.Bu
 	// Loop through each option
 	option := &UserAgentFlag{
 		isEnhancedContainerInsights: false,
-		isPulseApm:                  false,
+		isAppSignals:                false,
 	}
 	for _, opt := range opts {
 		opt(option)
@@ -229,8 +229,8 @@ func newCollectorUserAgentHandler(buildInfo component.BuildInfo, logGroupName st
 		extraStr = "EnhancedEKSContainerInsights"
 	case containerInsightsRegexPattern.MatchString(logGroupName):
 		extraStr = "ContainerInsights"
-	case userAgentFlag.isPulseApm:
-		extraStr = "Pulse"
+	case userAgentFlag.isAppSignals:
+		extraStr = "AppSignals"
 	}
 
 	fn := request.MakeAddToUserAgentHandler(buildInfo.Command, buildInfo.Version, extraStr)

--- a/internal/aws/cwlogs/cwlog_client_test.go
+++ b/internal/aws/cwlogs/cwlog_client_test.go
@@ -596,10 +596,10 @@ func TestUserAgent(t *testing.T) {
 			"opentelemetry-collector-contrib/1.0",
 		},
 		{
-			"emptyLogGroupPulse",
+			"emptyLogGroupAppSignals",
 			component.BuildInfo{Command: "opentelemetry-collector-contrib", Version: "1.0"},
 			"",
-			WithEnabledPulseApm(false),
+			WithEnabledAppSignals(false),
 			"opentelemetry-collector-contrib/1.0",
 		},
 		{
@@ -610,10 +610,10 @@ func TestUserAgent(t *testing.T) {
 			"test-collector-contrib/1.0",
 		},
 		{
-			"buildInfoCommandUsedPulse",
+			"buildInfoCommandUsedAppSignals",
 			component.BuildInfo{Command: "test-collector-contrib", Version: "1.0"},
 			"",
-			WithEnabledPulseApm(false),
+			WithEnabledAppSignals(false),
 			"test-collector-contrib/1.0",
 		},
 		{
@@ -660,17 +660,17 @@ func TestUserAgent(t *testing.T) {
 			"opentelemetry-collector-contrib/1.0 (ContainerInsights)",
 		},
 		{
-			"validPulseEMFEnabled",
+			"validAppSignalsEMFEnabled",
 			component.BuildInfo{Command: "opentelemetry-collector-contrib", Version: "1.0"},
-			"/aws/apm",
-			WithEnabledPulseApm(true),
-			"opentelemetry-collector-contrib/1.0 (Pulse)",
+			"/aws/appsignals",
+			WithEnabledAppSignals(true),
+			"opentelemetry-collector-contrib/1.0 (AppSignals)",
 		},
 		{
-			"PulseEMFNotEnabled",
+			"AppSignalsEMFNotEnabled",
 			component.BuildInfo{Command: "opentelemetry-collector-contrib", Version: "1.0"},
-			"/aws/apm",
-			WithEnabledPulseApm(false),
+			"/aws/appsignals",
+			WithEnabledAppSignals(false),
 			"opentelemetry-collector-contrib/1.0",
 		},
 	}


### PR DESCRIPTION
**Notes: It is only for public preview and DO NOT merge it for private beta build.**

**Description:**
Remove all usages of APM/Pulse in EMF exporter and use AppSignals instead. 

**Testing:** 
Passed unit test.
