### PR TITLE
Add InstanceType to GPU metrics

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper.go
+++ b/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper.go
@@ -56,6 +56,7 @@ type DcgmScraperOpts struct {
 type hostInfoProvider interface {
 	GetClusterName() string
 	GetInstanceID() string
+	GetInstanceType() string
 }
 
 func NewDcgmScraper(opts DcgmScraperOpts) (*DcgmScraper, error) {
@@ -168,6 +169,13 @@ func getMetricRelabelConfig(hostInfoProvider hostInfoProvider) []*relabel.Config
 			TargetLabel:  ci.InstanceID,
 			Regex:        relabel.MustNewRegexp(".*"),
 			Replacement:  hostInfoProvider.GetInstanceID(),
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"namespace"},
+			TargetLabel:  ci.InstanceType,
+			Regex:        relabel.MustNewRegexp(".*"),
+			Replacement:  hostInfoProvider.GetInstanceType(),
 			Action:       relabel.Replace,
 		},
 		{

--- a/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_test.go
@@ -35,8 +35,9 @@ DCGM_FI_DEV_GPU_UTIL{gpu="0",UUID="uuid",device="nvidia0",modelName="NVIDIA A10G
 `
 
 const (
-	dummyInstanceID  = "i-0000000000"
-	dummyClusterName = "cluster-name"
+	dummyInstanceID   = "i-0000000000"
+	dummyClusterName  = "cluster-name"
+	dummyInstanceType = "instance-type"
 )
 
 type mockHostInfoProvider struct {
@@ -48,6 +49,10 @@ func (m mockHostInfoProvider) GetClusterName() string {
 
 func (m mockHostInfoProvider) GetInstanceID() string {
 	return dummyInstanceID
+}
+
+func (m mockHostInfoProvider) GetInstanceType() string {
+	return dummyInstanceType
 }
 
 type mockDecorator struct {
@@ -151,6 +156,7 @@ func TestNewDcgmScraperEndToEnd(t *testing.T) {
 				ci.AttributeK8sNamespace:  "kube-system",
 				ci.ClusterNameKey:         dummyClusterName,
 				ci.InstanceID:             dummyInstanceID,
+				ci.InstanceType:           dummyInstanceType,
 				ci.AttributeFullPodName:   "fullname-hash",
 				ci.AttributeK8sPodName:    "fullname-hash",
 				ci.AttributeContainerName: "main",
@@ -164,6 +170,7 @@ func TestNewDcgmScraperEndToEnd(t *testing.T) {
 				ci.AttributeK8sNamespace:  "kube-system",
 				ci.ClusterNameKey:         dummyClusterName,
 				ci.InstanceID:             dummyInstanceID,
+				ci.InstanceType:           dummyInstanceType,
 				ci.AttributeFullPodName:   "fullname-hash",
 				ci.AttributeK8sPodName:    "fullname-hash",
 				ci.AttributeContainerName: "main",


### PR DESCRIPTION
**Description:** 
Add `InstanceType` attribute to GPU metrics

**Testing:** 
Tested on a test cluster. Example EMF entry:
```
{
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName"
                ],
                [
                    "ClusterName",
                    "InstanceId",
                    "NodeName"
                ],
                [
                    "ClusterName",
                    "GpuDevice",
                    "InstanceId",
                    "InstanceType",
                    "NodeName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "node_gpu_temperature",
                    "Unit": "None"
                },
                {
                    "Name": "node_gpu_power_draw",
                    "Unit": "None"
                },
                {
                    "Name": "node_gpu_utilization",
                    "Unit": "Percent"
                },
                {
                    "Name": "node_gpu_memory_utilization",
                    "Unit": "Percent"
                },
                {
                    "Name": "node_gpu_memory_used",
                    "Unit": "Bytes"
                },
                {
                    "Name": "node_gpu_memory_total",
                    "Unit": "Bytes"
                }
            ]
        }
    ],
    "ClusterName": "mixed-test",
    "GpuDevice": "nvidia0",
    "InstanceId": "i-xxxxxxxxxx",
    "InstanceType": "g4dn.xlarge",
    "NodeName": "ip-x-x-x-x.us-west-2.compute.internal",
    "OTelLib": "otelcol/prometheusreceiver",
    "Timestamp": "1710445148938",
    "Type": "NodeGPU",
    "Version": "0",
    "http.scheme": "https",
    "k8s.namespace.name": "amazon-cloudwatch",
    "kubernetes": {
        "host": "ip-x-x-x-x.us-west-2.compute.internal"
    },
    "net.host.name": "dcgm-exporter-service.amazon-cloudwatch.svc",
    "net.host.port": "9400",
    "service.instance.id": "dcgm-exporter-service.amazon-cloudwatch.svc:9400",
    "service.name": "containerInsightsDCGMExporterScraper",
    "node_gpu_memory_total": 16106127360,
    "node_gpu_memory_used": 198180864,
    "node_gpu_memory_utilization": 0.0007999999999999999,
    "node_gpu_power_draw": 33.199,
    "node_gpu_temperature": 31,
    "node_gpu_utilization": 9
}
```
