### PR TITLE
Add logic for stripping the AWS.SDK prefix for Local Root spans

### DIFF
--- a/.chloggen/strip-aws-sdk-local-root.yaml
+++ b/.chloggen/strip-aws-sdk-local-root.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsxrayexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Extend the AWSK.SDK prefix stripping to cover a previously missed case, for local root spans
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27232]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Follow-up from https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27232
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -155,7 +155,11 @@ func MakeDependencySubsegmentForLocalRootDependencySpan(span ptrace.Span, resour
 	}
 
 	if myAwsRemoteService, ok := span.Attributes().Get(awsRemoteService); ok {
-		dependencySubsegment.Name = awsxray.String(myAwsRemoteService.Str())
+		subsegmentName := myAwsRemoteService.Str()
+		if isAwsSdkSpan(span) && strings.HasPrefix(subsegmentName, "AWS.SDK.") {
+			subsegmentName = strings.TrimPrefix(subsegmentName, "AWS.SDK.")
+		}
+		dependencySubsegment.Name = awsxray.String(subsegmentName)
 	}
 
 	return dependencySubsegment, err

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -156,10 +156,7 @@ func MakeDependencySubsegmentForLocalRootDependencySpan(span ptrace.Span, resour
 
 	if myAwsRemoteService, ok := span.Attributes().Get(awsRemoteService); ok {
 		subsegmentName := myAwsRemoteService.Str()
-		if isAwsSdkSpan(span) && strings.HasPrefix(subsegmentName, "AWS.SDK.") {
-			subsegmentName = strings.TrimPrefix(subsegmentName, "AWS.SDK.")
-		}
-		dependencySubsegment.Name = awsxray.String(subsegmentName)
+		dependencySubsegment.Name = awsxray.String(trimAwsSdkPrefix(subsegmentName, span))
 	}
 
 	return dependencySubsegment, err
@@ -374,9 +371,7 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 		if remoteServiceName, ok := attributes.Get(awsRemoteService); ok {
 			name = remoteServiceName.Str()
 			// only strip the prefix for AWS spans
-			if isAwsSdkSpan(span) && strings.HasPrefix(name, "AWS.SDK.") {
-				name = strings.TrimPrefix(name, "AWS.SDK.")
-			}
+			name = trimAwsSdkPrefix(name, span)
 		}
 	}
 
@@ -755,4 +750,11 @@ func fixAnnotationKey(key string) string {
 			return '_'
 		}
 	}, key)
+}
+
+func trimAwsSdkPrefix(name string, span ptrace.Span) string {
+	if isAwsSdkSpan(span) && strings.HasPrefix(name, "AWS.SDK.") {
+		return strings.TrimPrefix(name, "AWS.SDK.")
+	}
+	return name
 }


### PR DESCRIPTION
- Previous change to strip the prefix in other cases https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27232/commits/7c037ad3022a2d5d0dcb09bf43cde89760fb5f8b

**Description:** Adding logic to strip AWS.SDK from local root dependency spans. This had been done previously for other spans, but there was a missed codepath related to local root naming.

**Link to tracking Issue:** None

**Testing:** Added a unit test

**Documentation:** None