### PR TITLE
Add password file option to JMX config.

### DIFF
--- a/.chloggen-aws/jmx-update-config.yaml
+++ b/.chloggen-aws/jmx-update-config.yaml
@@ -1,0 +1,23 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: jmxreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds a `password_file` option to the JMX receiver config.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [162]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Allows the passwords to be read in through a separate file instead of being set directly in the |
+  receiver YAML. Performs config validation to check if file exists, can be read, and is owner-only accessible. |
+  Also sets authentication related fields to `omitempty`.
+
+# e.g. '[aws]'
+# Include 'aws' if the change is done done by cwa
+# Default: '[user]'
+change_logs: [aws]

--- a/receiver/jmxreceiver/go.mod
+++ b/receiver/jmxreceiver/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxrec
 go 1.20
 
 require (
+	github.com/magiconair/properties v1.8.7
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.89.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.89.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.89.0
@@ -52,7 +53,6 @@ require (
 	github.com/knadh/koanf/providers/confmap v0.1.0 // indirect
 	github.com/knadh/koanf/v2 v2.0.1 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
-	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/receiver/jmxreceiver/receiver.go
+++ b/receiver/jmxreceiver/receiver.go
@@ -165,9 +165,9 @@ func (jmx *jmxMetricReceiver) buildOTLPReceiver() (receiver.Metrics, error) {
 func (jmx *jmxMetricReceiver) buildJMXMetricGathererConfig() (string, error) {
 	config := map[string]string{}
 	failedToParse := `failed to parse Endpoint "%s": %w`
-	parsed, err := url.Parse(jmx.config.Endpoint)
-	if err != nil {
-		return "", fmt.Errorf(failedToParse, jmx.config.Endpoint, err)
+	parsed, parseErr := url.Parse(jmx.config.Endpoint)
+	if parseErr != nil {
+		return "", fmt.Errorf(failedToParse, jmx.config.Endpoint, parseErr)
 	}
 
 	if !(parsed.Scheme == "service" && strings.HasPrefix(parsed.Opaque, "jmx:")) {
@@ -201,9 +201,10 @@ func (jmx *jmxMetricReceiver) buildJMXMetricGathererConfig() (string, error) {
 
 	var passwordMap map[string]string
 	if jmx.config.PasswordFile != "" {
+		var err error
 		passwordMap, err = parsePasswordFile(jmx.config.PasswordFile)
 		if err != nil {
-			jmx.logger.Error("issue with password retrieval", zap.Error(err))
+			jmx.logger.Error("Unable to retrieve password from file", zap.Error(err))
 		}
 	}
 


### PR DESCRIPTION
**Description:** Instead of storing the password in plaintext in the receiver config, provide the option to read it in from a read-restricted file in a Java Properties file format.

**Testing:** Built and tested.
On start up if the file is missing:
```
receivers::jmx: `password_file` is inaccessible: stat /home/ec2-user/jmxremote.password: no such file or directory
```
When file is not read-restricted:
```
receivers::jmx: `password_file` read access must be restricted to owner-only: /home/ec2-user/jmxremote.password
```
If both are valid, then on start up the password will be present in the `jmx-config-*.properties` file, which has 0600 access.

A known issue is that if the file is also being used by the JMX agent and the file has read-write permissions, the JMX agent will hash the password, which the collector cannot use. The collector should use a separate file with only the passwords it needs.

**Documentation:** Added field to README for receiver.