### PR TITLE
[extension/awsmiddleware] Change Configure to take in either SDK version

### DIFF
--- a/exporter/awscloudwatchlogsexporter/exporter.go
+++ b/exporter/awscloudwatchlogsexporter/exporter.go
@@ -146,7 +146,7 @@ func (e *exporter) getLogPusher(pusherKey cwlogs.PusherKey) cwlogs.Pusher {
 
 func (e *exporter) start(_ context.Context, host component.Host) error {
 	if e.Config.MiddlewareID != nil {
-		awsmiddleware.TryConfigureSDKv1(e.logger, host.GetExtensions(), *e.Config.MiddlewareID, e.svcStructuredLog.Handlers())
+		awsmiddleware.TryConfigure(e.logger, host, *e.Config.MiddlewareID, awsmiddleware.SDKv1(e.svcStructuredLog.Handlers()))
 	}
 	pusherKey := cwlogs.PusherKey{
 		LogGroupName:  e.Config.LogGroupName,

--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -197,7 +197,7 @@ func (emf *emfExporter) listPushers() []cwlogs.Pusher {
 
 func (emf *emfExporter) start(_ context.Context, host component.Host) error {
 	if emf.config.MiddlewareID != nil {
-		awsmiddleware.TryConfigureSDKv1(emf.config.logger, host.GetExtensions(), *emf.config.MiddlewareID, emf.svcStructuredLog.Handlers())
+		awsmiddleware.TryConfigure(emf.config.logger, host, *emf.config.MiddlewareID, awsmiddleware.SDKv1(emf.svcStructuredLog.Handlers()))
 	}
 	return nil
 }

--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -88,7 +88,7 @@ func newTracesExporter(
 		exporterhelper.WithStart(func(_ context.Context, host component.Host) error {
 			sender.Start()
 			if cfg.MiddlewareID != nil {
-				awsmiddleware.TryConfigureSDKv1(logger, host.GetExtensions(), *cfg.MiddlewareID, xrayClient.Handlers())
+				awsmiddleware.TryConfigure(logger, host, *cfg.MiddlewareID, awsmiddleware.SDKv1(xrayClient.Handlers()))
 			}
 			return nil
 		}),

--- a/extension/awsmiddleware/README.md
+++ b/extension/awsmiddleware/README.md
@@ -1,8 +1,8 @@
 # AWS Middleware
 
 An AWS middleware extension provides request and/or response handlers that can be configured on AWS SDK v1/v2 clients.
-Other components can configure their AWS SDK clients using `awsmiddleware.GetConfigurer` and the `ConfigureSDKv1` and
-`ConfigureSDKv2` functions available on the `Configurer`.
+Other components can configure their AWS SDK clients using `awsmiddleware.GetConfigurer` and passing the `SDKv1` or `SDKv2`
+options into the `Configure` function available on the `Configurer`.
 
 The `awsmiddleware.Extension` interface extends `component.Extension` by adding the following method:
 ```

--- a/extension/awsmiddleware/helper.go
+++ b/extension/awsmiddleware/helper.go
@@ -4,28 +4,15 @@
 package awsmiddleware // import "github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware"
 
 import (
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
 	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 )
 
-// TryConfigureSDKv1 is a helper function that will try to get the extension and configure the AWS SDKv1 handlers with it.
-func TryConfigureSDKv1(logger *zap.Logger, extensions map[component.ID]component.Component, middlewareID ID, handlers *request.Handlers) {
-	if c, err := GetConfigurer(extensions, middlewareID); err != nil {
+// TryConfigure is a helper function that will try to get the extension and configure the provided AWS SDK with it.
+func TryConfigure(logger *zap.Logger, host component.Host, middlewareID component.ID, sdkVersion SDKVersion) {
+	if c, err := GetConfigurer(host.GetExtensions(), middlewareID); err != nil {
 		logger.Error("Unable to find AWS Middleware extension", zap.Error(err))
-	} else if err = c.ConfigureSDKv1(handlers); err != nil {
-		logger.Warn("Unable to configure middleware on AWS client", zap.Error(err))
-	} else {
-		logger.Debug("Configured middleware on AWS client", zap.String("middleware", middlewareID.String()))
-	}
-}
-
-// TryConfigureSDKv2 is a helper function that will try to get the extension and configure the AWS SDKv2 config with it.
-func TryConfigureSDKv2(logger *zap.Logger, extensions map[component.ID]component.Component, middlewareID ID, cfg *aws.Config) {
-	if c, err := GetConfigurer(extensions, middlewareID); err != nil {
-		logger.Error("Unable to find AWS Middleware extension", zap.Error(err))
-	} else if err = c.ConfigureSDKv2(cfg); err != nil {
+	} else if err = c.Configure(sdkVersion); err != nil {
 		logger.Warn("Unable to configure middleware on AWS client", zap.Error(err))
 	} else {
 		logger.Debug("Configured middleware on AWS client", zap.String("middleware", middlewareID.String()))

--- a/extension/awsmiddleware/helper_test.go
+++ b/extension/awsmiddleware/helper_test.go
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package awsmiddleware
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestTryConfigure(t *testing.T) {
+	testCases := []SDKVersion{SDKv1(&request.Handlers{}), SDKv2(&aws.Config{})}
+	for _, testCase := range testCases {
+		id := component.NewID("test")
+		host := new(MockExtensionsHost)
+		host.On("GetExtensions").Return(nil).Once()
+		core, observed := observer.New(zap.DebugLevel)
+		logger := zap.New(core)
+		TryConfigure(logger, host, id, testCase)
+		require.Len(t, observed.FilterLevelExact(zap.ErrorLevel).TakeAll(), 1)
+
+		extensions := map[component.ID]component.Component{}
+		host.On("GetExtensions").Return(extensions)
+		handler := new(MockHandler)
+		handler.On("ID").Return("test")
+		handler.On("Position").Return(HandlerPosition(-1))
+		extension := new(MockMiddlewareExtension)
+		extension.On("Handlers").Return([]RequestHandler{handler}, nil).Once()
+		extensions[id] = extension
+		TryConfigure(logger, host, id, testCase)
+		require.Len(t, observed.FilterLevelExact(zap.WarnLevel).TakeAll(), 1)
+
+		extension.On("Handlers").Return(nil, nil).Once()
+		TryConfigure(logger, host, id, testCase)
+		require.Len(t, observed.FilterLevelExact(zap.DebugLevel).TakeAll(), 1)
+	}
+}

--- a/extension/awsmiddleware/options.go
+++ b/extension/awsmiddleware/options.go
@@ -1,0 +1,33 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package awsmiddleware
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+type SDKVersion interface {
+	unused()
+}
+
+type sdkVersion1 struct {
+	SDKVersion
+	handlers *request.Handlers
+}
+
+// SDKv1 takes in AWS SDKv1 client request handlers.
+func SDKv1(handlers *request.Handlers) SDKVersion {
+	return sdkVersion1{handlers: handlers}
+}
+
+type sdkVersion2 struct {
+	SDKVersion
+	cfg *aws.Config
+}
+
+// SDKv2 takes in an AWS SDKv2 config.
+func SDKv2(cfg *aws.Config) SDKVersion {
+	return sdkVersion2{cfg: cfg}
+}


### PR DESCRIPTION
**Description:** Add an option to pass in the SDK version instead of having separate repeated functions for each.

**Link to tracking Issue:** N/A

**Testing:** Added unit tests.

**Documentation:** Updated README.