### PR TITLE
Support IPv6 clusters with Container Insights

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil/kubeletclient.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil/kubeletclient.go
@@ -15,6 +15,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kubelet"
 )
 
+var kubeletNewClientProvider = kubelet.NewClientProvider
+
 type KubeletClient struct {
 	KubeIP     string
 	Port       string
@@ -40,7 +42,7 @@ func NewKubeletClient(kubeIP string, port string, logger *zap.Logger) (*KubeletC
 		},
 	}
 
-	clientProvider, err := kubelet.NewClientProvider(endpoint, clientConfig, logger)
+	clientProvider, err := kubeletNewClientProvider(endpoint, clientConfig, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil/kubeletclient.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil/kubeletclient.go
@@ -9,6 +9,7 @@ import (
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/net"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kubelet"
@@ -26,7 +27,11 @@ func NewKubeletClient(kubeIP string, port string, logger *zap.Logger) (*KubeletC
 		KubeIP: kubeIP,
 	}
 
-	endpoint := kubeIP + ":" + port
+	endpoint := kubeIP
+	if net.IsIPv6String(kubeIP) {
+		endpoint = "[" + endpoint + "]"
+	}
+	endpoint = endpoint + ":" + port
 
 	// use service account for authentication
 	clientConfig := &kubelet.ClientConfig{

--- a/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil/kubeletclient_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil/kubeletclient_test.go
@@ -1,0 +1,71 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kubeletutil
+
+import (
+	"testing"
+
+	kube "github.com/open-telemetry/opentelemetry-collector-contrib/internal/kubelet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type mockClientProvider struct {
+	endpoint string
+	cfg      *kube.ClientConfig
+}
+
+func (cp *mockClientProvider) BuildClient() (kube.Client, error) {
+	return &fakeClient{
+		endpoint: cp.endpoint,
+	}, nil
+}
+
+type fakeClient struct {
+	endpoint string
+}
+
+func (f *fakeClient) Get(path string) ([]byte, error) {
+	return []byte(path), nil
+}
+
+func TestNewKubeletClient(t *testing.T) {
+	kubeletNewClientProvider = func(endpoint string, cfg *kube.ClientConfig, logger *zap.Logger) (kube.ClientProvider, error) {
+		return &mockClientProvider{
+			endpoint: endpoint,
+			cfg:      cfg,
+		}, nil
+	}
+
+	tests := []struct {
+		kubeIP       string
+		port         string
+		wantEndpoint string
+	}{
+		{
+			kubeIP:       "0.0.0.0",
+			port:         "8000",
+			wantEndpoint: "0.0.0.0:8000",
+		},
+		{
+			kubeIP:       "2001:db8:3333:4444:5555:6666:7777:8888",
+			port:         "8000",
+			wantEndpoint: "[2001:db8:3333:4444:5555:6666:7777:8888]:8000",
+		},
+		{
+			kubeIP:       "2001:db8:3333:4444:5555:6666:1.2.3.4",
+			port:         "8000",
+			wantEndpoint: "[2001:db8:3333:4444:5555:6666:1.2.3.4]:8000",
+		},
+	}
+	for _, tt := range tests {
+		client, err := NewKubeletClient(tt.kubeIP, tt.port, zap.NewNop())
+		require.NoError(t, err)
+		assert.Equal(t, client.KubeIP, tt.kubeIP)
+		fc := (client.restClient).(*fakeClient)
+		assert.NotNil(t, fc)
+		assert.Equal(t, fc.endpoint, tt.wantEndpoint)
+	}
+}

--- a/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil/kubeletclient_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil/kubeletclient_test.go
@@ -6,10 +6,11 @@ package kubeletutil
 import (
 	"testing"
 
-	kube "github.com/open-telemetry/opentelemetry-collector-contrib/internal/kubelet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	kube "github.com/open-telemetry/opentelemetry-collector-contrib/internal/kubelet"
 )
 
 type mockClientProvider struct {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
CloudWatch Agent fails to start within IPv6 EKS clusters by throwing an error while trying to connect to kubelet. This issue affects Container Insights customers with IPv6 clusters. This change adds a check for IPv6 in the kubelet client to handle IPv6 address correctly. 

The Error from agent pod:
```
 stream logs failed Internal error occurred: Authorization error (user=kube-apiserver-kubelet-client, verb=get, resource=nodes, subresource=proxy) for amazo │
│ n-cloudwatch/cloudwatch-agent-xxxxx (cloudwatch-agent) 
```

**Testing:** 
IPv6 Cluster yaml used:
```
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: ipv6
  region: us-west-1
  version: "1.27"

kubernetesNetworkConfig:
  ipFamily: IPv6

addons:
  - name: vpc-cni
    version: latest
  - name: coredns
    version: latest
  - name: kube-proxy
    version: latest

iam:
  withOIDC: true

managedNodeGroups:
  - name: ipv6ng
    instanceType: t3.medium
```

Also tested with IPv4 cluster by applying similar cluster config with `ipFamily: IPv4`.

<img width="1336" alt="Screenshot 2023-12-18 at 10 38 03 AM" src="https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/884273/2f141906-d905-48f4-9877-e04f901c63fc">


**Documentation:** <Describe the documentation added.>