### PR TITLE
Add Container level metrics for CPU and memory resources.

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractor.go
@@ -36,7 +36,7 @@ type RawMetric struct {
 }
 
 type MetricExtractor interface {
-	HasValue(summary *RawMetric) bool
-	GetValue(summary *RawMetric, mInfo cExtractor.CPUMemInfoProvider, containerType string) []*cExtractor.CAdvisorMetric
+	HasValue(summary RawMetric) bool
+	GetValue(summary RawMetric, mInfo cExtractor.CPUMemInfoProvider, containerType string) []*cExtractor.CAdvisorMetric
 	Shutdown() error
 }

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/k8swindows.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/k8swindows.go
@@ -22,12 +22,12 @@ import (
 )
 
 type K8sWindows struct {
-	cancel          context.CancelFunc
-	logger          *zap.Logger
-	nodeName        string `toml:"node_name"`
-	k8sDecorator    stores.K8sDecorator
-	summaryProvider *kubelet
-	hostInfo        host.Info
+	cancel                 context.CancelFunc
+	logger                 *zap.Logger
+	nodeName               string `toml:"node_name"`
+	k8sDecorator           stores.K8sDecorator
+	kubeletSummaryProvider *kubelet
+	hostInfo               host.Info
 }
 
 var metricsExtractors = []extractors.MetricExtractor{}
@@ -47,11 +47,11 @@ func New(logger *zap.Logger, decorator *stores.K8sDecorator, hostInfo host.Info)
 	metricsExtractors = append(metricsExtractors, extractors.NewCPUMetricExtractor(logger))
 	metricsExtractors = append(metricsExtractors, extractors.NewMemMetricExtractor(logger))
 	return &K8sWindows{
-		logger:          logger,
-		nodeName:        nodeName,
-		k8sDecorator:    *decorator,
-		summaryProvider: k8sSummaryProvider,
-		hostInfo:        hostInfo,
+		logger:                 logger,
+		nodeName:               nodeName,
+		k8sDecorator:           *decorator,
+		kubeletSummaryProvider: k8sSummaryProvider,
+		hostInfo:               hostInfo,
 	}, nil
 }
 
@@ -59,7 +59,7 @@ func (k *K8sWindows) GetMetrics() []pmetric.Metrics {
 	k.logger.Debug("D! called K8sWindows GetMetrics")
 	var result []pmetric.Metrics
 
-	metrics, err := k.summaryProvider.getMetrics()
+	metrics, err := k.kubeletSummaryProvider.getMetrics()
 	if err != nil {
 		k.logger.Error("error getting metrics from kubelet summary provider, ", zap.Error(err))
 		return result

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet.go
@@ -13,71 +13,127 @@ import (
 
 	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
 	cExtractor "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/host"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil"
-	"go.uber.org/zap"
+
 	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 )
 
-type kubeletSummaryProvider struct {
-	logger   *zap.Logger
-	hostIP   string
-	hostPort string
-	client   *kubeletutil.KubeletClient
-	hostInfo host.Info
+// KubeletProvider Represents interface to kubelet.
+type KubeletProvider interface {
+	GetClient() (*kubeletutil.KubeletClient, error)
+	GetSummary() (*stats.Summary, error)
 }
 
-func new(logger *zap.Logger, info host.Info) (*kubeletSummaryProvider, error) {
-	hostIP := os.Getenv("HOST_IP")
-	kclient, err := kubeletutil.NewKubeletClient(hostIP, ci.KubeSecurePort, logger)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize kubelet client: %w", err)
+type kubeletProvider struct {
+	logger *zap.Logger
+	hostIP string
+	port   string
+	client *kubeletutil.KubeletClient
+}
+
+// GetClient Returns singleton kubelet client.
+func (k *kubeletProvider) GetClient() (*kubeletutil.KubeletClient, error) {
+	if k.client != nil {
+		return k.client, nil
 	}
-
-	return &kubeletSummaryProvider{
-		logger:   logger,
-		client:   kclient,
-		hostInfo: info,
-	}, nil
+	kclient, err := kubeletutil.NewKubeletClient(k.hostIP, k.port, k.logger)
+	if err != nil {
+		k.logger.Error("failed to initialize kubeletProvider client, ", zap.Error(err))
+		return nil, err
+	}
+	k.client = kclient
+	return kclient, nil
 }
 
-func (k *kubeletSummaryProvider) getMetrics() ([]*cExtractor.CAdvisorMetric, error) {
-	summary, err := k.client.Summary(k.logger)
+// GetSummary Get Summary from kubelet API.
+func (k *kubeletProvider) GetSummary() (*stats.Summary, error) {
+	kclient, err := k.GetClient()
 	if err != nil {
-		k.logger.Error("kubelet summary API failed, ", zap.Error(err))
+		k.logger.Error("failed to get kubeletProvider client, ", zap.Error(err))
 		return nil, err
 	}
 
-	return k.getPodMetrics(summary)
+	summary, err := kclient.Summary(k.logger)
+	if err != nil {
+		k.logger.Error("kubeletProvider summary API failed, ", zap.Error(err))
+		return nil, err
+	}
+	return summary, nil
 }
 
-func (k *kubeletSummaryProvider) getContainerMetrics(summary *stats.Summary) ([]*cExtractor.CAdvisorMetric, error) {
+func createDefaultKubeletProvider(logger *zap.Logger) KubeletProvider {
+	kSP := &kubeletProvider{logger: logger, hostIP: os.Getenv("HOST_IP"), port: ci.KubeSecurePort}
+	return kSP
+}
+
+// kubelet represents receiver to get metrics from kubelet.
+type kubelet struct {
+	logger          *zap.Logger
+	kubeletProvider KubeletProvider
+	hostInfo        cExtractor.CPUMemInfoProvider
+}
+
+// options decorates kubelet struct.
+type options func(provider *kubelet)
+
+func new(logger *zap.Logger, info cExtractor.CPUMemInfoProvider, opts ...options) (*kubelet, error) {
+	kSP := &kubelet{
+		logger:          logger,
+		hostInfo:        info,
+		kubeletProvider: createDefaultKubeletProvider(logger),
+	}
+
+	for _, opt := range opts {
+		opt(kSP)
+	}
+	return kSP, nil
+}
+
+func (k *kubelet) getMetrics() ([]*cExtractor.CAdvisorMetric, error) {
 	var metrics []*cExtractor.CAdvisorMetric
-	// todo: implement CPU, memory metrics from containers
+
+	summary, err := k.kubeletProvider.GetSummary()
+	if err != nil {
+		k.logger.Error("kubeletProvider summary API failed, ", zap.Error(err))
+		return nil, err
+	}
+	outMetrics, err := k.getPodMetrics(summary)
+	if err != nil {
+		k.logger.Error("kubelet pod summary metrics failed, ", zap.Error(err))
+		return metrics, err
+	}
+	metrics = append(metrics, outMetrics...)
+
+	nodeMetics, err := k.getNodeMetrics(summary)
+	if err != nil {
+		k.logger.Error("kubelet node summary metrics failed, ", zap.Error(err))
+		return nodeMetics, err
+	}
+	metrics = append(metrics, nodeMetics...)
+
 	return metrics, nil
 }
 
-func (k *kubeletSummaryProvider) getPodMetrics(summary *stats.Summary) ([]*cExtractor.CAdvisorMetric, error) {
-	// todo: This is not complete implementation of pod level metric collection since network level metrics are pending
-	// May need to add some more pod level labels for store decorators to work properly
-
+// getContainerMetrics returns container level metrics from kubelet.
+func (k *kubelet) getContainerMetrics(pod *stats.PodStats) ([]*cExtractor.CAdvisorMetric, error) {
 	var metrics []*cExtractor.CAdvisorMetric
 
-	for _, pod := range summary.Pods {
-		k.logger.Info(fmt.Sprintf("pod summary %v", pod.PodRef.Name))
-
+	for _, container := range pod.Containers {
 		tags := map[string]string{}
 
 		tags[ci.PodIDKey] = pod.PodRef.UID
 		tags[ci.K8sPodNameKey] = pod.PodRef.Name
 		tags[ci.K8sNamespace] = pod.PodRef.Namespace
+		tags[ci.ContainerNamekey] = container.Name
+		containerID := fmt.Sprintf("%s-%s", pod.PodRef.UID, container.Name)
+		tags[ci.ContainerIDkey] = containerID
 
-		rawMetric := extractors.ConvertPodToRaw(pod)
+		rawMetric := extractors.ConvertContainerToRaw(container, pod)
 		tags[ci.Timestamp] = strconv.FormatInt(rawMetric.Time.UnixNano(), 10)
 		for _, extractor := range GetMetricsExtractors() {
 			if extractor.HasValue(rawMetric) {
-				metrics = append(metrics, extractor.GetValue(rawMetric, &k.hostInfo, ci.TypePod)...)
+				metrics = append(metrics, extractor.GetValue(rawMetric, k.hostInfo, ci.TypeContainer)...)
 			}
 		}
 		for _, metric := range metrics {
@@ -87,8 +143,51 @@ func (k *kubeletSummaryProvider) getPodMetrics(summary *stats.Summary) ([]*cExtr
 	return metrics, nil
 }
 
-func (k *kubeletSummaryProvider) getNodeMetrics() ([]*cExtractor.CAdvisorMetric, error) {
+// getPodMetrics returns pod and container level metrics from kubelet.
+func (k *kubelet) getPodMetrics(summary *stats.Summary) ([]*cExtractor.CAdvisorMetric, error) {
+	// todo: This is not complete implementation of pod level metric collection since network level metrics are pending
+	// May need to add some more pod level labels for store decorators to work properly
 	var metrics []*cExtractor.CAdvisorMetric
-	//todo: Implement CPU, memory and network metrics at node
+
+	for _, pod := range summary.Pods {
+		var metricsPerPod []*cExtractor.CAdvisorMetric
+
+		tags := map[string]string{}
+
+		tags[ci.PodIDKey] = pod.PodRef.UID
+		tags[ci.K8sPodNameKey] = pod.PodRef.Name
+		tags[ci.K8sNamespace] = pod.PodRef.Namespace
+		tags[ci.Timestamp] = strconv.FormatInt(pod.CPU.Time.UnixNano(), 10)
+		rawMetric := extractors.ConvertPodToRaw(&pod)
+		for _, extractor := range GetMetricsExtractors() {
+			if extractor.HasValue(rawMetric) {
+				metricsPerPod = append(metricsPerPod, extractor.GetValue(rawMetric, k.hostInfo, ci.TypePod)...)
+			}
+		}
+		for _, metric := range metricsPerPod {
+			metric.AddTags(tags)
+		}
+		metrics = append(metrics, metricsPerPod...)
+
+		containerMetrics, err := k.getContainerMetrics(&pod)
+		if err != nil {
+			k.logger.Error("kubelet container metrics failed, ", zap.Error(err))
+			return containerMetrics, err
+		}
+		metrics = append(metrics, containerMetrics...)
+	}
+	return metrics, nil
+}
+
+// getNodeMetrics returns Node level metrics from kubelet.
+func (k *kubelet) getNodeMetrics(summary *stats.Summary) ([]*cExtractor.CAdvisorMetric, error) {
+	var metrics []*cExtractor.CAdvisorMetric
+
+	rawMetric := extractors.ConvertNodeToRaw(&summary.Node)
+	for _, extractor := range GetMetricsExtractors() {
+		if extractor.HasValue(rawMetric) {
+			metrics = append(metrics, extractor.GetValue(rawMetric, k.hostInfo, ci.TypeNode)...)
+		}
+	}
 	return metrics, nil
 }

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet.go
@@ -26,10 +26,10 @@ type KubeletProvider interface {
 }
 
 type kubeletProvider struct {
-	logger *zap.Logger
-	hostIP string
-	port   string
-	client *kubeletutil.KubeletClient
+	logger   *zap.Logger
+	hostIP   string
+	hostPort string
+	client   *kubeletutil.KubeletClient
 }
 
 // GetClient Returns singleton kubelet client.
@@ -37,7 +37,7 @@ func (k *kubeletProvider) GetClient() (*kubeletutil.KubeletClient, error) {
 	if k.client != nil {
 		return k.client, nil
 	}
-	kclient, err := kubeletutil.NewKubeletClient(k.hostIP, k.port, k.logger)
+	kclient, err := kubeletutil.NewKubeletClient(k.hostIP, k.hostPort, k.logger)
 	if err != nil {
 		k.logger.Error("failed to initialize kubeletProvider client, ", zap.Error(err))
 		return nil, err
@@ -63,7 +63,7 @@ func (k *kubeletProvider) GetSummary() (*stats.Summary, error) {
 }
 
 func createDefaultKubeletProvider(logger *zap.Logger) KubeletProvider {
-	kSP := &kubeletProvider{logger: logger, hostIP: os.Getenv("HOST_IP"), port: ci.KubeSecurePort}
+	kSP := &kubeletProvider{logger: logger, hostIP: os.Getenv("HOST_IP"), hostPort: ci.KubeSecurePort}
 	return kSP
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet/client.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet/client.go
@@ -1,0 +1,52 @@
+//go:build windows
+// +build windows
+
+package kubelet
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil"
+	"go.uber.org/zap"
+	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+)
+
+// KubeletProvider Represents interface to kubelet.
+type KubeletProvider interface {
+	GetSummary() (*stats.Summary, error)
+}
+
+type kubeletProvider struct {
+	logger   *zap.Logger
+	hostIP   string
+	hostPort string
+	client   *kubeletutil.KubeletClient
+}
+
+// getClient Returns singleton kubelet client.
+func (kp *kubeletProvider) getClient() (*kubeletutil.KubeletClient, error) {
+	if kp.client != nil {
+		return kp.client, nil
+	}
+	kclient, err := kubeletutil.NewKubeletClient(kp.hostIP, kp.hostPort, kp.logger)
+	if err != nil {
+		kp.logger.Error("failed to initialize new kubelet client, ", zap.Error(err))
+		return nil, err
+	}
+	kp.client = kclient
+	return kclient, nil
+}
+
+// GetSummary Get Summary from kubelet API.
+func (kp *kubeletProvider) GetSummary() (*stats.Summary, error) {
+	kclient, err := kp.getClient()
+	if err != nil {
+		kp.logger.Error("failed to get kubelet client, ", zap.Error(err))
+		return nil, err
+	}
+
+	summary, err := kclient.Summary(kp.logger)
+	if err != nil {
+		kp.logger.Error("failure from kubelet on getting summary, ", zap.Error(err))
+		return nil, err
+	}
+	return summary, nil
+}

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet/kubelet.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet/kubelet.go
@@ -15,6 +15,7 @@ import (
 	cExtractor "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors"
 
+	"go.uber.org/zap"
 	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 )
 

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet/kubelet_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet/kubelet_test.go
@@ -7,7 +7,6 @@
 package kubelet
 
 import (
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil"
 	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	"testing"
 
@@ -24,10 +23,6 @@ import (
 type MockKubeletProvider struct {
 	logger *zap.Logger
 	t      *testing.T
-}
-
-func (m *MockKubeletProvider) GetClient() (*kubeletutil.KubeletClient, error) {
-	return nil, nil
 }
 
 func (m *MockKubeletProvider) GetSummary() (*stats.Summary, error) {

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet_test.go
@@ -1,0 +1,113 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+// +build windows
+
+package k8swindows
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil"
+	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+	"testing"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	cTestUtils "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows/testutils"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// MockKubeletProvider Mock provider implements KubeletProvider interface.
+type MockKubeletProvider struct {
+	logger *zap.Logger
+	t      *testing.T
+}
+
+func (m *MockKubeletProvider) GetClient() (*kubeletutil.KubeletClient, error) {
+	return nil, nil
+}
+
+func (m *MockKubeletProvider) GetSummary() (*stats.Summary, error) {
+	return testutils.LoadKubeletSummary(m.t, "./extractors/testdata/CurSingleKubeletSummary.json"), nil
+}
+
+func createKubeletDecoratorWithMockKubeletProvider(t *testing.T, logger *zap.Logger) options {
+	return func(provider *kubelet) {
+		provider.kubeletProvider = &MockKubeletProvider{t: t, logger: logger}
+	}
+}
+
+func mockKubeletDependencies() cTestUtils.MockHostInfo {
+	hostInfo := cTestUtils.MockHostInfo{ClusterName: "cluster"}
+	metricsExtractors = []extractors.MetricExtractor{}
+	metricsExtractors = append(metricsExtractors, extractors.NewCPUMetricExtractor(&zap.Logger{}))
+	metricsExtractors = append(metricsExtractors, extractors.NewMemMetricExtractor(&zap.Logger{}))
+	return hostInfo
+}
+
+// TestGetPodMetrics Verify tags on pod and container levels metrics.
+func TestGetPodMetrics(t *testing.T) {
+	hostInfo := mockKubeletDependencies()
+
+	k8sSummaryProvider, err := new(&zap.Logger{}, hostInfo, createKubeletDecoratorWithMockKubeletProvider(t, &zap.Logger{}))
+	summary, err := k8sSummaryProvider.kubeletProvider.GetSummary()
+	metrics, err := k8sSummaryProvider.getPodMetrics(summary)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, metrics)
+
+	podMetric := metrics[1]
+	assert.Equal(t, podMetric.GetMetricType(), ci.TypePod)
+	assert.NotNil(t, podMetric.GetTag(ci.PodIDKey))
+	assert.NotNil(t, podMetric.GetTag(ci.K8sPodNameKey))
+	assert.NotNil(t, podMetric.GetTag(ci.K8sNamespace))
+	assert.NotNil(t, podMetric.GetTag(ci.Timestamp))
+
+	containerMetric := metrics[len(metrics)-1]
+	assert.Equal(t, containerMetric.GetMetricType(), ci.TypeContainer)
+	assert.NotNil(t, containerMetric.GetTag(ci.PodIDKey))
+	assert.NotNil(t, containerMetric.GetTag(ci.K8sPodNameKey))
+	assert.NotNil(t, containerMetric.GetTag(ci.K8sNamespace))
+	assert.NotNil(t, containerMetric.GetTag(ci.Timestamp))
+	assert.NotNil(t, containerMetric.GetTag(ci.ContainerNamekey))
+	assert.NotNil(t, containerMetric.GetTag(ci.ContainerIDkey))
+}
+
+// TestGetContainerMetrics verify tags on container level metrics returned.
+func TestGetContainerMetrics(t *testing.T) {
+	hostInfo := mockKubeletDependencies()
+
+	k8sSummaryProvider, err := new(&zap.Logger{}, hostInfo, createKubeletDecoratorWithMockKubeletProvider(t, &zap.Logger{}))
+	summary, err := k8sSummaryProvider.kubeletProvider.GetSummary()
+
+	metrics, err := k8sSummaryProvider.getContainerMetrics(&summary.Pods[0])
+	assert.NoError(t, err)
+	assert.NotNil(t, metrics)
+
+	containerMetric := metrics[1]
+	assert.Equal(t, containerMetric.GetMetricType(), ci.TypeContainer)
+	assert.NotNil(t, containerMetric.GetTag(ci.PodIDKey))
+	assert.NotNil(t, containerMetric.GetTag(ci.K8sPodNameKey))
+	assert.NotNil(t, containerMetric.GetTag(ci.K8sNamespace))
+	assert.NotNil(t, containerMetric.GetTag(ci.Timestamp))
+	assert.NotNil(t, containerMetric.GetTag(ci.ContainerNamekey))
+	assert.NotNil(t, containerMetric.GetTag(ci.ContainerIDkey))
+}
+
+// TestGetNodeMetrics verify tags on node level metrics.
+func TestGetNodeMetrics(t *testing.T) {
+	hostInfo := mockKubeletDependencies()
+
+	k8sSummaryProvider, err := new(&zap.Logger{}, hostInfo, createKubeletDecoratorWithMockKubeletProvider(t, &zap.Logger{}))
+	summary, err := k8sSummaryProvider.kubeletProvider.GetSummary()
+
+	metrics, err := k8sSummaryProvider.getNodeMetrics(summary)
+	assert.NoError(t, err)
+	assert.NotNil(t, metrics)
+
+	containerMetric := metrics[1]
+	assert.Equal(t, containerMetric.GetMetricType(), ci.TypeNode)
+}


### PR DESCRIPTION
**Description:** 
Add container level CPU and memory metrics collection
  1. Add metric collection at container level
  2. Refactor existing kubelet code to make it unit testable.
  3. Add units for kubelet to test pod, node and container level metric collection.

**Testing:** 
1. Local unit tests passed correctly.
2. contaner level metrics are visible in CW dashboard
<img width="1191" alt="Screenshot 2024-01-06 at 2 21 04 AM" src="https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/10296556/cb551166-0848-4cb8-963c-93857c5f4281">
