### PR TITLE
Update container insights to account for InitContainers/Pod Overhead

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -17,6 +17,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
@@ -189,6 +190,223 @@ func getBaseTestPodInfo() *corev1.Pod {
 	return &pods.Items[0]
 }
 
+func getInitContainerBaseTestPodInfo() *corev1.Pod {
+	podJSON := `
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "cpu-limit",
+        "namespace": "default",
+        "ownerReferences": [
+            {
+                "apiVersion": "apps/v1",
+                "blockOwnerDeletion": true,
+                "controller": true,
+                "kind": "DaemonSet",
+                "name": "DaemonSetTest",
+                "uid": "36779a62-4aca-11e9-977b-0672b6c6fc94"
+            }
+        ],
+        "selfLink": "/api/v1/namespaces/default/pods/cpu-limit",
+        "uid": "764d01e1-2a2f-11e9-95ea-0a695d7ce286",
+        "resourceVersion": "5671573",
+        "creationTimestamp": "2019-02-06T16:51:34Z",
+        "labels": {
+          "app": "hello_test"
+        },
+        "annotations": {
+          "kubernetes.io/config.seen": "2019-02-19T00:06:56.109155665Z",
+          "kubernetes.io/config.source": "api"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-tlgw7",
+            "secret": {
+              "secretName": "default-token-tlgw7",
+              "defaultMode": 420
+            }
+          }
+        ],
+		"initContainers": [
+          {
+            "name": "logshipper1",
+            "image": "alpine:latest",
+            "restartPolicy": "Always",
+            "command": [
+              "sh",
+              "-c",
+              "tail -F /opt/logs.txt"
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "5m",
+                "memory": "50Mi"
+              },
+              "requests": {
+                "cpu": "5m",
+                "memory": "50Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "data",
+                "mountPath": "/opt"
+              }
+            ]
+          },
+          {
+            "name": "logshipper2",
+            "image": "alpine:latest",
+            "command": [
+              "sh",
+              "-c",
+              "tail -F /opt/logs.txt"
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "15m",
+                "memory": "25Mi"
+              },
+              "requests": {
+                "cpu": "15m",
+                "memory": "25Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "data",
+                "mountPath": "/opt"
+              }
+            ]
+          }
+        ],
+        "containers": [
+          {
+            "name": "ubuntu",
+            "image": "ubuntu",
+            "command": [
+              "/bin/bash"
+            ],
+            "args": [
+              "-c",
+              "sleep 300000000"
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              },
+              "requests": {
+                "cpu": "10m",
+                "memory": "50Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-tlgw7",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "ip-192-168-67-127.us-west-2.compute.internal",
+        "securityContext": {
+        },
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:43Z"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": null
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-02-06T16:51:34Z"
+          }
+        ],
+        "hostIP": "192.168.67.127",
+        "podIP": "192.168.76.93",
+        "startTime": "2019-02-06T16:51:34Z",
+        "containerStatuses": [
+          {
+            "name": "ubuntu",
+            "state": {
+              "running": {
+                "startedAt": "2019-02-06T16:51:42Z"
+              }
+            },
+            "lastState": {
+            },
+            "ready": true,
+            "restartCount": 0,
+            "image": "ubuntu:latest",
+            "imageID": "docker-pullable://ubuntu@sha256:7a47ccc3bbe8a451b500d2b53104868b46d60ee8f5b35a24b41a86077c650210",
+            "containerID": "docker://637631e2634ea92c0c1aa5d24734cfe794f09c57933026592c12acafbaf6972c"
+          }
+        ],
+        "qosClass": "Guaranteed"
+      }
+    }
+  ]
+}`
+	pods := corev1.PodList{}
+	err := json.Unmarshal([]byte(podJSON), &pods)
+	if err != nil {
+		panic(fmt.Sprintf("unmarshal pod err %v", err))
+	}
+
+	return &pods.Items[0]
+}
+
 func getPodStore() *PodStore {
 	nodeInfo := newNodeInfo("testNode1", &mockNodeInfoProvider{}, zap.NewNop())
 	nodeInfo.setCPUCapacity(4000)
@@ -247,6 +465,29 @@ func TestPodStore_decorateCpu(t *testing.T) {
 	assert.Equal(t, float64(10), metric.GetField("container_cpu_utilization_over_container_limit").(float64))
 }
 
+func TestPodStore_decorateCpu_WithInitContainersAndPodOverhead(t *testing.T) {
+	podStore := getPodStore()
+	defer require.NoError(t, podStore.Shutdown())
+
+	pod := getInitContainerBaseTestPodInfo()
+
+	pod.Spec.Overhead = make(corev1.ResourceList)
+	pod.Spec.Overhead[corev1.ResourceCPU] = *resource.NewQuantity(5, resource.DecimalSI)
+
+	// test pod metrics
+	tags := map[string]string{ci.MetricType: ci.TypePod}
+	fields := map[string]interface{}{ci.MetricName(ci.TypePod, ci.CPUTotal): float64(1)}
+
+	metric := generateMetric(fields, tags)
+	podStore.decorateCPU(metric, pod)
+
+	assert.Equal(t, uint64(25), metric.GetField("pod_cpu_request").(uint64))
+	assert.Equal(t, uint64(25), metric.GetField("pod_cpu_limit").(uint64))
+	assert.Equal(t, 0.625, metric.GetField("pod_cpu_reserved_capacity").(float64))
+	assert.Equal(t, float64(4), metric.GetField("pod_cpu_utilization_over_pod_limit").(float64))
+	assert.Equal(t, float64(1), metric.GetField("pod_cpu_usage_total").(float64))
+}
+
 func TestPodStore_decorateMem(t *testing.T) {
 	podStore := getPodStore()
 	defer require.NoError(t, podStore.Shutdown())
@@ -279,6 +520,27 @@ func TestPodStore_decorateMem(t *testing.T) {
 	podStore.decorateMem(metric, pod)
 
 	assert.Equal(t, float64(20), metric.GetField("container_memory_utilization_over_container_limit").(float64))
+}
+
+func TestPodStore_decorateMem_WithInitContainersAndPodOverhead(t *testing.T) {
+	podStore := getPodStore()
+	defer require.NoError(t, podStore.Shutdown())
+	pod := getInitContainerBaseTestPodInfo()
+
+	pod.Spec.Overhead = make(corev1.ResourceList)
+	pod.Spec.Overhead[corev1.ResourceMemory] = *resource.NewQuantity(5*1024*1024, resource.BinarySI)
+
+	tags := map[string]string{ci.MetricType: ci.TypePod}
+	fields := map[string]interface{}{ci.MetricName(ci.TypePod, ci.MemWorkingset): uint64(10 * 1024 * 1024)}
+
+	metric := generateMetric(fields, tags)
+	podStore.decorateMem(metric, pod)
+
+	assert.Equal(t, uint64(110100480), metric.GetField("pod_memory_request").(uint64))
+	assert.Equal(t, uint64(110100480), metric.GetField("pod_memory_limit").(uint64))
+	assert.Equal(t, 26.25, metric.GetField("pod_memory_reserved_capacity").(float64))
+	assert.Equal(t, 9.523809523809524, metric.GetField("pod_memory_utilization_over_pod_limit").(float64))
+	assert.Equal(t, uint64(10*1024*1024), metric.GetField("pod_memory_working_set").(uint64))
 }
 
 func TestPodStore_previousCleanupLocking(_ *testing.T) {

--- a/receiver/awscontainerinsightreceiver/internal/stores/utils.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/utils.go
@@ -174,3 +174,10 @@ func refreshWithTimeout(parentContext context.Context, refresh func(), timeout t
 	<-ctx.Done()
 	cancel()
 }
+
+func maxUint64(x, y uint64) uint64 {
+	if x < y {
+		return y
+	}
+	return x
+}

--- a/receiver/awscontainerinsightreceiver/internal/stores/utils_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/utils_test.go
@@ -201,3 +201,8 @@ func TestUtils_TagMetricSource(t *testing.T) {
 		assert.Equal(t, expectedSources[i], metric.tags[ci.SourcesKey])
 	}
 }
+
+func Test_maxUint64(t *testing.T) {
+	assert.Equal(t, uint64(10), maxUint64(uint64(5), uint64(10)))
+	assert.Equal(t, uint64(10), maxUint64(uint64(10), uint64(5)))
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>

Kubernetes currently supports a concept called “[init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)" which run to completion before the main container(s) of a pod are started. Starting with EKS 1.29, a new feature "[SidecarContainers](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/)" will be introduced which allows init containers to run indefinitely, alongside the main application container(s) - thus acting as sidecars. A sidecar container is an init container with a restart policy.

https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/753-sidecar-containers#exposing-pod-resource-requirements.

https://kubernetes.io/docs/concepts/scheduling-eviction/pod-overhead/

The current Container Insights implementation does not take into account initContainers(sidecar or regular) when reporting metrics. This will result in incorrect metrics values and therefore affect customer observability in EKS 1.29 clusters. This issue will only affect customers who choose to use the new sidecar containers feature.

This PR updates container insights to be accurate for EKS 1.29, by implementing resource calculations (cpu/mem limits/requests) in the same way kubernetes does. 

Kubernetes code for reference: https://github.com/kubernetes/kubernetes/blob/e2afa175e4077d767745246662170acd86affeaf/pkg/api/v1/resource/helpers.go#L50

TLDR: With EKS 1.29 the formula for computing resource usage for Pods will need to be changed to account for init containers (sidecar/regular) and pod overhead if set. 

The old formula was just `Sum(Container)` when it should have been `Max ( Max (Init Containers), Sum(Containers))`. As of EKS 1.29 the formula will be:

```
Max ( Max( each InitContainerUse ) , Sum(Sidecar Containers) + Sum(each ContainerUse) ) + pod overhead
```

where `InitContainerUse(i) = Sum(sidecar containers with index < i) + InitContainer(i)`

**Testing:**
- Unit tests in contrib repo (aws-cwa-dev)
- Unit tests passing in [agent](https://github.com/aws/amazon-cloudwatch-agent)
- Tested on EKS cluster