### PR TITLE
[internal/aws/proxy] Fix proxy server unit test.

### DIFF
--- a/internal/aws/proxy/server_test.go
+++ b/internal/aws/proxy/server_test.go
@@ -226,7 +226,7 @@ func TestCanCreateTransport(t *testing.T) {
 
 	_, err := NewServer(cfg, logger)
 	assert.Error(t, err, "NewServer should fail")
-	assert.Contains(t, err.Error(), "failed to parse proxy URL")
+	assert.Contains(t, err.Error(), "invalid control character in URL")
 }
 
 func TestGetServiceEndpointInvalidAWSConfig(t *testing.T) {

--- a/receiver/awsxrayreceiver/factory_test.go
+++ b/receiver/awsxrayreceiver/factory_test.go
@@ -32,7 +32,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 		t.Skip()
 	}
 
-	t.Setenv(defaultRegionEnvName, mockRegion)
+	t.Setenv(regionEnvName, mockRegion)
 
 	factory := NewFactory()
 	_, err := factory.CreateTracesReceiver(

--- a/receiver/awsxrayreceiver/receiver_test.go
+++ b/receiver/awsxrayreceiver/receiver_test.go
@@ -34,9 +34,9 @@ import (
 )
 
 const (
-	segmentHeader        = "{\"format\": \"json\", \"version\": 1}\n"
-	defaultRegionEnvName = "AWS_DEFAULT_REGION"
-	mockRegion           = "us-west-2"
+	segmentHeader = "{\"format\": \"json\", \"version\": 1}\n"
+	regionEnvName = "AWS_REGION"
+	mockRegion    = "us-west-2"
 )
 
 func TestConsumerCantBeNil(t *testing.T) {
@@ -114,7 +114,7 @@ func TestSegmentsPassedToConsumer(t *testing.T) {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
 
-	t.Setenv(defaultRegionEnvName, mockRegion)
+	t.Setenv(regionEnvName, mockRegion)
 
 	addr, rcvr, _ := createAndOptionallyStartReceiver(t, nil, true, receiver.CreateSettings{ID: receiverID, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()})
 	defer func() {
@@ -145,7 +145,7 @@ func TestTranslatorErrorsOut(t *testing.T) {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
 
-	t.Setenv(defaultRegionEnvName, mockRegion)
+	t.Setenv(regionEnvName, mockRegion)
 
 	addr, rcvr, recordedLogs := createAndOptionallyStartReceiver(t, nil, true, receiver.CreateSettings{ID: receiverID, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()})
 	defer func() {
@@ -172,7 +172,7 @@ func TestSegmentsConsumerErrorsOut(t *testing.T) {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
 
-	t.Setenv(defaultRegionEnvName, mockRegion)
+	t.Setenv(regionEnvName, mockRegion)
 
 	addr, rcvr, recordedLogs := createAndOptionallyStartReceiver(t, consumertest.NewErr(errors.New("can't consume traces")), true, receiver.CreateSettings{ID: receiverID, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()})
 	defer func() {
@@ -202,7 +202,7 @@ func TestPollerCloseError(t *testing.T) {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
 
-	t.Setenv(defaultRegionEnvName, mockRegion)
+	t.Setenv(regionEnvName, mockRegion)
 
 	_, rcvr, _ := createAndOptionallyStartReceiver(t, nil, false, receiver.CreateSettings{ID: receiverID, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()})
 	mPoller := &mockPoller{closeErr: errors.New("mockPollerCloseErr")}
@@ -220,7 +220,7 @@ func TestProxyCloseError(t *testing.T) {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
 
-	t.Setenv(defaultRegionEnvName, mockRegion)
+	t.Setenv(regionEnvName, mockRegion)
 
 	_, rcvr, _ := createAndOptionallyStartReceiver(t, nil, false, receiver.CreateSettings{ID: receiverID, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()})
 	mProxy := &mockProxy{closeErr: errors.New("mockProxyCloseErr")}
@@ -238,7 +238,7 @@ func TestBothPollerAndProxyCloseError(t *testing.T) {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
 
-	t.Setenv(defaultRegionEnvName, mockRegion)
+	t.Setenv(regionEnvName, mockRegion)
 
 	_, rcvr, _ := createAndOptionallyStartReceiver(t, nil, false, receiver.CreateSettings{ID: receiverID, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()})
 	mPoller := &mockPoller{closeErr: errors.New("mockPollerCloseErr")}


### PR DESCRIPTION
**Description:** A previous PR (https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/174) unified the AWS session creation so the proxy uses the `internal/aws/awsutil` package. The unit tests could not be run at the time.

**Testing:** Ran the unit tests locally.