### PR TITLE
Add fstype and fsdev in ContainerFS metrics

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractor.go
@@ -32,6 +32,8 @@ type MemoryStat struct {
 type FileSystemStat struct {
 	Time           time.Time
 	Name           string
+	Device         string
+	Type           string
 	AvailableBytes uint64
 	CapacityBytes  uint64
 	UsedBytes      uint64

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/fs_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/fs_extractor.go
@@ -34,9 +34,8 @@ func (f *FileSystemMetricExtractor) GetValue(rawMetric RawMetric, _ cExtractor.C
 	for _, v := range rawMetric.FileSystemStats {
 		metric := cExtractor.NewCadvisorMetric(containerType, f.logger)
 
-		if v.Name != "" {
-			metric.AddTag(ci.DiskDev, v.Name)
-		}
+		metric.AddTag(ci.DiskDev, v.Device)
+		metric.AddTag(ci.FSType, v.Type)
 
 		metric.AddField(ci.MetricName(containerType, ci.FSUsage), v.UsedBytes)
 		metric.AddField(ci.MetricName(containerType, ci.FSCapacity), v.CapacityBytes)

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/fs_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/fs_extractor_test.go
@@ -35,7 +35,9 @@ func TestFSStats(t *testing.T) {
 		"node_filesystem_utilization": float64(40.358791544917224),
 	}
 	expectedTags := map[string]string{
-		"Type": "NodeFS",
+		"fstype": "",
+		"device": "",
+		"Type":   "NodeFS",
 	}
 	cExtractor.AssertContainsTaggedField(t, cMetrics[0], expectedFields, expectedTags)
 
@@ -66,7 +68,8 @@ func TestFSStats(t *testing.T) {
 		"container_filesystem_utilization": float64(0.3955174875484043),
 	}
 	expectedTags = map[string]string{
-		"device": "rootfs",
+		"fstype": "",
+		"device": "",
 		"Type":   "ContainerFS",
 	}
 	cExtractor.AssertContainsTaggedField(t, cMetrics[0], expectedFields, expectedTags)
@@ -78,7 +81,8 @@ func TestFSStats(t *testing.T) {
 		"container_filesystem_utilization": float64(0.0010704219949207732),
 	}
 	expectedTags = map[string]string{
-		"device": "logfs",
+		"fstype": "",
+		"device": "",
 		"Type":   "ContainerFS",
 	}
 	cExtractor.AssertContainsTaggedField(t, cMetrics[1], expectedFields, expectedTags)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Add fstype and fsdev in ContainerFS metrics. Values for these two tags will be empty.

**Testing:** <Describe what testing was performed and which tests were added.>
1. Tested this with integ tests