### PR TITLE
Add memory extractors for pod and node level

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/mem_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/mem_extractor.go
@@ -1,0 +1,66 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package extractors // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors"
+
+import (
+	"time"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	awsmetrics "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics"
+	cExtractor "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors"
+
+	"go.uber.org/zap"
+)
+
+type MemMetricExtractor struct {
+	logger         *zap.Logger
+	rateCalculator awsmetrics.MetricCalculator
+}
+
+func (m *MemMetricExtractor) HasValue(rawMetric *RawMetric) bool {
+	if rawMetric.MemoryStats != nil {
+		return true
+	}
+	return false
+}
+
+func (m *MemMetricExtractor) GetValue(rawMetric *RawMetric, mInfo cExtractor.CPUMemInfoProvider, containerType string) []*cExtractor.CAdvisorMetric {
+	var metrics []*cExtractor.CAdvisorMetric
+
+	metric := cExtractor.NewCadvisorMetric(containerType, m.logger)
+	identifier := rawMetric.Id
+
+	metric.AddField(ci.MetricName(containerType, ci.MemUsage), *rawMetric.MemoryStats.UsageBytes)
+	metric.AddField(ci.MetricName(containerType, ci.MemRss), *rawMetric.MemoryStats.RSSBytes)
+	metric.AddField(ci.MetricName(containerType, ci.MemWorkingset), *rawMetric.MemoryStats.WorkingSetBytes)
+
+	multiplier := float64(time.Second)
+	cExtractor.AssignRateValueToField(&m.rateCalculator, metric.GetFields(), ci.MetricName(containerType, ci.MemPgfault), identifier,
+		float64(*rawMetric.MemoryStats.PageFaults), rawMetric.Time, multiplier)
+	cExtractor.AssignRateValueToField(&m.rateCalculator, metric.GetFields(), ci.MetricName(containerType, ci.MemPgmajfault), identifier,
+		float64(*rawMetric.MemoryStats.MajorPageFaults), rawMetric.Time, multiplier)
+
+	memoryCapacity := mInfo.GetMemoryCapacity()
+	if metric.GetField(ci.MetricName(containerType, ci.MemWorkingset)) != nil && memoryCapacity != 0 {
+		metric.AddField(ci.MetricName(containerType, ci.MemUtilization), float64(metric.GetField(ci.MetricName(containerType, ci.MemWorkingset)).(uint64))/float64(memoryCapacity)*100)
+	}
+
+	if containerType == ci.TypeNode {
+		metric.AddField(ci.MetricName(containerType, ci.MemLimit), memoryCapacity)
+	}
+
+	metrics = append(metrics, metric)
+	return metrics
+}
+
+func (m *MemMetricExtractor) Shutdown() error {
+	return m.rateCalculator.Shutdown()
+}
+
+func NewMemMetricExtractor(logger *zap.Logger) *MemMetricExtractor {
+	return &MemMetricExtractor{
+		logger:         logger,
+		rateCalculator: cExtractor.NewFloat64RateCalculator(),
+	}
+}

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/mem_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/mem_extractor_test.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package extractors
 
 import (
@@ -9,21 +12,18 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows/testutils"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
-func TestCPUStats(t *testing.T) {
+func TestMemStats(t *testing.T) {
 	MockCPUMemInfo := cTestUtils.MockCPUMemInfo{}
-
 	result := testutils.LoadKubeletSummary(t, "./testdata/PreSingleKubeletSummary.json")
 	result2 := testutils.LoadKubeletSummary(t, "./testdata/CurSingleKubeletSummary.json")
 
 	podRawMetric := ConvertPodToRaw(&result.Pods[0])
 	podRawMetric2 := ConvertPodToRaw(&result2.Pods[0])
 
-	// test container type
 	containerType := containerinsight.TypePod
-	extractor := NewCPUMetricExtractor(&zap.Logger{})
+	extractor := NewMemMetricExtractor(nil)
 
 	var cMetrics []*cExtractor.CAdvisorMetric
 	if extractor.HasValue(podRawMetric) {
@@ -33,26 +33,37 @@ func TestCPUStats(t *testing.T) {
 		cMetrics = extractor.GetValue(podRawMetric2, MockCPUMemInfo, containerType)
 	}
 
-	cExtractor.AssertContainsTaggedFloat(t, cMetrics[0], "pod_cpu_usage_total", 3.125000, 0)
-	cExtractor.AssertContainsTaggedFloat(t, cMetrics[0], "pod_cpu_utilization", 0.156250, 0)
+	cExtractor.AssertContainsTaggedUint(t, cMetrics[0], "pod_memory_rss", 0)
+	cExtractor.AssertContainsTaggedUint(t, cMetrics[0], "pod_memory_usage", 0)
+	cExtractor.AssertContainsTaggedUint(t, cMetrics[0], "pod_memory_working_set", 209088512)
+
+	cExtractor.AssertContainsTaggedFloat(t, cMetrics[0], "pod_memory_pgfault", 0, 0)
+	cExtractor.AssertContainsTaggedFloat(t, cMetrics[0], "pod_memory_pgmajfault", 0, 0)
 	require.NoError(t, extractor.Shutdown())
 
-	// test node type
+	// for node type
 	containerType = containerinsight.TypeNode
-	extractor = NewCPUMetricExtractor(nil)
+	extractor = NewMemMetricExtractor(nil)
 
 	nodeRawMetric := ConvertNodeToRaw(&result.Node)
 	nodeRawMetric2 := ConvertNodeToRaw(&result2.Node)
+
 	if extractor.HasValue(nodeRawMetric) {
 		cMetrics = extractor.GetValue(nodeRawMetric, MockCPUMemInfo, containerType)
 	}
+
 	if extractor.HasValue(nodeRawMetric2) {
 		cMetrics = extractor.GetValue(nodeRawMetric2, MockCPUMemInfo, containerType)
 	}
 
-	cExtractor.AssertContainsTaggedFloat(t, cMetrics[0], "node_cpu_usage_total", 51.5, 0.5)
-	cExtractor.AssertContainsTaggedFloat(t, cMetrics[0], "node_cpu_utilization", 2.5, 0.5)
-	cExtractor.AssertContainsTaggedInt(t, cMetrics[0], "node_cpu_limit", 2000)
+	cExtractor.AssertContainsTaggedUint(t, cMetrics[0], "node_memory_rss", 0)
+	cExtractor.AssertContainsTaggedUint(t, cMetrics[0], "node_memory_usage", 3572293632)
+	cExtractor.AssertContainsTaggedUint(t, cMetrics[0], "node_memory_working_set", 1026678784)
+	cExtractor.AssertContainsTaggedInt(t, cMetrics[0], "node_memory_limit", 1073741824)
+
+	cExtractor.AssertContainsTaggedFloat(t, cMetrics[0], "node_memory_pgfault", 0, 0)
+	cExtractor.AssertContainsTaggedFloat(t, cMetrics[0], "node_memory_pgmajfault", 0, 0)
+	cExtractor.AssertContainsTaggedFloat(t, cMetrics[0], "node_memory_utilization", 95, 0.7)
 
 	require.NoError(t, extractor.Shutdown())
 }


### PR DESCRIPTION
**Description:** 
    1. Added memory extractor at pod and node level
    2. Add unit tests for memory extractor
    3. use cpu and memory extractor for k8s windows
    
   **Testing**
   Unit tests - Passed
   Manual tests - 
   Ran CW agent on EKS cluster to see following results in metrics section in CW dashboard
   CPU and memory utilization metrics for Windows pod `windows-server-jis-Itsc2019`
<img width="1215" alt="Screenshot 2024-01-04 at 7 13 08 AM" src="https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/10296556/93a24744-e112-4c32-9da2-914e440eb882">
