### PR TITLE
Fix CPU utilization percentage for Windows nodes

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/host/nodeCapacity_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/nodeCapacity_test.go
@@ -66,8 +66,8 @@ func TestNodeCapacity(t *testing.T) {
 	cpuInfoOption = func(nc *nodeCapacity) {
 		nc.cpuInfo = func(ctx context.Context) ([]cpu.InfoStat, error) {
 			return []cpu.InfoStat{
-				{},
-				{},
+				{Cores: 1},
+				{Cores: 1},
 			}, nil
 		}
 	}

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractor.go
@@ -31,6 +31,7 @@ type MemoryStat struct {
 // FileSystemStat for Container and Node.
 type FileSystemStat struct {
 	Time           time.Time
+	Name           string
 	AvailableBytes uint64
 	CapacityBytes  uint64
 	UsedBytes      uint64

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractorhelpers.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractorhelpers.go
@@ -163,10 +163,14 @@ func ConvertContainerToRaw(containerStat stats.ContainerStats, podStat stats.Pod
 
 	rawMetic.FileSystemStats = []FileSystemStat{}
 	if containerStat.Rootfs != nil {
-		rawMetic.FileSystemStats = append(rawMetic.FileSystemStats, convertFileSystemStats(*containerStat.Rootfs))
+		fStat := convertFileSystemStats(*containerStat.Rootfs)
+		fStat.Name = "rootfs"
+		rawMetic.FileSystemStats = append(rawMetic.FileSystemStats)
 	}
 	if containerStat.Logs != nil {
-		rawMetic.FileSystemStats = append(rawMetic.FileSystemStats, convertFileSystemStats(*containerStat.Logs))
+		fStat := convertFileSystemStats(*containerStat.Logs)
+		fStat.Name = "logs"
+		rawMetic.FileSystemStats = append(rawMetic.FileSystemStats)
 	}
 
 	return rawMetic

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractorhelpers.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractorhelpers.go
@@ -169,7 +169,7 @@ func ConvertContainerToRaw(containerStat stats.ContainerStats, podStat stats.Pod
 	}
 	if containerStat.Logs != nil {
 		fStat := convertFileSystemStats(*containerStat.Logs)
-		fStat.Name = "logs"
+		fStat.Name = "logfs"
 		rawMetic.FileSystemStats = append(rawMetic.FileSystemStats, fStat)
 	}
 

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractorhelpers.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractorhelpers.go
@@ -165,12 +165,12 @@ func ConvertContainerToRaw(containerStat stats.ContainerStats, podStat stats.Pod
 	if containerStat.Rootfs != nil {
 		fStat := convertFileSystemStats(*containerStat.Rootfs)
 		fStat.Name = "rootfs"
-		rawMetic.FileSystemStats = append(rawMetic.FileSystemStats)
+		rawMetic.FileSystemStats = append(rawMetic.FileSystemStats, fStat)
 	}
 	if containerStat.Logs != nil {
 		fStat := convertFileSystemStats(*containerStat.Logs)
 		fStat.Name = "logs"
-		rawMetic.FileSystemStats = append(rawMetic.FileSystemStats)
+		rawMetic.FileSystemStats = append(rawMetic.FileSystemStats, fStat)
 	}
 
 	return rawMetic

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/fs_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/fs_extractor.go
@@ -31,19 +31,21 @@ func (f *FileSystemMetricExtractor) GetValue(rawMetric RawMetric, _ cExtractor.C
 	containerType = getFSMetricType(containerType, f.logger)
 	metrics := make([]*cExtractor.CAdvisorMetric, 0, len(rawMetric.FileSystemStats))
 
-	for _, v := range rawMetric.FileSystemStats {
-		metric := cExtractor.NewCadvisorMetric(containerType, f.logger)
+	metric := cExtractor.NewCadvisorMetric(containerType, f.logger)
 
-		metric.AddField(ci.MetricName(containerType, ci.FSUsage), v.UsedBytes)
+	var usedBytes uint64
+	for _, v := range rawMetric.FileSystemStats {
+
+		usedBytes += v.UsedBytes
+		metric.AddField(ci.MetricName(containerType, ci.FSUsage), usedBytes)
 		metric.AddField(ci.MetricName(containerType, ci.FSCapacity), v.CapacityBytes)
 		metric.AddField(ci.MetricName(containerType, ci.FSAvailable), v.AvailableBytes)
 
 		if v.CapacityBytes != 0 {
 			metric.AddField(ci.MetricName(containerType, ci.FSUtilization), float64(v.UsedBytes)/float64(v.CapacityBytes)*100)
 		}
-
-		metrics = append(metrics, metric)
 	}
+	metrics = append(metrics, metric)
 	return metrics
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/fs_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/fs_extractor_test.go
@@ -66,7 +66,8 @@ func TestFSStats(t *testing.T) {
 		"container_filesystem_utilization": float64(0.3955174875484043),
 	}
 	expectedTags = map[string]string{
-		"Type": "ContainerFS",
+		"device": "rootfs",
+		"Type":   "ContainerFS",
 	}
 	cExtractor.AssertContainsTaggedField(t, cMetrics[0], expectedFields, expectedTags)
 
@@ -77,7 +78,8 @@ func TestFSStats(t *testing.T) {
 		"container_filesystem_utilization": float64(0.0010704219949207732),
 	}
 	expectedTags = map[string]string{
-		"Type": "ContainerFS",
+		"device": "logfs",
+		"Type":   "ContainerFS",
 	}
 	cExtractor.AssertContainsTaggedField(t, cMetrics[1], expectedFields, expectedTags)
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Windows server 2019 nodes showed CPU utilization above 100 when customer workload is deployed. This patch will fix this issue for Windows.
GetCPUCores returned number of physical cores but this patch will consider virtual cores on machine.

**Testing:** <Describe what testing was performed and which tests were added.>
1. Unit tests pass for extractors
2. e2e tests for Windows node worked and CPU utilization is comparative with CPU usage in task manager.
