### PR TITLE
Add option to clear resource attributes after copy

### DIFF
--- a/pkg/resourcetotelemetry/README.md
+++ b/pkg/resourcetotelemetry/README.md
@@ -11,3 +11,4 @@ The following configuration options can be modified:
 
 - `resource_to_telemetry_conversion`
     - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
+    - `clear_after_copy` (default = false): If `clear_after_copy` is `true`, all the resource attributes will be cleared after they've been copied.

--- a/pkg/resourcetotelemetry/resource_to_telemetry_test.go
+++ b/pkg/resourcetotelemetry/resource_to_telemetry_test.go
@@ -18,7 +18,8 @@ func TestConvertResourceToAttributes(t *testing.T) {
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().Len())
 
-	cloneMd := convertToMetricsAttributes(md)
+	wme := &wrapperMetricsExporter{}
+	cloneMd := wme.convertToMetricsAttributes(md)
 
 	// After converting resource to labels
 	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).Resource().Attributes().Len())
@@ -43,7 +44,8 @@ func TestConvertResourceToAttributesAllDataTypesEmptyDataPoint(t *testing.T) {
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(5).Summary().DataPoints().At(0).Attributes().Len())
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(6).ExponentialHistogram().DataPoints().At(0).Attributes().Len())
 
-	cloneMd := convertToMetricsAttributes(md)
+	wme := &wrapperMetricsExporter{}
+	cloneMd := wme.convertToMetricsAttributes(md)
 
 	// After converting resource to labels
 	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).Resource().Attributes().Len())
@@ -63,5 +65,25 @@ func TestConvertResourceToAttributesAllDataTypesEmptyDataPoint(t *testing.T) {
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(4).Histogram().DataPoints().At(0).Attributes().Len())
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(5).Summary().DataPoints().At(0).Attributes().Len())
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(6).ExponentialHistogram().DataPoints().At(0).Attributes().Len())
+
+}
+
+func TestClearAfterCopy(t *testing.T) {
+	md := testdata.GenerateMetricsOneMetric()
+	assert.NotNil(t, md)
+
+	// Before converting resource to labels
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().Len())
+
+	wme := &wrapperMetricsExporter{clearAfterCopy: true}
+	cloneMd := wme.convertToMetricsAttributes(md)
+
+	// After converting resource to labels
+	assert.Equal(t, 0, cloneMd.ResourceMetrics().At(0).Resource().Attributes().Len())
+	assert.Equal(t, 2, cloneMd.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().Len())
+
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().Len())
 
 }


### PR DESCRIPTION
**Description:** The `pkg/resourcetotelemetry` exporter helper wraps an exporter and enabling it will copy all attributes from resource metrics to each data point within. Currently, the helper only performs a copy and does not modify the resource attributes, which can result in duplicate attributes in certain exporters (e.g. PRW exporter).

Adds an option to clear the resource attributes after the copy has been completed.

**Link to tracking Issue:** N/A

**Testing:** Added unit test to verify behavior.

**Documentation:** Updated README.