### PR TITLE
[extension/awsmiddleware] Expose NewConfigurer.

### DIFF
--- a/extension/awsmiddleware/config.go
+++ b/extension/awsmiddleware/config.go
@@ -27,5 +27,5 @@ func GetConfigurer(extensions map[component.ID]component.Component, middlewareID
 	if err != nil {
 		return nil, err
 	}
-	return newConfigurer(middleware.Handlers()), nil
+	return NewConfigurer(middleware.Handlers()), nil
 }

--- a/extension/awsmiddleware/middleware.go
+++ b/extension/awsmiddleware/middleware.go
@@ -115,8 +115,8 @@ type Configurer struct {
 	responseHandlers []ResponseHandler
 }
 
-// newConfigurer sets the request/response handlers.
-func newConfigurer(requestHandlers []RequestHandler, responseHandlers []ResponseHandler) *Configurer {
+// NewConfigurer sets the request/response handlers.
+func NewConfigurer(requestHandlers []RequestHandler, responseHandlers []ResponseHandler) *Configurer {
 	return &Configurer{requestHandlers: requestHandlers, responseHandlers: responseHandlers}
 }
 

--- a/extension/awsmiddleware/middleware_test.go
+++ b/extension/awsmiddleware/middleware_test.go
@@ -116,7 +116,7 @@ func TestInvalidHandlers(t *testing.T) {
 	handler.On("Position").Return(HandlerPosition(-1))
 	middleware := new(MockMiddlewareExtension)
 	middleware.On("Handlers").Return([]RequestHandler{handler}, []ResponseHandler{handler})
-	c := newConfigurer(middleware.Handlers())
+	c := NewConfigurer(middleware.Handlers())
 	testCases := []SDKVersion{SDKv1(&request.Handlers{}), SDKv2(&awsv2.Config{})}
 	for _, testCase := range testCases {
 		err := c.Configure(testCase)
@@ -132,7 +132,7 @@ func TestConfigureUnsupported(t *testing.T) {
 	type unsupportedVersion struct {
 		SDKVersion
 	}
-	err := newConfigurer(nil, nil).Configure(unsupportedVersion{})
+	err := NewConfigurer(nil, nil).Configure(unsupportedVersion{})
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, errUnsupportedVersion)
 }
@@ -194,7 +194,7 @@ func TestAppendOrder(t *testing.T) {
 				requestHandlers,
 				[]ResponseHandler{handler},
 			)
-			c := newConfigurer(middleware.Handlers())
+			c := NewConfigurer(middleware.Handlers())
 			// v1
 			client := awstesting.NewClient(&awsv1.Config{
 				Region:     awsv1.String("mock-region"),
@@ -231,7 +231,7 @@ func TestRoundTripSDKv1(t *testing.T) {
 	})
 	require.Equal(t, 3, client.Handlers.Build.Len())
 	require.Equal(t, 1, client.Handlers.ValidateResponse.Len())
-	assert.NoError(t, newConfigurer(middleware.Handlers()).Configure(SDKv1(&client.Handlers)))
+	assert.NoError(t, NewConfigurer(middleware.Handlers()).Configure(SDKv1(&client.Handlers)))
 	assert.Equal(t, 5, client.Handlers.Build.Len())
 	assert.Equal(t, 2, client.Handlers.ValidateResponse.Len())
 	s3Client := &s3v1.S3{Client: client}
@@ -249,7 +249,7 @@ func TestRoundTripSDKv2(t *testing.T) {
 	middleware, recorder, server := setup(t)
 	defer server.Close()
 	cfg := awsv2.Config{Region: "mock-region", RetryMaxAttempts: 0}
-	assert.NoError(t, newConfigurer(middleware.Handlers()).Configure(SDKv2(&cfg)))
+	assert.NoError(t, NewConfigurer(middleware.Handlers()).Configure(SDKv2(&cfg)))
 	s3Client := s3v2.NewFromConfig(cfg, func(options *s3v2.Options) {
 		options.BaseEndpoint = awsv2.String(server.URL)
 	})


### PR DESCRIPTION
**Description:** Expose the constructor for the configurer in case it needs to be used outside of the extension context. This isn't the standard usecase.

**Link to tracking Issue:** N/A

**Testing:** N/A

**Documentation:** N/A