### PR TITLE
[exporter/awsemfexporter] Add app signals specific user agent.

### DIFF
--- a/.chloggen-aws/sdk-telemetry-user-agent.yaml
+++ b/.chloggen-aws/sdk-telemetry-user-agent.yaml
@@ -1,0 +1,21 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsemfexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds additional user agents for the telemetry SDKs if AppSignals is enabled.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [170]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# e.g. '[aws]'
+# Include 'aws' if the change is done done by cwa
+# Default: '[user]'
+change_logs: [aws]

--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -421,6 +421,7 @@ require (
 	github.com/jcmturner/gofork v1.7.6 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
+	github.com/jellydator/ttlcache/v3 v3.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect

--- a/cmd/configschema/go.sum
+++ b/cmd/configschema/go.sum
@@ -990,6 +990,8 @@ github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh6
 github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
+github.com/jellydator/ttlcache/v3 v3.1.0 h1:0gPFG0IHHP6xyUyXq+JaD8fwkDCqgqwohXNJBcYE71g=
+github.com/jellydator/ttlcache/v3 v3.1.0/go.mod h1:hi7MGFdMAwZna5n2tuvh63DvFLzVKySzCVW6+0gA2n4=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -466,6 +466,7 @@ require (
 	github.com/jcmturner/gofork v1.7.6 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
+	github.com/jellydator/ttlcache/v3 v3.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect

--- a/cmd/otelcontribcol/go.sum
+++ b/cmd/otelcontribcol/go.sum
@@ -987,6 +987,8 @@ github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh6
 github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
+github.com/jellydator/ttlcache/v3 v3.1.0 h1:0gPFG0IHHP6xyUyXq+JaD8fwkDCqgqwohXNJBcYE71g=
+github.com/jellydator/ttlcache/v3 v3.1.0/go.mod h1:hi7MGFdMAwZna5n2tuvh63DvFLzVKySzCVW6+0gA2n4=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=

--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter/internal/appsignals"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs"
 )
@@ -44,6 +45,8 @@ type emfExporter struct {
 	pusherMapLock sync.Mutex
 	retryCnt      int
 	collectorID   string
+
+	processResourceLabels func(map[string]string)
 }
 
 // newEmfExporter creates a new exporter using exporterhelper
@@ -71,19 +74,26 @@ func newEmfExporter(config *Config, set exporter.CreateSettings) (*emfExporter, 
 		cwlogs.WithEnabledContainerInsights(config.IsEnhancedContainerInsights()),
 		cwlogs.WithEnabledAppSignals(config.IsAppSignalsEnabled()),
 	)
-	collectorIdentifier, err := uuid.NewRandom()
 
+	collectorIdentifier, err := uuid.NewRandom()
 	if err != nil {
 		return nil, err
 	}
 
 	emfExporter := &emfExporter{
-		svcStructuredLog: svcStructuredLog,
-		config:           config,
-		metricTranslator: newMetricTranslator(*config),
-		retryCnt:         *awsConfig.MaxRetries,
-		collectorID:      collectorIdentifier.String(),
-		pusherMap:        map[cwlogs.StreamKey]cwlogs.Pusher{},
+		svcStructuredLog:      svcStructuredLog,
+		config:                config,
+		metricTranslator:      newMetricTranslator(*config),
+		retryCnt:              *awsConfig.MaxRetries,
+		collectorID:           collectorIdentifier.String(),
+		pusherMap:             map[cwlogs.StreamKey]cwlogs.Pusher{},
+		processResourceLabels: func(map[string]string) {},
+	}
+
+	if config.IsAppSignalsEnabled() {
+		userAgent := appsignals.NewUserAgent()
+		svcStructuredLog.Handlers().Build.PushBackNamed(userAgent.Handler())
+		emfExporter.processResourceLabels = userAgent.Process
 	}
 
 	config.logger.Warn("the default value for DimensionRollupOption will be changing to NoDimensionRollup" +
@@ -107,6 +117,7 @@ func (emf *emfExporter) pushMetricsData(_ context.Context, md pmetric.Metrics) e
 		}
 	}
 	emf.config.logger.Info("Start processing resource metrics", zap.Any("labels", labels))
+	emf.processResourceLabels(labels)
 
 	groupedMetrics := make(map[any]*groupedMetric)
 	defaultLogStream := fmt.Sprintf("otel-stream-%s", emf.collectorID)

--- a/exporter/awsemfexporter/go.mod
+++ b/exporter/awsemfexporter/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware v0.0.0-00010101000000-000000000000
 	github.com/aws/aws-sdk-go v1.47.10
 	github.com/google/uuid v1.4.0
+	github.com/jellydator/ttlcache/v3 v3.1.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.89.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs v0.89.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics v0.89.0
@@ -54,6 +55,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.20.0 // indirect
 	go.opentelemetry.io/otel/trace v1.20.0 // indirect
 	golang.org/x/net v0.18.0 // indirect
+	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.14.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d // indirect

--- a/exporter/awsemfexporter/go.sum
+++ b/exporter/awsemfexporter/go.sum
@@ -66,6 +66,8 @@ github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
 github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/jellydator/ttlcache/v3 v3.1.0 h1:0gPFG0IHHP6xyUyXq+JaD8fwkDCqgqwohXNJBcYE71g=
+github.com/jellydator/ttlcache/v3 v3.1.0/go.mod h1:hi7MGFdMAwZna5n2tuvh63DvFLzVKySzCVW6+0gA2n4=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
@@ -181,6 +183,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/exporter/awsemfexporter/internal/appsignals/useragent.go
+++ b/exporter/awsemfexporter/internal/appsignals/useragent.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/jellydator/ttlcache/v3"
-	semconv "go.opentelemetry.io/collector/semconv/v1.6.1"
+	semconv "go.opentelemetry.io/collector/semconv/v1.18.0"
 )
 
 const (
@@ -24,6 +24,9 @@ const (
 	cacheSize = 5
 	// attrLengthLimit is the maximum length of the language and version that will be used for the user agent.
 	attrLengthLimit = 20
+
+	// TODO: Available in semconv/v1.21.0+. Replace after collector dependency is v0.91.0+.
+	attributeTelemetryDistroVersion = "telemetry.distro.version"
 )
 
 type UserAgent struct {
@@ -69,7 +72,10 @@ func (ua *UserAgent) handle(r *request.Request) {
 // cache and has the same value, extends the TTL. If not, then it sets it and rebuilds the user agent string.
 func (ua *UserAgent) Process(labels map[string]string) {
 	language := labels[semconv.AttributeTelemetrySDKLanguage]
-	version := labels[semconv.AttributeTelemetryAutoVersion]
+	version := labels[attributeTelemetryDistroVersion]
+	if version == "" {
+		version = labels[semconv.AttributeTelemetryAutoVersion]
+	}
 	if language != "" && version != "" {
 		language = truncate(language, attrLengthLimit)
 		version = truncate(version, attrLengthLimit)

--- a/exporter/awsemfexporter/internal/appsignals/useragent.go
+++ b/exporter/awsemfexporter/internal/appsignals/useragent.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package appsignals
 
 import (

--- a/exporter/awsemfexporter/internal/appsignals/useragent.go
+++ b/exporter/awsemfexporter/internal/appsignals/useragent.go
@@ -1,0 +1,81 @@
+package appsignals
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/jellydator/ttlcache/v3"
+	semconv "go.opentelemetry.io/collector/semconv/v1.6.1"
+)
+
+const (
+	handlerName = "aws.appsignals.UserAgentHandler"
+)
+
+type UserAgent struct {
+	mu       sync.RWMutex
+	prebuilt []string
+	cache    *ttlcache.Cache[string, string]
+}
+
+func NewUserAgent() *UserAgent {
+	return newUserAgent(time.Minute)
+}
+
+func newUserAgent(ttl time.Duration) *UserAgent {
+	ua := &UserAgent{cache: ttlcache.New[string, string](ttlcache.WithTTL[string, string](ttl))}
+	ua.cache.OnEviction(func(context.Context, ttlcache.EvictionReason, *ttlcache.Item[string, string]) {
+		ua.rebuild()
+	})
+	go ua.cache.Start()
+	return ua
+}
+
+// Handler creates a named handler with the UserAgent's handle function.
+func (h *UserAgent) Handler() request.NamedHandler {
+	return request.NamedHandler{
+		Name: handlerName,
+		Fn:   h.handle,
+	}
+}
+
+// handle adds the pre-built user agent strings to the user agent header.
+func (h *UserAgent) handle(r *request.Request) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for _, str := range h.prebuilt {
+		request.AddToUserAgent(r, str)
+	}
+}
+
+// formatStr formats the telemetry SDK language and version into the user agent format.
+func formatStr(language, version string) string {
+	return fmt.Sprintf("telemetry-sdk-%s/%s", language, version)
+}
+
+// Process takes the telemetry SDK language and version and adds them to the cache. If it already exists in the cache
+// and has the same value, extends the TTL. If not, then it sets it and rebuilds the user agent strings.
+func (h *UserAgent) Process(labels map[string]string) {
+	language := labels[semconv.AttributeTelemetrySDKLanguage]
+	version := labels[semconv.AttributeTelemetrySDKVersion]
+	if language != "" && version != "" {
+		value := h.cache.Get(language)
+		if value == nil || value.Value() != version {
+			h.cache.Set(language, version, ttlcache.DefaultTTL)
+			h.rebuild()
+		}
+	}
+}
+
+func (h *UserAgent) rebuild() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	items := h.cache.Items()
+	h.prebuilt = make([]string, 0, len(items))
+	for _, item := range h.cache.Items() {
+		h.prebuilt = append(h.prebuilt, formatStr(item.Key(), item.Value()))
+	}
+}

--- a/exporter/awsemfexporter/internal/appsignals/useragent.go
+++ b/exporter/awsemfexporter/internal/appsignals/useragent.go
@@ -69,7 +69,7 @@ func (ua *UserAgent) handle(r *request.Request) {
 // cache and has the same value, extends the TTL. If not, then it sets it and rebuilds the user agent string.
 func (ua *UserAgent) Process(labels map[string]string) {
 	language := labels[semconv.AttributeTelemetrySDKLanguage]
-	version := labels[semconv.AttributeTelemetrySDKVersion]
+	version := labels[semconv.AttributeTelemetryAutoVersion]
 	if language != "" && version != "" {
 		language = truncate(language, attrLengthLimit)
 		version = truncate(version, attrLengthLimit)

--- a/exporter/awsemfexporter/internal/appsignals/useragent_test.go
+++ b/exporter/awsemfexporter/internal/appsignals/useragent_test.go
@@ -52,6 +52,17 @@ func TestUserAgent(t *testing.T) {
 				"telemetry-sdk-test/1.0",
 			},
 		},
+		"WithTruncatedAttributes": {
+			labelSets: []map[string]string{
+				{
+					semconv.AttributeTelemetrySDKLanguage: " incrediblyverboselanguagename",
+					semconv.AttributeTelemetrySDKVersion:  "notsemanticversioningversion",
+				},
+			},
+			want: []string{
+				"telemetry-sdk-incrediblyverboselan/notsemanticversionin",
+			},
+		},
 	}
 
 	for name, testCase := range testCases {

--- a/exporter/awsemfexporter/internal/appsignals/useragent_test.go
+++ b/exporter/awsemfexporter/internal/appsignals/useragent_test.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package appsignals
 
 import (

--- a/exporter/awsemfexporter/internal/appsignals/useragent_test.go
+++ b/exporter/awsemfexporter/internal/appsignals/useragent_test.go
@@ -1,0 +1,101 @@
+package appsignals
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/stretchr/testify/assert"
+	semconv "go.opentelemetry.io/collector/semconv/v1.6.1"
+)
+
+func TestUserAgent(t *testing.T) {
+	testCases := map[string]struct {
+		labelSets []map[string]string
+		want      []string
+	}{
+		"WithEmpty": {},
+		"WithMultipleLanguages": {
+			labelSets: []map[string]string{
+				{
+					semconv.AttributeTelemetrySDKLanguage: "foo",
+					semconv.AttributeTelemetrySDKVersion:  "1.1",
+				},
+				{
+					semconv.AttributeTelemetrySDKLanguage: "bar",
+					semconv.AttributeTelemetrySDKVersion:  "1.0",
+				},
+			},
+			want: []string{
+				"telemetry-sdk-bar/1.0",
+				"telemetry-sdk-foo/1.1",
+			},
+		},
+		"WithMultipleVersions": {
+			labelSets: []map[string]string{
+				{
+					semconv.AttributeTelemetrySDKLanguage: "test",
+					semconv.AttributeTelemetrySDKVersion:  "1.1",
+				},
+				{
+					semconv.AttributeTelemetrySDKLanguage: "test",
+					semconv.AttributeTelemetrySDKVersion:  "1.0",
+				},
+			},
+			want: []string{
+				"telemetry-sdk-test/1.0",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			userAgent := NewUserAgent()
+			for _, labelSet := range testCase.labelSets {
+				userAgent.Process(labelSet)
+			}
+			req := &request.Request{
+				HTTPRequest: &http.Request{
+					Header: http.Header{},
+				},
+			}
+			userAgent.Handler().Fn(req)
+			got := req.HTTPRequest.Header.Get("User-Agent")
+			if got == "" {
+				assert.Empty(t, testCase.want)
+			} else {
+				gotUserAgents := strings.Split(got, " ")
+				sort.Strings(gotUserAgents)
+				assert.Equal(t, testCase.want, gotUserAgents)
+			}
+		})
+	}
+}
+
+func TestUserAgentExpiration(t *testing.T) {
+	userAgent := newUserAgent(50 * time.Millisecond)
+	req := &request.Request{
+		HTTPRequest: &http.Request{
+			Header: http.Header{},
+		},
+	}
+	labels := map[string]string{
+		semconv.AttributeTelemetrySDKLanguage: "test",
+		semconv.AttributeTelemetrySDKVersion:  "1.0",
+	}
+	userAgent.Process(labels)
+	userAgent.handle(req)
+	got := req.HTTPRequest.Header.Get("User-Agent")
+	assert.Equal(t, "telemetry-sdk-test/1.0", got)
+
+	// wait for expiration
+	time.Sleep(100 * time.Millisecond)
+	// reset user-agent header
+	req.HTTPRequest.Header.Del("User-Agent")
+	userAgent.handle(req)
+	got = req.HTTPRequest.Header.Get("User-Agent")
+	assert.Empty(t, got)
+}

--- a/exporter/awsemfexporter/internal/appsignals/useragent_test.go
+++ b/exporter/awsemfexporter/internal/appsignals/useragent_test.go
@@ -5,8 +5,6 @@ package appsignals
 
 import (
 	"net/http"
-	"sort"
-	"strings"
 	"testing"
 	"time"
 
@@ -18,7 +16,7 @@ import (
 func TestUserAgent(t *testing.T) {
 	testCases := map[string]struct {
 		labelSets []map[string]string
-		want      []string
+		want      string
 	}{
 		"WithEmpty": {},
 		"WithMultipleLanguages": {
@@ -32,10 +30,7 @@ func TestUserAgent(t *testing.T) {
 					semconv.AttributeTelemetrySDKVersion:  "1.0",
 				},
 			},
-			want: []string{
-				"telemetry-sdk-bar/1.0",
-				"telemetry-sdk-foo/1.1",
-			},
+			want: "telemetry-sdk (bar/1.0;foo/1.1)",
 		},
 		"WithMultipleVersions": {
 			labelSets: []map[string]string{
@@ -48,9 +43,7 @@ func TestUserAgent(t *testing.T) {
 					semconv.AttributeTelemetrySDKVersion:  "1.0",
 				},
 			},
-			want: []string{
-				"telemetry-sdk-test/1.0",
-			},
+			want: "telemetry-sdk (test/1.0)",
 		},
 		"WithTruncatedAttributes": {
 			labelSets: []map[string]string{
@@ -59,9 +52,7 @@ func TestUserAgent(t *testing.T) {
 					semconv.AttributeTelemetrySDKVersion:  "notsemanticversioningversion",
 				},
 			},
-			want: []string{
-				"telemetry-sdk-incrediblyverboselan/notsemanticversionin",
-			},
+			want: "telemetry-sdk (incrediblyverboselan/notsemanticversionin)",
 		},
 	}
 
@@ -81,9 +72,7 @@ func TestUserAgent(t *testing.T) {
 			if got == "" {
 				assert.Empty(t, testCase.want)
 			} else {
-				gotUserAgents := strings.Split(got, " ")
-				sort.Strings(gotUserAgents)
-				assert.Equal(t, testCase.want, gotUserAgents)
+				assert.Equal(t, testCase.want, got)
 			}
 		})
 	}
@@ -103,7 +92,7 @@ func TestUserAgentExpiration(t *testing.T) {
 	userAgent.Process(labels)
 	userAgent.handle(req)
 	got := req.HTTPRequest.Header.Get("User-Agent")
-	assert.Equal(t, "telemetry-sdk-test/1.0", got)
+	assert.Equal(t, "telemetry-sdk (test/1.0)", got)
 
 	// wait for expiration
 	time.Sleep(100 * time.Millisecond)

--- a/exporter/awsemfexporter/internal/appsignals/useragent_test.go
+++ b/exporter/awsemfexporter/internal/appsignals/useragent_test.go
@@ -23,11 +23,11 @@ func TestUserAgent(t *testing.T) {
 			labelSets: []map[string]string{
 				{
 					semconv.AttributeTelemetrySDKLanguage: "foo",
-					semconv.AttributeTelemetrySDKVersion:  "1.1",
+					semconv.AttributeTelemetryAutoVersion: "1.1",
 				},
 				{
 					semconv.AttributeTelemetrySDKLanguage: "bar",
-					semconv.AttributeTelemetrySDKVersion:  "1.0",
+					semconv.AttributeTelemetryAutoVersion: "1.0",
 				},
 			},
 			want: "telemetry-sdk (bar/1.0;foo/1.1)",
@@ -36,11 +36,11 @@ func TestUserAgent(t *testing.T) {
 			labelSets: []map[string]string{
 				{
 					semconv.AttributeTelemetrySDKLanguage: "test",
-					semconv.AttributeTelemetrySDKVersion:  "1.1",
+					semconv.AttributeTelemetryAutoVersion: "1.1",
 				},
 				{
 					semconv.AttributeTelemetrySDKLanguage: "test",
-					semconv.AttributeTelemetrySDKVersion:  "1.0",
+					semconv.AttributeTelemetryAutoVersion: "1.0",
 				},
 			},
 			want: "telemetry-sdk (test/1.0)",
@@ -49,7 +49,7 @@ func TestUserAgent(t *testing.T) {
 			labelSets: []map[string]string{
 				{
 					semconv.AttributeTelemetrySDKLanguage: " incrediblyverboselanguagename",
-					semconv.AttributeTelemetrySDKVersion:  "notsemanticversioningversion",
+					semconv.AttributeTelemetryAutoVersion: "notsemanticversioningversion",
 				},
 			},
 			want: "telemetry-sdk (incrediblyverboselan/notsemanticversionin)",
@@ -87,7 +87,7 @@ func TestUserAgentExpiration(t *testing.T) {
 	}
 	labels := map[string]string{
 		semconv.AttributeTelemetrySDKLanguage: "test",
-		semconv.AttributeTelemetrySDKVersion:  "1.0",
+		semconv.AttributeTelemetryAutoVersion: "1.0",
 	}
 	userAgent.Process(labels)
 	userAgent.handle(req)

--- a/go.mod
+++ b/go.mod
@@ -441,6 +441,7 @@ require (
 	github.com/jcmturner/gofork v1.7.6 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
+	github.com/jellydator/ttlcache/v3 v3.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -995,6 +995,8 @@ github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh6
 github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
+github.com/jellydator/ttlcache/v3 v3.1.0 h1:0gPFG0IHHP6xyUyXq+JaD8fwkDCqgqwohXNJBcYE71g=
+github.com/jellydator/ttlcache/v3 v3.1.0/go.mod h1:hi7MGFdMAwZna5n2tuvh63DvFLzVKySzCVW6+0gA2n4=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=


### PR DESCRIPTION
**Description:** Adds additional user agent if configured for App Signals. Extracts the SDK Telemetry attributes from the resource attributes to build the user agent strings. Uses a TTL cache to keep track of the language/version pairs received by the exporter. 

**Testing:** Built (w/ AWS SDK LogLevel set to `LogDebug`).
```
│ -----------------------------------------------------                                                                                                                                                                                                                                                                                                                  │
│ 2024/02/26 23:05:41 DEBUG: Request logs/PutLogEvents Details:                                                                                                                                                                                                                                                                                                          │
│ ---[ REQUEST POST-SIGN ]-----------------------------                                                                                                                                                                                                                                                                                                                  │
│ POST / HTTP/1.1                                                                                                                                                                                                                                                                                                                                                        │
│ Host: logs.us-east-2.amazonaws.com                                                                                                                                                                                                                                                                                                                                     │
│ User-Agent: CWAgent/Unknown (go1.20.12; linux; amd64) ID/2cad80d1-f569-451e-86af-6ca4668c0e84 inputs:(otlp) processors:(awsappsignals resourcedetection) outputs:(app_signals awsemf awsxray cloudwatchlogs) CWAgent/Unknown (AppSignals) aws-sdk-go/1.48.6 (go1.20.12; linux; amd64) telemetry-sdk-java/1.31.0                                                        │
```