### PR TITLE
http semantic convention 1.23.0 support

### DIFF
--- a/.chloggen/aws-xray-exporter-http-semconv-stable.yaml
+++ b/.chloggen/aws-xray-exporter-http-semconv-stable.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsxrayexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: support both deprecated and stable http attributes translation for backward compatibility.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30935]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/awsxrayexporter/internal/translator/http.go
+++ b/exporter/awsxrayexporter/internal/translator/http.go
@@ -4,6 +4,7 @@
 package translator // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter/internal/translator"
 
 import (
+	"net"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,6 +13,19 @@ import (
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
+)
+
+const (
+	AttributeHTTPRequestMethod      = "http.request.method"
+	AttributeHTTPResponseStatusCode = "http.response.status_code"
+	AttributeServerAddress          = "server.address"
+	AttributeServerPort             = "server.port"
+	AttributeNetworkPeerAddress     = "network.peer.address"
+	AttributeClientAddress          = "client.address"
+	AttributeURLScheme              = "url.scheme"
+	AttributeURLFull                = "url.full"
+	AttributeURLPath                = "url.path"
+	AttributeUserAgentOriginal      = "user_agent.original"
 )
 
 func makeHTTP(span ptrace.Span) (map[string]pcommon.Value, *awsxray.HTTPData) {
@@ -30,28 +44,28 @@ func makeHTTP(span ptrace.Span) (map[string]pcommon.Value, *awsxray.HTTPData) {
 
 	hasHTTP := false
 	hasHTTPRequestURLAttributes := false
+	hasNetPeerAddr := false
 
 	span.Attributes().Range(func(key string, value pcommon.Value) bool {
 		switch key {
-		case conventions.AttributeHTTPMethod:
+		case conventions.AttributeHTTPMethod, AttributeHTTPRequestMethod:
 			info.Request.Method = awsxray.String(value.Str())
 			hasHTTP = true
 		case conventions.AttributeHTTPClientIP:
 			info.Request.ClientIP = awsxray.String(value.Str())
-			info.Request.XForwardedFor = aws.Bool(true)
 			hasHTTP = true
-		case conventions.AttributeHTTPUserAgent:
+		case conventions.AttributeHTTPUserAgent, AttributeUserAgentOriginal:
 			info.Request.UserAgent = awsxray.String(value.Str())
 			hasHTTP = true
-		case conventions.AttributeHTTPStatusCode:
+		case conventions.AttributeHTTPStatusCode, AttributeHTTPResponseStatusCode:
 			info.Response.Status = aws.Int64(value.Int())
 			hasHTTP = true
-		case conventions.AttributeHTTPURL:
-			urlParts[key] = value.Str()
+		case conventions.AttributeHTTPURL, AttributeURLFull:
+			urlParts[conventions.AttributeHTTPURL] = value.Str()
 			hasHTTP = true
 			hasHTTPRequestURLAttributes = true
-		case conventions.AttributeHTTPScheme:
-			urlParts[key] = value.Str()
+		case conventions.AttributeHTTPScheme, AttributeURLScheme:
+			urlParts[conventions.AttributeHTTPScheme] = value.Str()
 			hasHTTP = true
 		case conventions.AttributeHTTPHost:
 			urlParts[key] = value.Str()
@@ -90,11 +104,40 @@ func makeHTTP(span ptrace.Span) (map[string]pcommon.Value, *awsxray.HTTPData) {
 			}
 			urlParts[key] = value.Str()
 			hasHTTPRequestURLAttributes = true
+			hasNetPeerAddr = true
+		case AttributeNetworkPeerAddress:
+			// Prefer HTTP forwarded information (AttributeHTTPClientIP) when present.
+			if net.ParseIP(value.Str()) != nil {
+				if info.Request.ClientIP == nil {
+					info.Request.ClientIP = awsxray.String(value.Str())
+				}
+				hasHTTPRequestURLAttributes = true
+				hasNetPeerAddr = true
+			}
+		case AttributeClientAddress:
+			if net.ParseIP(value.Str()) != nil {
+				info.Request.ClientIP = awsxray.String(value.Str())
+			}
+		case AttributeURLPath:
+			urlParts[key] = value.Str()
+			hasHTTP = true
+		case AttributeServerAddress:
+			urlParts[key] = value.Str()
+			hasHTTPRequestURLAttributes = true
+		case AttributeServerPort:
+			urlParts[key] = value.Str()
+			if len(urlParts[key]) == 0 {
+				urlParts[key] = strconv.FormatInt(value.Int(), 10)
+			}
 		default:
 			filtered[key] = value
 		}
 		return true
 	})
+
+	if !hasNetPeerAddr && info.Request.ClientIP != nil {
+		info.Request.XForwardedFor = aws.Bool(true)
+	}
 
 	if !hasHTTP {
 		// Didn't have any HTTP-specific information so don't need to fill it in segment
@@ -142,7 +185,7 @@ func extractResponseSizeFromAttributes(attributes pcommon.Map) int64 {
 
 func constructClientURL(urlParts map[string]string) string {
 	// follows OpenTelemetry specification-defined combinations for client spans described in
-	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-client
+	// https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#http-client
 
 	url, ok := urlParts[conventions.AttributeHTTPURL]
 	if ok {
@@ -181,7 +224,7 @@ func constructClientURL(urlParts map[string]string) string {
 
 func constructServerURL(urlParts map[string]string) string {
 	// follows OpenTelemetry specification-defined combinations for server spans described in
-	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-server-semantic-conventions
+	// https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#http-server
 
 	url, ok := urlParts[conventions.AttributeHTTPURL]
 	if ok {
@@ -200,12 +243,18 @@ func constructServerURL(urlParts map[string]string) string {
 		if !ok {
 			host, ok = urlParts[conventions.AttributeNetHostName]
 			if !ok {
-				host = urlParts[conventions.AttributeHostName]
+				host, ok = urlParts[conventions.AttributeHostName]
+				if !ok {
+					host = urlParts[AttributeServerAddress]
+				}
 			}
 		}
 		port, ok = urlParts[conventions.AttributeNetHostPort]
 		if !ok {
-			port = ""
+			port, ok = urlParts[AttributeServerPort]
+			if !ok {
+				port = ""
+			}
 		}
 	}
 	url = scheme + "://" + host
@@ -216,7 +265,12 @@ func constructServerURL(urlParts map[string]string) string {
 	if ok {
 		url += target
 	} else {
-		url += "/"
+		path, ok := urlParts[AttributeURLPath]
+		if ok {
+			url += path
+		} else {
+			url += "/"
+		}
 	}
 	return url
 }

--- a/exporter/awsxrayexporter/internal/translator/http_test.go
+++ b/exporter/awsxrayexporter/internal/translator/http_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -20,6 +21,24 @@ func TestClientSpanWithURLAttribute(t *testing.T) {
 	attributes[conventions.AttributeHTTPMethod] = "GET"
 	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/users/junit"
 	attributes[conventions.AttributeHTTPStatusCode] = 200
+	span := constructHTTPClientSpan(attributes)
+
+	filtered, httpData := makeHTTP(span)
+
+	assert.NotNil(t, httpData)
+	assert.NotNil(t, filtered)
+	w := testWriters.borrow()
+	require.NoError(t, w.Encode(httpData))
+	jsonStr := w.String()
+	testWriters.release(w)
+	assert.True(t, strings.Contains(jsonStr, "https://api.example.com/users/junit"))
+}
+
+func TestClientSpanWithURLAttributeStable(t *testing.T) {
+	attributes := make(map[string]any)
+	attributes[AttributeHTTPRequestMethod] = "GET"
+	attributes[AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPClientSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -79,10 +98,50 @@ func TestClientSpanWithPeerAttributes(t *testing.T) {
 	assert.True(t, strings.Contains(jsonStr, "http://kb234.example.com:8080/users/junit"))
 }
 
+func TestClientSpanWithPeerAttributesStable(t *testing.T) {
+	attributes := make(map[string]any)
+	attributes[AttributeHTTPRequestMethod] = "GET"
+	attributes[AttributeURLScheme] = "http"
+	attributes[conventions.AttributeNetPeerName] = "kb234.example.com"
+	attributes[conventions.AttributeNetPeerPort] = 8080
+	attributes[conventions.AttributeNetPeerIP] = "10.8.17.36"
+	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
+	attributes[conventions.AttributeHTTPStatusCode] = 200
+	span := constructHTTPClientSpan(attributes)
+
+	filtered, httpData := makeHTTP(span)
+
+	assert.NotNil(t, httpData)
+	assert.NotNil(t, filtered)
+
+	assert.Equal(t, "10.8.17.36", *httpData.Request.ClientIP)
+
+	w := testWriters.borrow()
+	require.NoError(t, w.Encode(httpData))
+	jsonStr := w.String()
+	testWriters.release(w)
+	assert.True(t, strings.Contains(jsonStr, "http://kb234.example.com:8080/users/junit"))
+}
+
 func TestClientSpanWithHttpPeerAttributes(t *testing.T) {
 	attributes := make(map[string]any)
 	attributes[conventions.AttributeHTTPClientIP] = "1.2.3.4"
 	attributes[conventions.AttributeNetPeerIP] = "10.8.17.36"
+	span := constructHTTPClientSpan(attributes)
+
+	filtered, httpData := makeHTTP(span)
+
+	assert.NotNil(t, httpData)
+	assert.NotNil(t, filtered)
+
+	assert.Equal(t, "1.2.3.4", *httpData.Request.ClientIP)
+}
+
+func TestClientSpanWithHttpPeerAttributesStable(t *testing.T) {
+	attributes := make(map[string]any)
+	attributes[AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[AttributeClientAddress] = "1.2.3.4"
+	attributes[AttributeNetworkPeerAddress] = "10.8.17.36"
 	span := constructHTTPClientSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -151,6 +210,26 @@ func TestServerSpanWithURLAttribute(t *testing.T) {
 	assert.True(t, strings.Contains(jsonStr, "https://api.example.com/users/junit"))
 }
 
+func TestServerSpanWithURLAttributeStable(t *testing.T) {
+	attributes := make(map[string]any)
+	attributes[AttributeHTTPRequestMethod] = "GET"
+	attributes[AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[AttributeClientAddress] = "192.168.15.32"
+	attributes[AttributeUserAgentOriginal] = "PostmanRuntime/7.21.0"
+	attributes[AttributeHTTPResponseStatusCode] = 200
+	span := constructHTTPServerSpan(attributes)
+
+	filtered, httpData := makeHTTP(span)
+
+	assert.NotNil(t, httpData)
+	assert.NotNil(t, filtered)
+	w := testWriters.borrow()
+	require.NoError(t, w.Encode(httpData))
+	jsonStr := w.String()
+	testWriters.release(w)
+	assert.True(t, strings.Contains(jsonStr, "https://api.example.com/users/junit"))
+}
+
 func TestServerSpanWithSchemeHostTargetAttributes(t *testing.T) {
 	attributes := make(map[string]any)
 	attributes[conventions.AttributeHTTPMethod] = "GET"
@@ -159,6 +238,27 @@ func TestServerSpanWithSchemeHostTargetAttributes(t *testing.T) {
 	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
 	attributes[conventions.AttributeHTTPClientIP] = "192.168.15.32"
 	attributes[conventions.AttributeHTTPStatusCode] = 200
+	span := constructHTTPServerSpan(attributes)
+
+	filtered, httpData := makeHTTP(span)
+
+	assert.NotNil(t, httpData)
+	assert.NotNil(t, filtered)
+	w := testWriters.borrow()
+	require.NoError(t, w.Encode(httpData))
+	jsonStr := w.String()
+	testWriters.release(w)
+	assert.True(t, strings.Contains(jsonStr, "https://api.example.com/users/junit"))
+}
+
+func TestServerSpanWithSchemeHostTargetAttributesStable(t *testing.T) {
+	attributes := make(map[string]any)
+	attributes[AttributeHTTPRequestMethod] = "GET"
+	attributes[AttributeURLScheme] = "https"
+	attributes[AttributeServerAddress] = "api.example.com"
+	attributes[AttributeURLPath] = "/users/junit"
+	attributes[AttributeClientAddress] = "192.168.15.32"
+	attributes[AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -194,6 +294,28 @@ func TestServerSpanWithSchemeServernamePortTargetAttributes(t *testing.T) {
 	assert.True(t, strings.Contains(jsonStr, "https://api.example.com/users/junit"))
 }
 
+func TestServerSpanWithSchemeServernamePortTargetAttributesStable(t *testing.T) {
+	attributes := make(map[string]any)
+	attributes[AttributeHTTPRequestMethod] = "GET"
+	attributes[AttributeURLScheme] = "https"
+	attributes[AttributeServerAddress] = "api.example.com"
+	attributes[AttributeServerPort] = 443
+	attributes[AttributeURLPath] = "/users/junit"
+	attributes[AttributeClientAddress] = "192.168.15.32"
+	attributes[AttributeHTTPResponseStatusCode] = 200
+	span := constructHTTPServerSpan(attributes)
+
+	filtered, httpData := makeHTTP(span)
+
+	assert.NotNil(t, httpData)
+	assert.NotNil(t, filtered)
+	w := testWriters.borrow()
+	require.NoError(t, w.Encode(httpData))
+	jsonStr := w.String()
+	testWriters.release(w)
+	assert.True(t, strings.Contains(jsonStr, "https://api.example.com/users/junit"))
+}
+
 func TestServerSpanWithSchemeNamePortTargetAttributes(t *testing.T) {
 	attributes := make(map[string]any)
 	attributes[conventions.AttributeHTTPMethod] = "GET"
@@ -203,6 +325,30 @@ func TestServerSpanWithSchemeNamePortTargetAttributes(t *testing.T) {
 	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
 	attributes[conventions.AttributeHTTPClientIP] = "192.168.15.32"
 	attributes[conventions.AttributeHTTPStatusCode] = 200
+	span := constructHTTPServerSpan(attributes)
+	timeEvents := constructTimedEventsWithReceivedMessageEvent(span.EndTimestamp())
+	timeEvents.CopyTo(span.Events())
+
+	filtered, httpData := makeHTTP(span)
+
+	assert.NotNil(t, httpData)
+	assert.NotNil(t, filtered)
+	w := testWriters.borrow()
+	require.NoError(t, w.Encode(httpData))
+	jsonStr := w.String()
+	testWriters.release(w)
+	assert.True(t, strings.Contains(jsonStr, "http://kb234.example.com:8080/users/junit"))
+}
+
+func TestServerSpanWithSchemeNamePortTargetAttributesStable(t *testing.T) {
+	attributes := make(map[string]any)
+	attributes[AttributeHTTPRequestMethod] = "GET"
+	attributes[AttributeURLScheme] = "http"
+	attributes[AttributeServerAddress] = "kb234.example.com"
+	attributes[AttributeServerPort] = 8080
+	attributes[AttributeURLPath] = "/users/junit"
+	attributes[AttributeClientAddress] = "192.168.15.32"
+	attributes[AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 	timeEvents := constructTimedEventsWithReceivedMessageEvent(span.EndTimestamp())
 	timeEvents.CopyTo(span.Events())
@@ -242,6 +388,100 @@ func TestSpanWithNotEnoughHTTPRequestURLAttributes(t *testing.T) {
 	assert.Equal(t, int64(12452), contentLength)
 	assert.Equal(t, int64(200), *httpData.Response.Status)
 	assert.NotNil(t, filtered)
+}
+
+func TestSpanWithNotEnoughHTTPRequestURLAttributesStable(t *testing.T) {
+	attributes := make(map[string]any)
+	attributes[AttributeHTTPRequestMethod] = "GET"
+	attributes[AttributeURLScheme] = "http"
+	attributes[AttributeClientAddress] = "192.168.15.32"
+	attributes[AttributeUserAgentOriginal] = "PostmanRuntime/7.21.0"
+	attributes[AttributeURLPath] = "/users/junit"
+	attributes[AttributeServerPort] = 443
+	attributes[AttributeHTTPResponseStatusCode] = 200
+	span := constructHTTPServerSpan(attributes)
+	timeEvents := constructTimedEventsWithReceivedMessageEvent(span.EndTimestamp())
+	timeEvents.CopyTo(span.Events())
+
+	filtered, httpData := makeHTTP(span)
+
+	assert.Nil(t, httpData.Request.URL)
+	assert.Equal(t, "192.168.15.32", *httpData.Request.ClientIP)
+	assert.Equal(t, "GET", *httpData.Request.Method)
+	assert.Equal(t, "PostmanRuntime/7.21.0", *httpData.Request.UserAgent)
+	contentLength := *httpData.Response.ContentLength.(*int64)
+	assert.Equal(t, int64(12452), contentLength)
+	assert.Equal(t, int64(200), *httpData.Response.Status)
+	assert.NotNil(t, filtered)
+}
+
+func TestSpanWithNotEnoughHTTPRequestURLAttributesDuplicated(t *testing.T) {
+	attributes := make(map[string]any)
+	attributes[conventions.AttributeHTTPMethod] = "GET"
+	attributes[AttributeHTTPRequestMethod] = "GET"
+	attributes[conventions.AttributeHTTPScheme] = "http"
+	attributes[AttributeURLScheme] = "http"
+	attributes[conventions.AttributeHTTPClientIP] = "192.168.15.32"
+	attributes[AttributeClientAddress] = "192.168.15.32"
+	attributes[conventions.AttributeHTTPUserAgent] = "PostmanRuntime/7.21.0"
+	attributes[AttributeUserAgentOriginal] = "PostmanRuntime/7.21.0"
+	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
+	attributes[AttributeURLPath] = "/users/junit"
+	attributes[conventions.AttributeNetHostPort] = 443
+	attributes[AttributeServerPort] = 443
+	attributes[conventions.AttributeNetPeerPort] = 8080
+	attributes[conventions.AttributeHTTPStatusCode] = 200
+	attributes[AttributeHTTPResponseStatusCode] = 200
+	span := constructHTTPServerSpan(attributes)
+	timeEvents := constructTimedEventsWithReceivedMessageEvent(span.EndTimestamp())
+	timeEvents.CopyTo(span.Events())
+
+	filtered, httpData := makeHTTP(span)
+
+	assert.Nil(t, httpData.Request.URL)
+	assert.Equal(t, "192.168.15.32", *httpData.Request.ClientIP)
+	assert.Equal(t, "GET", *httpData.Request.Method)
+	assert.Equal(t, "PostmanRuntime/7.21.0", *httpData.Request.UserAgent)
+	contentLength := *httpData.Response.ContentLength.(*int64)
+	assert.Equal(t, int64(12452), contentLength)
+	assert.Equal(t, int64(200), *httpData.Response.Status)
+	assert.NotNil(t, filtered)
+}
+
+func TestSpanWithClientAddrWithoutNetworkPeerAddr(t *testing.T) {
+	attributes := make(map[string]any)
+	attributes[AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[AttributeClientAddress] = "192.168.15.32"
+	span := constructHTTPServerSpan(attributes)
+
+	_, httpData := makeHTTP(span)
+
+	assert.Equal(t, aws.Bool(true), httpData.Request.XForwardedFor)
+}
+func TestSpanWithClientAddrAndNetworkPeerAddr(t *testing.T) {
+	attributes := make(map[string]any)
+	attributes[AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[AttributeClientAddress] = "192.168.15.32"
+	attributes[AttributeNetworkPeerAddress] = "192.168.15.32"
+	span := constructHTTPServerSpan(attributes)
+
+	_, httpData := makeHTTP(span)
+
+	assert.Equal(t, "192.168.15.32", *httpData.Request.ClientIP)
+	assert.Nil(t, httpData.Request.XForwardedFor)
+}
+
+func TestSpanWithClientAddrNotIP(t *testing.T) {
+	attributes := make(map[string]any)
+	attributes[AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[AttributeClientAddress] = "api.example.com"
+	attributes[AttributeNetworkPeerAddress] = "api.example.com"
+	span := constructHTTPServerSpan(attributes)
+
+	_, httpData := makeHTTP(span)
+
+	assert.Nil(t, httpData.Request.ClientIP)
+	assert.Nil(t, httpData.Request.XForwardedFor)
 }
 
 func constructHTTPClientSpan(attributes map[string]any) ptrace.Span {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

It is a cherry-pick from opentelemetry upstream https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31120

`awsxrayexporter` is able to handle both old and new versions of http span attributes, support translate new http attributes to xray segment fields by following http [server span](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#http-server) and [client span](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#http-client) spec.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30935

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
https://opentelemetry.io/blog/2023/http-conventions-declared-stable/