### PR TITLE
Add Elastic Fabric Adapter (EFA) metric collection to awscontainerinsightreceiver.

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -170,7 +170,7 @@ const (
 	TypePodGPU          = "PodGPU"
 	TypeNodeGPU         = "NodeGPU"
 	TypeClusterGPU      = "ClusterGPU"
-	TypeNeuronContainer = "ContainerNeuron"
+	TypeContainerNeuron = "ContainerNeuron"
 	TypeContainerEFA    = "ContainerEFA"
 	TypePodEFA          = "PodEFA"
 	TypeNodeEFA         = "NodeEFA"

--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -13,6 +13,7 @@ const (
 	MinTimeDiff = 50 * time.Microsecond
 
 	// Environment variables
+	HostName                  = "HOST_NAME"
 	RunInContainer            = "RUN_IN_CONTAINER"
 	RunAsHostProcessContainer = "RUN_AS_HOST_PROCESS_CONTAINER"
 	TrueValue                 = "True"
@@ -133,6 +134,13 @@ const (
 	DiskIOWrite              = "Write"
 	DiskIOTotal              = "Total"
 
+	EfaRdmaReadBytes      = "rdma_read_bytes"
+	EfaRdmaWriteBytes     = "rdma_write_bytes"
+	EfaRdmaWriteRecvBytes = "rdma_write_recv_bytes"
+	EfaRxBytes            = "rx_bytes"
+	EfaRxDropped          = "rx_dropped"
+	EfaTxBytes            = "tx_bytes"
+
 	// Define the metric types
 	TypeCluster            = "Cluster"
 	TypeClusterService     = "ClusterService"
@@ -158,11 +166,14 @@ const (
 	// Special type for pause container
 	// because containerd does not set container name pause container name to POD like docker does.
 	TypeInfraContainer  = "InfraContainer"
-	TypeGpuContainer    = "ContainerGPU"
-	TypeGpuPod          = "PodGPU"
-	TypeGpuNode         = "NodeGPU"
-	TypeGpuCluster      = "ClusterGPU"
+	TypeContainerGPU    = "ContainerGPU"
+	TypePodGPU          = "PodGPU"
+	TypeNodeGPU         = "NodeGPU"
+	TypeClusterGPU      = "ClusterGPU"
 	TypeNeuronContainer = "ContainerNeuron"
+	TypeContainerEFA    = "ContainerEFA"
+	TypePodEFA          = "PodEFA"
+	TypeNodeEFA         = "NodeEFA"
 
 	// unit
 	UnitBytes       = "Bytes"
@@ -301,5 +312,12 @@ func init() {
 		ContainerCount:        UnitCount,
 		ContainerRestartCount: UnitCount,
 		RunningTaskCount:      UnitCount,
+
+		EfaRdmaReadBytes:      UnitBytesPerSec,
+		EfaRdmaWriteBytes:     UnitBytesPerSec,
+		EfaRdmaWriteRecvBytes: UnitBytesPerSec,
+		EfaRxBytes:            UnitBytesPerSec,
+		EfaRxDropped:          UnitCountPerSec,
+		EfaTxBytes:            UnitBytesPerSec,
 	}
 }

--- a/internal/aws/containerinsight/k8sconst.go
+++ b/internal/aws/containerinsight/k8sconst.go
@@ -17,6 +17,7 @@ const (
 	AttributeContainerName = "ContainerName"
 	AttributeContainerID   = "ContainerId"
 	AttributeGpuDevice     = "GpuDevice"
+	AttributeEfaDevice     = "EfaDevice"
 
 	PodStatus       = "pod_status"
 	ContainerStatus = "container_status"

--- a/internal/aws/containerinsight/utils.go
+++ b/internal/aws/containerinsight/utils.go
@@ -52,7 +52,13 @@ func SumFields(fields []map[string]any) map[string]float64 {
 // IsNode checks if a type belongs to node level metrics (for EKS)
 func IsNode(mType string) bool {
 	switch mType {
-	case TypeNode, TypeNodeNet, TypeNodeFS, TypeNodeDiskIO:
+	case
+		TypeNode,
+		TypeNodeDiskIO,
+		TypeNodeEFA,
+		TypeNodeFS,
+		TypeNodeGPU,
+		TypeNodeNet:
 		return true
 	}
 	return false
@@ -70,7 +76,12 @@ func IsInstance(mType string) bool {
 // IsContainer checks if a type belongs to container level metrics
 func IsContainer(mType string) bool {
 	switch mType {
-	case TypeContainer, TypeContainerDiskIO, TypeContainerFS:
+	case
+		TypeContainer,
+		TypeContainerDiskIO,
+		TypeContainerEFA,
+		TypeContainerFS,
+		TypeContainerGPU:
 		return true
 	}
 	return false
@@ -79,7 +90,11 @@ func IsContainer(mType string) bool {
 // IsPod checks if a type belongs to container level metrics
 func IsPod(mType string) bool {
 	switch mType {
-	case TypePod, TypePodNet:
+	case
+		TypePod,
+		TypePodEFA,
+		TypePodGPU,
+		TypePodNet:
 		return true
 	}
 	return false
@@ -100,9 +115,12 @@ func getPrefixByMetricType(mType string) string {
 	nodePrefix := "node_"
 	instanceNetPrefix := "instance_interface_"
 	nodeNetPrefix := "node_interface_"
+	nodeEfaPrefix := "node_efa_"
 	podPrefix := "pod_"
 	podNetPrefix := "pod_interface_"
+	podEfaPrefix := "pod_efa_"
 	containerPrefix := "container_"
+	containerEfaPrefix := "container_efa_"
 	service := "service_"
 	cluster := "cluster_"
 	namespace := "namespace_"
@@ -128,16 +146,22 @@ func getPrefixByMetricType(mType string) string {
 		prefix = nodePrefix
 	case TypeNodeNet:
 		prefix = nodeNetPrefix
+	case TypeNodeEFA:
+		prefix = nodeEfaPrefix
 	case TypePod:
 		prefix = podPrefix
 	case TypePodNet:
 		prefix = podNetPrefix
+	case TypePodEFA:
+		prefix = podEfaPrefix
 	case TypeContainer:
 		prefix = containerPrefix
 	case TypeContainerDiskIO:
 		prefix = containerPrefix
 	case TypeContainerFS:
 		prefix = containerPrefix
+	case TypeContainerEFA:
+		prefix = containerEfaPrefix
 	case TypeService:
 		prefix = service
 	case TypeCluster:

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -240,8 +240,6 @@ replace github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api
 // It appears that the v0.2.0 tag was modified.  Replacing with v0.2.1
 replace github.com/outcaste-io/ristretto v0.2.0 => github.com/outcaste-io/ristretto v0.2.1
 
-replace go.tmz.dev/musttag v0.7.2 => github.com/go-simpler/musttag v0.7.2
-
 retract (
 	v0.76.2
 	v0.76.1

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -240,6 +240,8 @@ replace github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api
 // It appears that the v0.2.0 tag was modified.  Replacing with v0.2.1
 replace github.com/outcaste-io/ristretto v0.2.0 => github.com/outcaste-io/ristretto v0.2.1
 
+replace go.tmz.dev/musttag v0.7.2 => github.com/go-simpler/musttag v0.7.2
+
 retract (
 	v0.76.2
 	v0.76.1

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -195,6 +195,8 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
+github.com/go-simpler/musttag v0.7.2 h1:tNQJlfcSoI1olMmjAkB4yNDxhvDq+ugxdL0vvptwTkM=
+github.com/go-simpler/musttag v0.7.2/go.mod h1:m6q5NiiSKMnQYokefa2xGoyoXnrswCbJ0AWYzf4Zs28=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-toolsmith/astcast v1.1.0 h1:+JN9xZV1A+Re+95pgnMgDboWNVnIMMQXwfBwLRPgSC8=
@@ -662,8 +664,6 @@ go.opentelemetry.io/build-tools/multimod v0.12.0 h1:DKi+A+4EaKrOZDTNDDZz3ijiAduE
 go.opentelemetry.io/build-tools/multimod v0.12.0/go.mod h1:w03q3WgZs7reoBNnmfdClkKdTIA/IHM8ric5E2jEDD0=
 go.opentelemetry.io/collector/cmd/builder v0.89.0 h1:L5rnsOAL5UX/EZgzJt6d6p0QKHf6bVSsnGRqfEPV1yM=
 go.opentelemetry.io/collector/cmd/builder v0.89.0/go.mod h1:wcxXrQyLrzvYKXCG3CqDkFpbL35cBCHke6wk2RFvmZk=
-go.tmz.dev/musttag v0.7.2 h1:1J6S9ipDbalBSODNT5jCep8dhZyMr4ttnjQagmGYR5s=
-go.tmz.dev/musttag v0.7.2/go.mod h1:m6q5NiiSKMnQYokefa2xGoyoXnrswCbJ0AWYzf4Zs28=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -195,8 +195,6 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
-github.com/go-simpler/musttag v0.7.2 h1:tNQJlfcSoI1olMmjAkB4yNDxhvDq+ugxdL0vvptwTkM=
-github.com/go-simpler/musttag v0.7.2/go.mod h1:m6q5NiiSKMnQYokefa2xGoyoXnrswCbJ0AWYzf4Zs28=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-toolsmith/astcast v1.1.0 h1:+JN9xZV1A+Re+95pgnMgDboWNVnIMMQXwfBwLRPgSC8=
@@ -664,6 +662,8 @@ go.opentelemetry.io/build-tools/multimod v0.12.0 h1:DKi+A+4EaKrOZDTNDDZz3ijiAduE
 go.opentelemetry.io/build-tools/multimod v0.12.0/go.mod h1:w03q3WgZs7reoBNnmfdClkKdTIA/IHM8ric5E2jEDD0=
 go.opentelemetry.io/collector/cmd/builder v0.89.0 h1:L5rnsOAL5UX/EZgzJt6d6p0QKHf6bVSsnGRqfEPV1yM=
 go.opentelemetry.io/collector/cmd/builder v0.89.0/go.mod h1:wcxXrQyLrzvYKXCG3CqDkFpbL35cBCHke6wk2RFvmZk=
+go.tmz.dev/musttag v0.7.2 h1:1J6S9ipDbalBSODNT5jCep8dhZyMr4ttnjQagmGYR5s=
+go.tmz.dev/musttag v0.7.2/go.mod h1:m6q5NiiSKMnQYokefa2xGoyoXnrswCbJ0AWYzf4Zs28=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_nolinux.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_nolinux.go
@@ -26,7 +26,7 @@ type Cadvisor struct {
 }
 
 type Decorator interface {
-	Decorate(*stores.RawContainerInsightsMetric) *stores.RawContainerInsightsMetric
+	Decorate(*stores.CIMetricImpl) *stores.CIMetricImpl
 	Shutdown() error
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/cpu_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/cpu_extractor.go
@@ -25,8 +25,8 @@ func (c *CPUMetricExtractor) HasValue(info *cInfo.ContainerInfo) bool {
 	return info.Spec.HasCpu
 }
 
-func (c *CPUMetricExtractor) GetValue(info *cInfo.ContainerInfo, mInfo CPUMemInfoProvider, containerType string) []*stores.RawContainerInsightsMetric {
-	var metrics []*stores.RawContainerInsightsMetric
+func (c *CPUMetricExtractor) GetValue(info *cInfo.ContainerInfo, mInfo CPUMemInfoProvider, containerType string) []*stores.CIMetricImpl {
+	var metrics []*stores.CIMetricImpl
 	// Skip infra container and handle node, pod, other containers in pod
 	if containerType == ci.TypeInfraContainer {
 		return metrics
@@ -34,7 +34,7 @@ func (c *CPUMetricExtractor) GetValue(info *cInfo.ContainerInfo, mInfo CPUMemInf
 
 	// When there is more than one stats point, always use the last one
 	curStats := GetStats(info)
-	metric := stores.NewRawContainerInsightsMetric(containerType, c.logger)
+	metric := stores.NewCIMetric(containerType, c.logger)
 	metric.ContainerName = info.Name
 	multiplier := float64(decimalToMillicores)
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/cpu_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/cpu_extractor_test.go
@@ -23,7 +23,7 @@ func TestCPUStats(t *testing.T) {
 	containerType := containerinsight.TypeContainer
 	extractor := NewCPUMetricExtractor(nil)
 
-	var cMetrics []*stores.RawContainerInsightsMetric
+	var cMetrics []*stores.CIMetricImpl
 	if extractor.HasValue(result[0]) {
 		cMetrics = extractor.GetValue(result[0], MockCPUMemInfo, containerType)
 	}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/diskio_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/diskio_extractor.go
@@ -25,8 +25,8 @@ func (d *DiskIOMetricExtractor) HasValue(info *cInfo.ContainerInfo) bool {
 	return info.Spec.HasDiskIo
 }
 
-func (d *DiskIOMetricExtractor) GetValue(info *cInfo.ContainerInfo, _ CPUMemInfoProvider, containerType string) []*stores.RawContainerInsightsMetric {
-	var metrics []*stores.RawContainerInsightsMetric
+func (d *DiskIOMetricExtractor) GetValue(info *cInfo.ContainerInfo, _ CPUMemInfoProvider, containerType string) []*stores.CIMetricImpl {
+	var metrics []*stores.CIMetricImpl
 	if containerType != ci.TypeNode && containerType != ci.TypeInstance {
 		return metrics
 	}
@@ -37,12 +37,12 @@ func (d *DiskIOMetricExtractor) GetValue(info *cInfo.ContainerInfo, _ CPUMemInfo
 	return metrics
 }
 
-func (d *DiskIOMetricExtractor) extractIoMetrics(curStatsSet []cInfo.PerDiskStats, namePrefix string, containerType string, infoName string, curTime time.Time) []*stores.RawContainerInsightsMetric {
-	var metrics []*stores.RawContainerInsightsMetric
+func (d *DiskIOMetricExtractor) extractIoMetrics(curStatsSet []cInfo.PerDiskStats, namePrefix string, containerType string, infoName string, curTime time.Time) []*stores.CIMetricImpl {
+	var metrics []*stores.CIMetricImpl
 	expectedKey := []string{ci.DiskIOAsync, ci.DiskIOSync, ci.DiskIORead, ci.DiskIOWrite, ci.DiskIOTotal}
 	for _, cur := range curStatsSet {
 		curDevName := devName(cur)
-		metric := stores.NewRawContainerInsightsMetric(getDiskIOMetricType(containerType, d.logger), d.logger)
+		metric := stores.NewCIMetric(getDiskIOMetricType(containerType, d.logger), d.logger)
 		metric.Tags[ci.DiskDev] = curDevName
 		for _, key := range expectedKey {
 			if curVal, curOk := cur.Stats[key]; curOk {

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/diskio_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/diskio_extractor_test.go
@@ -22,7 +22,7 @@ func TestDiskIOStats(t *testing.T) {
 	containerType := containerinsight.TypeNode
 	extractor := NewDiskIOMetricExtractor(nil)
 
-	var cMetrics []*stores.RawContainerInsightsMetric
+	var cMetrics []*stores.CIMetricImpl
 	if extractor.HasValue(result[0]) {
 		cMetrics = extractor.GetValue(result[0], nil, containerType)
 	}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor.go
@@ -29,7 +29,7 @@ type CPUMemInfoProvider interface {
 
 type MetricExtractor interface {
 	HasValue(*cinfo.ContainerInfo) bool
-	GetValue(info *cinfo.ContainerInfo, mInfo CPUMemInfoProvider, containerType string) []*stores.RawContainerInsightsMetric
+	GetValue(info *cinfo.ContainerInfo, mInfo CPUMemInfoProvider, containerType string) []*stores.CIMetricImpl
 	Shutdown() error
 }
 
@@ -55,9 +55,9 @@ func AssignRateValueToField(rateCalculator *awsmetrics.MetricCalculator, fields 
 }
 
 // MergeMetrics merges an array of cadvisor metrics based on common metric keys
-func MergeMetrics(metrics []*stores.RawContainerInsightsMetric) []*stores.RawContainerInsightsMetric {
-	result := make([]*stores.RawContainerInsightsMetric, 0, len(metrics))
-	metricMap := make(map[string]*stores.RawContainerInsightsMetric)
+func MergeMetrics(metrics []*stores.CIMetricImpl) []*stores.CIMetricImpl {
+	result := make([]*stores.CIMetricImpl, 0, len(metrics))
+	metricMap := make(map[string]*stores.CIMetricImpl)
 	for _, metric := range metrics {
 		if metricKey := getMetricKey(metric); metricKey != "" {
 			if mergedMetric, ok := metricMap[metricKey]; ok {
@@ -77,7 +77,7 @@ func MergeMetrics(metrics []*stores.RawContainerInsightsMetric) []*stores.RawCon
 }
 
 // return MetricKey for merge-able metrics
-func getMetricKey(metric *stores.RawContainerInsightsMetric) string {
+func getMetricKey(metric *stores.CIMetricImpl) string {
 	metricType := metric.GetMetricType()
 	var metricKey string
 	switch metricType {

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor_test.go
@@ -15,12 +15,12 @@ import (
 )
 
 func TestCAdvisorMetric_Merge(t *testing.T) {
-	src := &stores.RawContainerInsightsMetric{
+	src := &stores.CIMetricImpl{
 		Fields: map[string]any{"value1": 1, "value2": 2},
 		Tags:   map[string]string{ci.Timestamp: "1586331559882"},
 		Logger: zap.NewNop(),
 	}
-	dest := &stores.RawContainerInsightsMetric{
+	dest := &stores.CIMetricImpl{
 		Fields: map[string]any{"value1": 3, "value3": 3},
 		Tags:   map[string]string{ci.Timestamp: "1586331559973"},
 		Logger: zap.NewNop(),
@@ -31,21 +31,21 @@ func TestCAdvisorMetric_Merge(t *testing.T) {
 }
 
 func TestGetMetricKey(t *testing.T) {
-	c := &stores.RawContainerInsightsMetric{
+	c := &stores.CIMetricImpl{
 		Tags: map[string]string{
 			ci.MetricType: ci.TypeInstance,
 		},
 	}
 	assert.Equal(t, "metricType:Instance", getMetricKey(c))
 
-	c = &stores.RawContainerInsightsMetric{
+	c = &stores.CIMetricImpl{
 		Tags: map[string]string{
 			ci.MetricType: ci.TypeNode,
 		},
 	}
 	assert.Equal(t, "metricType:Node", getMetricKey(c))
 
-	c = &stores.RawContainerInsightsMetric{
+	c = &stores.CIMetricImpl{
 		Tags: map[string]string{
 			ci.MetricType:     ci.TypePod,
 			ci.AttributePodID: "podID",
@@ -53,7 +53,7 @@ func TestGetMetricKey(t *testing.T) {
 	}
 	assert.Equal(t, "metricType:Pod,podId:podID", getMetricKey(c))
 
-	c = &stores.RawContainerInsightsMetric{
+	c = &stores.CIMetricImpl{
 		Tags: map[string]string{
 			ci.MetricType:             ci.TypeContainer,
 			ci.AttributePodID:         "podID",
@@ -62,7 +62,7 @@ func TestGetMetricKey(t *testing.T) {
 	}
 	assert.Equal(t, "metricType:Container,podId:podID,containerName:ContainerName", getMetricKey(c))
 
-	c = &stores.RawContainerInsightsMetric{
+	c = &stores.CIMetricImpl{
 		Tags: map[string]string{
 			ci.MetricType: ci.TypeInstanceDiskIO,
 			ci.DiskDev:    "/abc",
@@ -70,7 +70,7 @@ func TestGetMetricKey(t *testing.T) {
 	}
 	assert.Equal(t, "metricType:InstanceDiskIO,device:/abc", getMetricKey(c))
 
-	c = &stores.RawContainerInsightsMetric{
+	c = &stores.CIMetricImpl{
 		Tags: map[string]string{
 			ci.MetricType: ci.TypeNodeDiskIO,
 			ci.DiskDev:    "/abc",
@@ -78,12 +78,12 @@ func TestGetMetricKey(t *testing.T) {
 	}
 	assert.Equal(t, "metricType:NodeDiskIO,device:/abc", getMetricKey(c))
 
-	c = &stores.RawContainerInsightsMetric{}
+	c = &stores.CIMetricImpl{}
 	assert.Equal(t, "", getMetricKey(c))
 }
 
 func TestMergeMetrics(t *testing.T) {
-	cpuMetrics := &stores.RawContainerInsightsMetric{
+	cpuMetrics := &stores.CIMetricImpl{
 		Fields: map[string]any{
 			"node_cpu_usage_total": float64(10),
 			"node_cpu_usage_user":  float64(10),
@@ -93,7 +93,7 @@ func TestMergeMetrics(t *testing.T) {
 		},
 	}
 
-	memMetrics := &stores.RawContainerInsightsMetric{
+	memMetrics := &stores.CIMetricImpl{
 		Fields: map[string]any{
 			"node_memory_cache": uint(25645056),
 		},
@@ -102,12 +102,12 @@ func TestMergeMetrics(t *testing.T) {
 		},
 	}
 
-	metrics := []*stores.RawContainerInsightsMetric{
+	metrics := []*stores.CIMetricImpl{
 		cpuMetrics,
 		memMetrics,
 	}
 
-	expected := &stores.RawContainerInsightsMetric{
+	expected := &stores.CIMetricImpl{
 		Fields: map[string]any{
 			"node_cpu_usage_total": float64(10),
 			"node_cpu_usage_user":  float64(10),

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractorhelpers.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractorhelpers.go
@@ -15,7 +15,7 @@ import (
 
 func AssertContainsTaggedFloat(
 	t *testing.T,
-	cadvisorMetric *stores.RawContainerInsightsMetric,
+	cadvisorMetric *stores.CIMetricImpl,
 	field string,
 	expectedValue float64,
 	delta float64,
@@ -41,7 +41,7 @@ func AssertContainsTaggedFloat(
 
 func AssertContainsTaggedInt(
 	t *testing.T,
-	cadvisorMetric *stores.RawContainerInsightsMetric,
+	cadvisorMetric *stores.CIMetricImpl,
 	field string,
 	expectedValue int64,
 ) {
@@ -61,7 +61,7 @@ func AssertContainsTaggedInt(
 
 func AssertContainsTaggedUint(
 	t *testing.T,
-	cadvisorMetric *stores.RawContainerInsightsMetric,
+	cadvisorMetric *stores.CIMetricImpl,
 	field string,
 	expectedValue uint64,
 ) {
@@ -81,7 +81,7 @@ func AssertContainsTaggedUint(
 
 func AssertContainsTaggedField(
 	t *testing.T,
-	cadvisorMetric *stores.RawContainerInsightsMetric,
+	cadvisorMetric *stores.CIMetricImpl,
 	expectedFields map[string]any,
 	expectedTags map[string]string,
 ) {

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/fs_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/fs_extractor.go
@@ -24,17 +24,17 @@ func (f *FileSystemMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
 	return info.Spec.HasFilesystem
 }
 
-func (f *FileSystemMetricExtractor) GetValue(info *cinfo.ContainerInfo, _ CPUMemInfoProvider, containerType string) []*stores.RawContainerInsightsMetric {
+func (f *FileSystemMetricExtractor) GetValue(info *cinfo.ContainerInfo, _ CPUMemInfoProvider, containerType string) []*stores.CIMetricImpl {
 	if containerType == ci.TypePod || containerType == ci.TypeInfraContainer {
 		return nil
 	}
 
 	containerType = getFSMetricType(containerType, f.logger)
 	stats := GetStats(info)
-	metrics := make([]*stores.RawContainerInsightsMetric, 0, len(stats.Filesystem))
+	metrics := make([]*stores.CIMetricImpl, 0, len(stats.Filesystem))
 
 	for _, v := range stats.Filesystem {
-		metric := stores.NewRawContainerInsightsMetric(containerType, f.logger)
+		metric := stores.NewCIMetric(containerType, f.logger)
 		if v.Device == "" {
 			continue
 		}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/fs_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/fs_extractor_test.go
@@ -22,7 +22,7 @@ func TestFSStats(t *testing.T) {
 	containerType := containerinsight.TypeContainer
 	extractor := NewFileSystemMetricExtractor(nil)
 
-	var cMetrics []*stores.RawContainerInsightsMetric
+	var cMetrics []*stores.CIMetricImpl
 	if extractor.HasValue(result[0]) {
 		cMetrics = extractor.GetValue(result[0], nil, containerType)
 	}
@@ -126,7 +126,7 @@ func TestFSStatsWithAllowList(t *testing.T) {
 	containerType := containerinsight.TypeContainer
 	extractor := NewFileSystemMetricExtractor(nil)
 
-	var cMetrics []*stores.RawContainerInsightsMetric
+	var cMetrics []*stores.CIMetricImpl
 	if extractor.HasValue(result[0]) {
 		cMetrics = extractor.GetValue(result[0], nil, containerType)
 	}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/mem_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/mem_extractor.go
@@ -23,13 +23,13 @@ func (m *MemMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
 	return info.Spec.HasMemory
 }
 
-func (m *MemMetricExtractor) GetValue(info *cinfo.ContainerInfo, mInfo CPUMemInfoProvider, containerType string) []*stores.RawContainerInsightsMetric {
-	var metrics []*stores.RawContainerInsightsMetric
+func (m *MemMetricExtractor) GetValue(info *cinfo.ContainerInfo, mInfo CPUMemInfoProvider, containerType string) []*stores.CIMetricImpl {
+	var metrics []*stores.CIMetricImpl
 	if containerType == ci.TypeInfraContainer {
 		return metrics
 	}
 
-	metric := stores.NewRawContainerInsightsMetric(containerType, m.logger)
+	metric := stores.NewCIMetric(containerType, m.logger)
 	metric.ContainerName = info.Name
 	curStats := GetStats(info)
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/mem_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/mem_extractor_test.go
@@ -21,7 +21,7 @@ func TestMemStats(t *testing.T) {
 	containerType := containerinsight.TypeContainer
 	extractor := NewMemMetricExtractor(nil)
 
-	var cMetrics []*stores.RawContainerInsightsMetric
+	var cMetrics []*stores.CIMetricImpl
 	if extractor.HasValue(result[0]) {
 		cMetrics = extractor.GetValue(result[0], MockCPUMemInfo, containerType)
 	}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/net_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/net_extractor.go
@@ -31,7 +31,7 @@ func (n *NetMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
 	return info.Spec.HasNetwork
 }
 
-func (n *NetMetricExtractor) GetValue(info *cinfo.ContainerInfo, _ CPUMemInfoProvider, containerType string) []*stores.RawContainerInsightsMetric {
+func (n *NetMetricExtractor) GetValue(info *cinfo.ContainerInfo, _ CPUMemInfoProvider, containerType string) []*stores.CIMetricImpl {
 
 	// Just a protection here, there is no Container level Net metrics
 	if containerType == ci.TypePod || containerType == ci.TypeContainer {
@@ -48,7 +48,7 @@ func (n *NetMetricExtractor) GetValue(info *cinfo.ContainerInfo, _ CPUMemInfoPro
 
 	// used for aggregation
 	netIfceMetrics := make([]map[string]any, len(curIfceStats))
-	metrics := make([]*stores.RawContainerInsightsMetric, len(curIfceStats))
+	metrics := make([]*stores.CIMetricImpl, len(curIfceStats))
 
 	for i, cur := range curIfceStats {
 		mType := getNetMetricType(containerType, n.logger)
@@ -71,7 +71,7 @@ func (n *NetMetricExtractor) GetValue(info *cinfo.ContainerInfo, _ CPUMemInfoPro
 
 		netIfceMetrics[i] = netIfceMetric
 
-		metric := stores.NewRawContainerInsightsMetric(mType, n.logger)
+		metric := stores.NewCIMetric(mType, n.logger)
 		metric.Tags[ci.NetIfce] = cur.Name
 		for k, v := range netIfceMetric {
 			metric.Fields[ci.MetricName(mType, k)] = v
@@ -82,7 +82,7 @@ func (n *NetMetricExtractor) GetValue(info *cinfo.ContainerInfo, _ CPUMemInfoPro
 
 	aggregatedFields := ci.SumFields(netIfceMetrics)
 	if len(aggregatedFields) > 0 {
-		metric := stores.NewRawContainerInsightsMetric(containerType, n.logger)
+		metric := stores.NewCIMetric(containerType, n.logger)
 		for k, v := range aggregatedFields {
 			metric.Fields[ci.MetricName(containerType, k)] = v
 		}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/net_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/net_extractor_test.go
@@ -20,7 +20,7 @@ func TestNetStats(t *testing.T) {
 
 	containerType := ci.TypeNode
 	extractor := NewNetMetricExtractor(nil)
-	var cMetrics []*stores.RawContainerInsightsMetric
+	var cMetrics []*stores.CIMetricImpl
 	if extractor.HasValue(result[0]) {
 		cMetrics = extractor.GetValue(result[0], nil, containerType)
 	}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/helpers.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/helpers.go
@@ -64,7 +64,7 @@ func (m MockHostInfo) GetInstanceID() string {
 }
 
 func (m MockHostInfo) GetInstanceType() string {
-	return "instance-id"
+	return "instance-type"
 }
 
 func (m MockHostInfo) GetAutoScalingGroupName() string {
@@ -72,5 +72,5 @@ func (m MockHostInfo) GetAutoScalingGroupName() string {
 }
 
 func (m MockHostInfo) ExtractEbsIDsUsedByKubernetes() map[string]string {
-	return map[string]string{}
+	return map[string]string{"device": "ebs-volume-id"}
 }

--- a/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs.go
+++ b/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs.go
@@ -1,0 +1,443 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package efa
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores"
+)
+
+const (
+	defaultCollectionInterval = 20 * time.Second
+)
+
+const (
+	efaPath            = "/sys/class/infiniband"
+	efaK8sResourceName = "vpc.amazonaws.com/efa"
+
+	// hardware counter names
+	counterRdmaReadBytes      = "rdma_read_bytes"
+	counterRdmaWriteBytes     = "rdma_write_bytes"
+	counterRdmaWriteRecvBytes = "rdma_write_recv_bytes"
+	counterRxBytes            = "rx_bytes"
+	counterRxDrops            = "rx_drops"
+	counterTxBytes            = "tx_bytes"
+)
+
+var counterNames = map[string]any{
+	counterRdmaReadBytes:      nil,
+	counterRdmaWriteBytes:     nil,
+	counterRdmaWriteRecvBytes: nil,
+	counterRxBytes:            nil,
+	counterRxDrops:            nil,
+	counterTxBytes:            nil,
+}
+
+type Scraper struct {
+	collectionInterval time.Duration
+	cancel             context.CancelFunc
+
+	sysFsReader       sysFsReader
+	deltaCalculator   metrics.MetricCalculator
+	decorator         stores.Decorator
+	podResourcesStore podResourcesStore
+	store             *efaStore
+	logger            *zap.Logger
+}
+
+type sysFsReader interface {
+	EfaDataExists() (bool, error)
+	ListDevices() ([]efaDeviceName, error)
+	ListPorts(deviceName efaDeviceName) ([]string, error)
+	ReadCounter(deviceName efaDeviceName, port string, counter string) (uint64, error)
+}
+
+type podResourcesStore interface {
+	AddResourceName(resourceName string)
+	GetContainerInfo(deviceID string, resourceName string) *stores.ContainerInfo
+}
+
+type efaStore struct {
+	timestamp time.Time
+	devices   *efaDevices
+}
+
+// efaDevices is a collection of every Amazon Elastic Fabric Adapter (EFA) device in
+// /sys/class/infiniband.
+type efaDevices map[efaDeviceName]*efaCounters
+
+type efaDeviceName string
+
+// efaCounters contains counter values from files in
+// /sys/class/infiniband/<Name>/ports/<Port>/hw_counters
+// for a single port of one Amazon Elastic Fabric Adapter device.
+type efaCounters struct {
+	rdmaReadBytes      uint64 // hw_counters/rdma_read_bytes
+	rdmaWriteBytes     uint64 // hw_counters/rdma_write_bytes
+	rdmaWriteRecvBytes uint64 // hw_counters/rdma_write_recv_bytes
+	rxBytes            uint64 // hw_counters/rx_bytes
+	rxDrops            uint64 // hw_counters/rx_drops
+	txBytes            uint64 // hw_counters/tx_bytes
+}
+
+func NewEfaSyfsScraper(logger *zap.Logger, decorator stores.Decorator, podResourcesStore podResourcesStore) *Scraper {
+	ctx, cancel := context.WithCancel(context.Background())
+	podResourcesStore.AddResourceName(efaK8sResourceName)
+	e := &Scraper{
+		collectionInterval: defaultCollectionInterval,
+		cancel:             cancel,
+		sysFsReader:        defaultSysFsReader(logger),
+		deltaCalculator:    metrics.NewMetricCalculator(calculateDelta),
+		decorator:          decorator,
+		podResourcesStore:  podResourcesStore,
+		store:              new(efaStore),
+		logger:             logger,
+	}
+
+	go e.startScrape(ctx)
+
+	return e
+}
+
+func calculateDelta(prev *metrics.MetricValue, val any, _ time.Time) (any, bool) {
+	if prev == nil {
+		return 0, false
+	}
+	return val.(uint64) - prev.RawValue.(uint64), true
+}
+
+func (s *Scraper) Shutdown() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+}
+
+func (s *Scraper) GetMetrics() []pmetric.Metrics {
+	var result []pmetric.Metrics
+
+	store := s.store
+	for deviceName, counters := range *store.devices {
+		containerInfo := s.podResourcesStore.GetContainerInfo(string(deviceName), efaK8sResourceName)
+		if containerInfo == nil {
+			continue
+		}
+
+		containerMetric := stores.NewCIMetric(ci.TypeContainerEFA, s.logger)
+		podMetric := stores.NewCIMetric(ci.TypePodEFA, s.logger)
+		nodeMetric := stores.NewCIMetric(ci.TypeNodeEFA, s.logger)
+
+		s.fillMetric(containerMetric, ci.TypeContainerEFA, containerInfo.Namespace, containerInfo.PodName,
+			containerInfo.ContainerName, string(deviceName), store.timestamp, counters)
+		s.fillMetric(podMetric, ci.TypePodEFA, containerInfo.Namespace, containerInfo.PodName,
+			containerInfo.ContainerName, string(deviceName), store.timestamp, counters)
+		s.fillMetric(nodeMetric, ci.TypeNodeEFA, containerInfo.Namespace, containerInfo.PodName,
+			containerInfo.ContainerName, string(deviceName), store.timestamp, counters)
+
+		for _, m := range []stores.CIMetric{containerMetric, podMetric, nodeMetric} {
+			m.AddTag(ci.AttributeEfaDevice, string(deviceName))
+			m.AddTag(ci.Timestamp, strconv.FormatInt(store.timestamp.UnixNano(), 10))
+		}
+		for _, m := range []stores.CIMetric{containerMetric, podMetric} {
+			m.AddTag(ci.AttributeK8sNamespace, containerInfo.Namespace)
+			m.AddTag(ci.AttributeK8sPodName, containerInfo.PodName)
+			m.AddTag(ci.AttributeContainerName, containerInfo.ContainerName)
+		}
+
+		for _, m := range []stores.CIMetric{containerMetric, podMetric, nodeMetric} {
+			if len(m.GetFields()) == 0 {
+				continue
+			}
+			metric := s.decorator.Decorate(m)
+			result = append(result, ci.ConvertToOTLPMetrics(metric.GetFields(), metric.GetTags(), s.logger))
+		}
+	}
+
+	return result
+}
+
+type metadata struct {
+	namespace     string
+	podName       string
+	containerName string
+	deviceName    string
+	metricName    string
+}
+
+func (s *Scraper) fillMetric(metric stores.CIMetric, metricType string, namespace string, podName string,
+	containerName string, deviceName string, timestamp time.Time, counters *efaCounters) {
+
+	metricNameValue := map[string]uint64{
+		ci.MetricName(metricType, ci.EfaRdmaReadBytes):      counters.rdmaReadBytes,
+		ci.MetricName(metricType, ci.EfaRdmaWriteBytes):     counters.rdmaWriteBytes,
+		ci.MetricName(metricType, ci.EfaRdmaWriteRecvBytes): counters.rdmaWriteRecvBytes,
+		ci.MetricName(metricType, ci.EfaRxBytes):            counters.rxBytes,
+		ci.MetricName(metricType, ci.EfaRxDropped):          counters.rxDrops,
+		ci.MetricName(metricType, ci.EfaTxBytes):            counters.txBytes,
+	}
+
+	for metricName, value := range metricNameValue {
+		s.assignRateValueToField(metricName, value, metric, namespace, podName, containerName, deviceName, timestamp)
+	}
+}
+
+func (s *Scraper) assignRateValueToField(metricName string, value uint64, metric stores.CIMetric, namespace string,
+	podName string, containerName string, deviceName string, timestamp time.Time) {
+	key := metrics.Key{
+		MetricMetadata: metadata{
+			namespace:     namespace,
+			podName:       podName,
+			containerName: containerName,
+			deviceName:    deviceName,
+			metricName:    metricName,
+		},
+	}
+	deltaValue, found := s.deltaCalculator.Calculate(key, value, timestamp)
+	if found {
+		metric.AddField(metricName, deltaValue)
+	}
+}
+
+func (s *Scraper) init() {
+}
+
+func (s *Scraper) startScrape(ctx context.Context) {
+	ticker := time.NewTicker(s.collectionInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			err := s.scrape()
+			if err != nil {
+				s.logger.Warn("Failed to scrape EFA metrics from filesystem", zap.Error(err))
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (s *Scraper) scrape() error {
+	exists, err := s.sysFsReader.EfaDataExists()
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
+	timestamp := time.Now()
+
+	devices, err := s.parseEfaDevices()
+	if err != nil {
+		return err
+	}
+
+	s.store = &efaStore{
+		timestamp: timestamp,
+		devices:   devices,
+	}
+
+	return nil
+}
+
+func (s *Scraper) parseEfaDevices() (*efaDevices, error) {
+	deviceNames, err := s.sysFsReader.ListDevices()
+	if err != nil {
+		return nil, err
+	}
+
+	devices := make(efaDevices, len(deviceNames))
+	for _, name := range deviceNames {
+		counters, err := s.parseEfaDevice(name)
+		if err != nil {
+			return nil, err
+		}
+
+		devices[name] = counters
+	}
+
+	return &devices, nil
+}
+
+func (s *Scraper) parseEfaDevice(deviceName efaDeviceName) (*efaCounters, error) {
+	ports, err := s.sysFsReader.ListPorts(deviceName)
+	if err != nil {
+		return nil, err
+	}
+
+	counters := new(efaCounters)
+	for _, port := range ports {
+		err := s.readCounters(deviceName, port, counters)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return counters, nil
+}
+
+func (s *Scraper) readCounters(deviceName efaDeviceName, port string, counters *efaCounters) error {
+	var errs error
+	reader := func(counter string) uint64 {
+		value, err := s.sysFsReader.ReadCounter(deviceName, port, counter)
+		if err != nil {
+			errs = errors.Join(errs, err)
+			return 0
+		}
+		return value
+	}
+
+	for counter := range counterNames {
+		switch counter {
+		case counterRdmaReadBytes:
+			counters.rdmaReadBytes += reader(counter)
+		case counterRdmaWriteBytes:
+			counters.rdmaWriteBytes += reader(counter)
+		case counterRdmaWriteRecvBytes:
+			counters.rdmaWriteRecvBytes += reader(counter)
+		case counterRxBytes:
+			counters.rxBytes += reader(counter)
+		case counterRxDrops:
+			counters.rxDrops += reader(counter)
+		case counterTxBytes:
+			counters.txBytes += reader(counter)
+		}
+	}
+
+	return errs
+}
+
+func defaultSysFsReader(logger *zap.Logger) sysFsReader {
+	return &sysfsReaderImpl{
+		logger: logger,
+	}
+}
+
+type sysfsReaderImpl struct {
+	logger *zap.Logger
+}
+
+var _ sysFsReader = (*sysfsReaderImpl)(nil)
+
+func (r *sysfsReaderImpl) EfaDataExists() (bool, error) {
+	info, err := os.Stat(efaPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return true, nil
+	}
+
+	fmt.Printf("EFA directory uid: %d, perms: %s\n", stat.Uid, info.Mode().Perm())
+
+	if stat.Uid != 0 {
+		r.logger.Warn("EFA directory exists but is not owned by root, not reading from it", zap.String("path", efaPath), zap.Uint32("owner uid", stat.Uid))
+		return false, nil
+	}
+	perms := info.Mode().Perm()
+	if perms&0002 != 0 {
+		r.logger.Warn("EFA directory exists but is writeable by anyone, not reading from it", zap.String("path", efaPath), zap.String("permissions", perms.String()))
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (r *sysfsReaderImpl) ListDevices() ([]efaDeviceName, error) {
+	dirs, err := os.ReadDir(efaPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list EFA devices at %q: %w", efaPath, err)
+	}
+
+	result := make([]efaDeviceName, 0)
+	for _, dir := range dirs {
+		if !dir.IsDir() && dir.Type()&os.ModeSymlink == 0 {
+			continue
+		}
+		result = append(result, efaDeviceName(dir.Name()))
+	}
+
+	return result, nil
+}
+
+func (r *sysfsReaderImpl) ListPorts(deviceName efaDeviceName) ([]string, error) {
+	portsPath := filepath.Join(efaPath, string(deviceName), "ports")
+	portDirs, err := os.ReadDir(portsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list EFA ports at %q: %w", portsPath, err)
+	}
+
+	result := make([]string, 0)
+	for _, dir := range portDirs {
+		if !dir.IsDir() {
+			continue
+		}
+		result = append(result, dir.Name())
+	}
+
+	return result, nil
+}
+
+func (r *sysfsReaderImpl) ReadCounter(deviceName efaDeviceName, port string, counter string) (uint64, error) {
+	path := filepath.Join(efaPath, string(deviceName), "ports", port, "hw_counters", counter)
+	return readUint64ValueFromFile(path)
+}
+
+func readUint64ValueFromFile(path string) (uint64, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to read file %q: %w", path, err)
+	}
+	stringValue := strings.TrimSpace(string(bytes))
+
+	// Ugly workaround for handling https://github.com/prometheus/node_exporter/issues/966
+	// when counters are `N/A (not available)`.
+	// This was already patched and submitted, see
+	// https://www.spinics.net/lists/linux-rdma/msg68596.html
+	// Remove this as soon as the fix lands in the enterprise distros.
+	if strings.Contains(stringValue, "N/A (no PMA)") {
+		return 0, nil
+	}
+
+	value, err := parseUInt64(stringValue)
+	if err != nil {
+		return 0, err
+	}
+
+	return value, nil
+}
+
+// Parse string to UInt64
+func parseUInt64(value string) (uint64, error) {
+	// A base value of zero makes ParseInt infer the correct base using the
+	// string's prefix, if any.
+	const base = 0
+	v, err := strconv.ParseUint(value, base, 64)
+	if err != nil {
+		return 0, err
+	}
+	return v, err
+}

--- a/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs.go
+++ b/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs.go
@@ -345,10 +345,9 @@ func (r *sysfsReaderImpl) EfaDataExists() (bool, error) {
 
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
-		return true, nil
+		r.logger.Warn("Couldn't read permissions of EFA directory, not reading from it", zap.String("path", efaPath))
+		return false, nil
 	}
-
-	fmt.Printf("EFA directory uid: %d, perms: %s\n", stat.Uid, info.Mode().Perm())
 
 	if stat.Uid != 0 {
 		r.logger.Warn("EFA directory exists but is not owned by root, not reading from it", zap.String("path", efaPath), zap.Uint32("owner uid", stat.Uid))
@@ -432,7 +431,7 @@ func readUint64ValueFromFile(path string) (uint64, error) {
 
 // Parse string to UInt64
 func parseUInt64(value string) (uint64, error) {
-	// A base value of zero makes ParseInt infer the correct base using the
+	// A base value of zero makes ParseUint infer the correct base using the
 	// string's prefix, if any.
 	const base = 0
 	v, err := strconv.ParseUint(value, base, 64)

--- a/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs_test.go
@@ -1,0 +1,467 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package efa
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores"
+)
+
+type mockSysfsReader struct {
+	scrapeCounts map[string]uint64
+}
+
+var _ sysFsReader = (*mockSysfsReader)(nil)
+
+func newMockSysfsReader() mockSysfsReader {
+	return mockSysfsReader{
+		scrapeCounts: make(map[string]uint64),
+	}
+}
+
+func (r mockSysfsReader) EfaDataExists() (bool, error) {
+	return true, nil
+}
+
+func (r mockSysfsReader) ListDevices() ([]efaDeviceName, error) {
+	return []efaDeviceName{"efa0", "efa1"}, nil
+}
+
+func (r mockSysfsReader) ListPorts(_ efaDeviceName) ([]string, error) {
+	return []string{"1", "2"}, nil
+}
+
+// func (r mockSysfsReader) ListCounters(_ efaDeviceName, _ string) ([]string, error) {
+//	return []string{
+//		counterRdmaReadBytes,
+//		counterRdmaWriteBytes,
+//		counterRdmaWriteRecvBytes,
+//		counterRxBytes,
+//		counterRxDrops,
+//		counterTxBytes,
+//		"ignored-counter",
+//	}, nil
+// }
+
+var mockCounterValues = map[string]uint64{
+	counterRdmaReadBytes:      1,
+	counterRdmaWriteBytes:     2,
+	counterRdmaWriteRecvBytes: 3,
+	counterRxBytes:            4,
+	counterRxDrops:            5,
+	counterTxBytes:            6,
+}
+
+func (r mockSysfsReader) ReadCounter(deviceName efaDeviceName, port string, counter string) (uint64, error) {
+	key := fmt.Sprintf("%s/%s/%s", deviceName, port, counter)
+	value := mockCounterValues[counter] * (r.scrapeCounts[key] + 1)
+	r.scrapeCounts[key]++
+	return value, nil
+}
+
+type mockDecorator struct{}
+
+var _ stores.Decorator = (*mockDecorator)(nil)
+
+func (d mockDecorator) Decorate(metric stores.CIMetric) stores.CIMetric {
+	metric.AddTag("decorated", "true")
+	return metric
+}
+
+func (d mockDecorator) Shutdown() error {
+	return nil
+}
+
+type mockPodResourcesStore struct{}
+
+var _ podResourcesStore = (*mockPodResourcesStore)(nil)
+
+func (p mockPodResourcesStore) AddResourceName(_ string) {}
+
+func (p mockPodResourcesStore) GetContainerInfo(deviceID string, _ string) *stores.ContainerInfo {
+	switch deviceID {
+	case "efa0":
+		return &stores.ContainerInfo{
+			PodName:       "pod0",
+			ContainerName: "container0",
+			Namespace:     "namespace0",
+		}
+	case "efa1":
+		return &stores.ContainerInfo{
+			PodName:       "pod1",
+			ContainerName: "container1",
+			Namespace:     "namespace1",
+		}
+	}
+	return nil
+}
+
+type expectation struct {
+	fields map[string]uint64
+	tags   map[string]string
+}
+
+var efa0Metrics = []expectation{
+	{
+		map[string]uint64{
+			"container_efa_rdma_read_bytes":       2,
+			"container_efa_rdma_write_bytes":      4,
+			"container_efa_rdma_write_recv_bytes": 6,
+			"container_efa_rx_bytes":              8,
+			"container_efa_rx_dropped":            10,
+			"container_efa_tx_bytes":              12,
+		},
+		map[string]string{
+			ci.MetricType:             ci.TypeContainerEFA,
+			ci.AttributeEfaDevice:     "efa0",
+			ci.AttributeK8sNamespace:  "namespace0",
+			ci.AttributeK8sPodName:    "pod0",
+			ci.AttributeContainerName: "container0",
+			ci.Timestamp:              "to-be-replaced",
+			"decorated":               "true",
+		},
+	},
+	{
+		map[string]uint64{
+			"pod_efa_rdma_read_bytes":       2,
+			"pod_efa_rdma_write_bytes":      4,
+			"pod_efa_rdma_write_recv_bytes": 6,
+			"pod_efa_rx_bytes":              8,
+			"pod_efa_rx_dropped":            10,
+			"pod_efa_tx_bytes":              12,
+		},
+		map[string]string{
+			ci.MetricType:             ci.TypePodEFA,
+			ci.AttributeEfaDevice:     "efa0",
+			ci.AttributeK8sNamespace:  "namespace0",
+			ci.AttributeK8sPodName:    "pod0",
+			ci.AttributeContainerName: "container0",
+			ci.Timestamp:              "to-be-replaced",
+			"decorated":               "true",
+		},
+	},
+	{
+		map[string]uint64{
+			"node_efa_rdma_read_bytes":       2,
+			"node_efa_rdma_write_bytes":      4,
+			"node_efa_rdma_write_recv_bytes": 6,
+			"node_efa_rx_bytes":              8,
+			"node_efa_rx_dropped":            10,
+			"node_efa_tx_bytes":              12,
+		},
+		map[string]string{
+			ci.MetricType:         ci.TypeNodeEFA,
+			ci.AttributeEfaDevice: "efa0",
+			ci.Timestamp:          "to-be-replaced",
+			"decorated":           "true",
+		},
+	},
+}
+
+var efa1Metrics = []expectation{
+	{
+		map[string]uint64{
+			"container_efa_rdma_read_bytes":       2,
+			"container_efa_rdma_write_bytes":      4,
+			"container_efa_rdma_write_recv_bytes": 6,
+			"container_efa_rx_bytes":              8,
+			"container_efa_rx_dropped":            10,
+			"container_efa_tx_bytes":              12,
+		},
+		map[string]string{
+			ci.MetricType:             ci.TypeContainerEFA,
+			ci.AttributeEfaDevice:     "efa1",
+			ci.AttributeK8sNamespace:  "namespace1",
+			ci.AttributeK8sPodName:    "pod1",
+			ci.AttributeContainerName: "container1",
+			ci.Timestamp:              "to-be-replaced",
+			"decorated":               "true",
+		},
+	},
+	{
+		map[string]uint64{
+			"pod_efa_rdma_read_bytes":       2,
+			"pod_efa_rdma_write_bytes":      4,
+			"pod_efa_rdma_write_recv_bytes": 6,
+			"pod_efa_rx_bytes":              8,
+			"pod_efa_rx_dropped":            10,
+			"pod_efa_tx_bytes":              12,
+		},
+		map[string]string{
+			ci.MetricType:             ci.TypePodEFA,
+			ci.AttributeEfaDevice:     "efa1",
+			ci.AttributeK8sNamespace:  "namespace1",
+			ci.AttributeK8sPodName:    "pod1",
+			ci.AttributeContainerName: "container1",
+			ci.Timestamp:              "to-be-replaced",
+			"decorated":               "true",
+		},
+	},
+	{
+		map[string]uint64{
+			"node_efa_rdma_read_bytes":       2,
+			"node_efa_rdma_write_bytes":      4,
+			"node_efa_rdma_write_recv_bytes": 6,
+			"node_efa_rx_bytes":              8,
+			"node_efa_rx_dropped":            10,
+			"node_efa_tx_bytes":              12,
+		},
+		map[string]string{
+			ci.MetricType:         ci.TypeNodeEFA,
+			ci.AttributeEfaDevice: "efa1",
+			ci.Timestamp:          "to-be-replaced",
+			"decorated":           "true",
+		},
+	},
+}
+
+func TestGetMetrics(t *testing.T) {
+	s := NewEfaSyfsScraper(zap.NewNop(), mockDecorator{}, mockPodResourcesStore{})
+	s.sysFsReader = newMockSysfsReader()
+
+	var expectedMetrics []expectation
+	expectedMetrics = append(expectedMetrics, efa0Metrics...)
+	expectedMetrics = append(expectedMetrics, efa1Metrics...)
+
+	// first metric collection should return no metrics because we haven't established a baseline for the delta
+	// calculation yet
+	assert.NoError(t, s.scrape())
+	result := s.GetMetrics()
+	assert.Empty(t, result)
+
+	assert.NoError(t, s.scrape())
+	result = s.GetMetrics()
+	checkExpectations(t, expectedMetrics, result)
+}
+
+type mockPodResourcesStoreMissingOneDevice struct{}
+
+var _ podResourcesStore = (*mockPodResourcesStoreMissingOneDevice)(nil)
+
+func (p mockPodResourcesStoreMissingOneDevice) AddResourceName(_ string) {}
+
+func (p mockPodResourcesStoreMissingOneDevice) GetContainerInfo(deviceID string, _ string) *stores.ContainerInfo {
+	if deviceID == "efa0" {
+		return &stores.ContainerInfo{
+			PodName:       "pod0",
+			ContainerName: "container0",
+			Namespace:     "namespace0",
+		}
+	}
+	return nil
+}
+
+func TestGetMetricsMissingDeviceFromPodResources(t *testing.T) {
+	s := NewEfaSyfsScraper(zap.NewNop(), mockDecorator{}, mockPodResourcesStoreMissingOneDevice{})
+	s.sysFsReader = newMockSysfsReader()
+
+	assert.NoError(t, s.scrape())
+	assert.Empty(t, s.GetMetrics())
+
+	expectedMetrics := efa0Metrics
+
+	assert.NoError(t, s.scrape())
+	result := s.GetMetrics()
+	checkExpectations(t, expectedMetrics, result)
+}
+
+func checkExpectations(t *testing.T, expected []expectation, actual []pmetric.Metrics) {
+	assert.Equal(t, len(expected), len(actual))
+	for i := 0; i < len(expected); i++ {
+		expectedMetric := expected[i]
+		actualMetric := actual[i]
+		checkExpectation(t, expectedMetric.fields, expectedMetric.tags, actualMetric)
+	}
+}
+
+func checkExpectation(t *testing.T, expectedFields map[string]uint64, expectedTags map[string]string, md pmetric.Metrics) {
+	rm := md.ResourceMetrics()
+	assert.Equal(t, 1, rm.Len())
+	resource := rm.At(0)
+
+	sm := resource.ScopeMetrics()
+	assert.Equal(t, len(expectedFields), sm.Len())
+	for i := 0; i < sm.Len(); i++ {
+		metrics := sm.At(i).Metrics()
+		assert.Equal(t, 1, metrics.Len())
+		metric := metrics.At(0)
+		assert.Contains(t, expectedFields, metric.Name())
+		dps := metric.Gauge().DataPoints()
+		assert.Equal(t, 1, dps.Len())
+		dp := dps.At(0)
+		assert.Equal(t, int64(expectedFields[metric.Name()]), dp.IntValue())
+	}
+
+	attrs := resource.Resource().Attributes()
+	assert.Equal(t, len(expectedTags), attrs.Len())
+	if _, ok := expectedTags[ci.Timestamp]; ok {
+		timestampString, timestamp := findTimestamp(t, attrs)
+		assert.NotNil(t, timestamp)
+		age := time.Since(timestamp)
+		assert.Less(t, age, time.Minute)
+		expectedTags[ci.Timestamp] = timestampString
+	}
+	for key, value := range expectedTags {
+		actual, ok := attrs.Get(key)
+		assert.True(t, ok)
+		assert.Equal(t, value, actual.Str())
+	}
+}
+
+func findTimestamp(t *testing.T, attrs pcommon.Map) (string, time.Time) {
+	var timestampString string
+	var timestamp time.Time
+	attrs.Range(func(k string, v pcommon.Value) bool {
+		if k == ci.Timestamp {
+			ms, err := strconv.ParseInt(v.Str(), 10, 64)
+			assert.NoError(t, err)
+			timestampString = v.Str()
+			timestamp = time.Unix(ms/1000, 0)
+			return false
+		}
+		return true
+	})
+	return timestampString, timestamp
+}
+
+func TestScrape(t *testing.T) {
+	s := NewEfaSyfsScraper(zap.NewNop(), nil, mockPodResourcesStore{})
+	s.sysFsReader = newMockSysfsReader()
+
+	expectedCounters := efaCounters{
+		// All values multiplied by 2 because we mock 2 ports
+		rdmaReadBytes:      2,
+		rdmaWriteBytes:     4,
+		rdmaWriteRecvBytes: 6,
+		rxBytes:            8,
+		rxDrops:            10,
+		txBytes:            12,
+	}
+	expected := efaDevices{
+		"efa0": &expectedCounters,
+		"efa1": &expectedCounters,
+	}
+
+	assert.NoError(t, s.scrape())
+	assert.Equal(t, expected, *s.store.devices)
+}
+
+type mockSysfsReaderError1 struct{}
+
+func (r mockSysfsReaderError1) EfaDataExists() (bool, error) {
+	return false, errors.New("mocked error")
+}
+
+func (r mockSysfsReaderError1) ListDevices() ([]efaDeviceName, error) {
+	return []efaDeviceName{"efa0"}, nil
+}
+
+func (r mockSysfsReaderError1) ListPorts(_ efaDeviceName) ([]string, error) {
+	return []string{}, nil
+}
+
+func (r mockSysfsReaderError1) ReadCounter(_ efaDeviceName, _ string, _ string) (uint64, error) {
+	return 0, nil
+}
+
+type mockSysfsReaderError2 struct{}
+
+func (r mockSysfsReaderError2) EfaDataExists() (bool, error) {
+	return true, nil
+}
+
+func (r mockSysfsReaderError2) ListDevices() ([]efaDeviceName, error) {
+	return nil, errors.New("mocked error")
+}
+
+func (r mockSysfsReaderError2) ListPorts(_ efaDeviceName) ([]string, error) {
+	return []string{}, nil
+}
+
+func (r mockSysfsReaderError2) ReadCounter(_ efaDeviceName, _ string, _ string) (uint64, error) {
+	return 0, nil
+}
+
+type mockSysfsReaderError3 struct{}
+
+func (r mockSysfsReaderError3) EfaDataExists() (bool, error) {
+	return true, nil
+}
+
+func (r mockSysfsReaderError3) ListDevices() ([]efaDeviceName, error) {
+	return []efaDeviceName{"efa0"}, nil
+}
+
+func (r mockSysfsReaderError3) ListPorts(_ efaDeviceName) ([]string, error) {
+	return nil, errors.New("mocked error")
+}
+
+func (r mockSysfsReaderError3) ReadCounter(_ efaDeviceName, _ string, _ string) (uint64, error) {
+	return 0, nil
+}
+
+type mockSysfsReaderError4 struct{}
+
+func (r mockSysfsReaderError4) EfaDataExists() (bool, error) {
+	return true, nil
+}
+
+func (r mockSysfsReaderError4) ListDevices() ([]efaDeviceName, error) {
+	return []efaDeviceName{"efa0"}, nil
+}
+
+func (r mockSysfsReaderError4) ListPorts(_ efaDeviceName) ([]string, error) {
+	return []string{"1"}, nil
+}
+
+func (r mockSysfsReaderError4) ReadCounter(_ efaDeviceName, _ string, _ string) (uint64, error) {
+	return 1, errors.New("mocked error")
+}
+
+func TestScrapeErrors(t *testing.T) {
+	for _, reader := range []sysFsReader{mockSysfsReaderError1{}, mockSysfsReaderError2{}, mockSysfsReaderError3{}, mockSysfsReaderError4{}} {
+		s := NewEfaSyfsScraper(zap.NewNop(), nil, mockPodResourcesStore{})
+		s.sysFsReader = reader
+
+		assert.Error(t, s.scrape())
+		assert.Nil(t, s.store.devices)
+	}
+}
+
+type mockSysfsReaderNoEfaData struct{}
+
+func (r mockSysfsReaderNoEfaData) EfaDataExists() (bool, error) {
+	return false, nil
+}
+
+func (r mockSysfsReaderNoEfaData) ListDevices() ([]efaDeviceName, error) {
+	return nil, errors.New("mocked error")
+}
+
+func (r mockSysfsReaderNoEfaData) ListPorts(_ efaDeviceName) ([]string, error) {
+	return nil, errors.New("mocked error")
+}
+
+func (r mockSysfsReaderNoEfaData) ReadCounter(_ efaDeviceName, _ string, _ string) (uint64, error) {
+	return 0, errors.New("mocked error")
+}
+
+func TestScrapeNoEfaData(t *testing.T) {
+	s := NewEfaSyfsScraper(zap.NewNop(), nil, mockPodResourcesStore{})
+	s.sysFsReader = mockSysfsReaderNoEfaData{}
+
+	assert.NoError(t, s.scrape())
+	assert.Nil(t, s.store.devices)
+}

--- a/receiver/awscontainerinsightreceiver/internal/host/ebsvolume_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/ebsvolume_test.go
@@ -172,9 +172,9 @@ func TestEBSVolume(t *testing.T) {
 	assert.Equal(t, "aws://us-west-2/vol-0c241693efb58734a", e.getEBSVolumeID("/dev/nvme0n2"))
 	assert.Equal(t, "", e.getEBSVolumeID("/dev/invalid"))
 
-	ebsIds := e.extractEbsIDsUsedByKubernetes()
-	assert.Equal(t, 1, len(ebsIds))
-	assert.Equal(t, "aws://us-west-2b/vol-0d9f0816149eb2050", ebsIds["/dev/nvme1n1"])
+	ebsIDs := e.extractEbsIDsUsedByKubernetes()
+	assert.Equal(t, 1, len(ebsIDs))
+	assert.Equal(t, "aws://us-west-2b/vol-0d9f0816149eb2050", ebsIDs["/dev/nvme1n1"])
 
 	// set e.hostMounts to an invalid path
 	hostMountsOption = func(e *ebsVolume) {
@@ -182,6 +182,6 @@ func TestEBSVolume(t *testing.T) {
 	}
 	e = newEBSVolume(ctx, sess, "instanceId", "us-west-2", time.Millisecond, zap.NewNop(),
 		clientOption, maxJitterOption, hostMountsOption, LstatOption, evalSymLinksOption)
-	ebsIds = e.extractEbsIDsUsedByKubernetes()
-	assert.Equal(t, 0, len(ebsIds))
+	ebsIDs = e.extractEbsIDsUsedByKubernetes()
+	assert.Equal(t, 0, len(ebsIDs))
 }

--- a/receiver/awscontainerinsightreceiver/internal/host/nodeCapacity_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/nodeCapacity_test.go
@@ -21,7 +21,7 @@ import (
 func TestNodeCapacity(t *testing.T) {
 	// no proc directory
 	lstatOption := func(nc *nodeCapacity) {
-		nc.osLstat = func(name string) (os.FileInfo, error) {
+		nc.osLstat = func(_ string) (os.FileInfo, error) {
 			return nil, os.ErrNotExist
 		}
 	}
@@ -31,24 +31,24 @@ func TestNodeCapacity(t *testing.T) {
 
 	// can't set environment variables
 	lstatOption = func(nc *nodeCapacity) {
-		nc.osLstat = func(name string) (os.FileInfo, error) {
+		nc.osLstat = func(_ string) (os.FileInfo, error) {
 			return nil, nil
 		}
 	}
 
 	// can't parse cpu and mem info
 	setEnvOption := func(nc *nodeCapacity) {
-		nc.osSetenv = func(key, value string) error {
+		nc.osSetenv = func(_, _ string) error {
 			return nil
 		}
 	}
 	virtualMemOption := func(nc *nodeCapacity) {
-		nc.virtualMemory = func(ctx context.Context) (*mem.VirtualMemoryStat, error) {
+		nc.virtualMemory = func(_ context.Context) (*mem.VirtualMemoryStat, error) {
 			return nil, errors.New("error")
 		}
 	}
 	cpuInfoOption := func(nc *nodeCapacity) {
-		nc.cpuInfo = func(ctx context.Context) ([]cpu.InfoStat, error) {
+		nc.cpuInfo = func(_ context.Context) ([]cpu.InfoStat, error) {
 			return nil, errors.New("error")
 		}
 	}
@@ -60,15 +60,18 @@ func TestNodeCapacity(t *testing.T) {
 
 	// normal case where everything is working
 	virtualMemOption = func(nc *nodeCapacity) {
-		nc.virtualMemory = func(ctx context.Context) (*mem.VirtualMemoryStat, error) {
+		nc.virtualMemory = func(_ context.Context) (*mem.VirtualMemoryStat, error) {
 			return &mem.VirtualMemoryStat{
 				Total: 1024,
 			}, nil
 		}
 	}
 	cpuInfoOption = func(nc *nodeCapacity) {
-		nc.cpuInfo = func(ctx context.Context) ([]cpu.InfoStat, error) {
-			return []cpu.InfoStat{}, nil
+		nc.cpuInfo = func(_ context.Context) ([]cpu.InfoStat, error) {
+			return []cpu.InfoStat{
+				{},
+				{},
+			}, nil
 		}
 	}
 	nc, err = newNodeCapacity(zap.NewNop(), lstatOption, setEnvOption, virtualMemOption, cpuInfoOption)

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/cpu_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/cpu_extractor.go
@@ -31,10 +31,10 @@ func (c *CPUMetricExtractor) HasValue(rawMetric RawMetric) bool {
 	return false
 }
 
-func (c *CPUMetricExtractor) GetValue(rawMetric RawMetric, mInfo cExtractor.CPUMemInfoProvider, containerType string) []*stores.RawContainerInsightsMetric {
-	var metrics []*stores.RawContainerInsightsMetric
+func (c *CPUMetricExtractor) GetValue(rawMetric RawMetric, mInfo cExtractor.CPUMemInfoProvider, containerType string) []*stores.CIMetricImpl {
+	var metrics []*stores.CIMetricImpl
 
-	metric := stores.NewRawContainerInsightsMetric(containerType, c.logger)
+	metric := stores.NewCIMetric(containerType, c.logger)
 
 	multiplier := float64(decimalToMillicores)
 	identifier := rawMetric.Id

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/cpu_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/cpu_extractor_test.go
@@ -32,7 +32,7 @@ func TestCPUStats(t *testing.T) {
 	containerType := containerinsight.TypePod
 	extractor := NewCPUMetricExtractor(&zap.Logger{})
 
-	var cMetrics []*stores.RawContainerInsightsMetric
+	var cMetrics []*stores.CIMetricImpl
 	if extractor.HasValue(podRawMetric) {
 		cMetrics = extractor.GetValue(podRawMetric, MockCPUMemInfo, containerType)
 	}

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractor.go
@@ -93,6 +93,6 @@ type RawMetric struct {
 
 type MetricExtractor interface {
 	HasValue(summary RawMetric) bool
-	GetValue(summary RawMetric, mInfo cExtractor.CPUMemInfoProvider, containerType string) []*stores.RawContainerInsightsMetric
+	GetValue(summary RawMetric, mInfo cExtractor.CPUMemInfoProvider, containerType string) []*stores.CIMetricImpl
 	Shutdown() error
 }

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/fs_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/fs_extractor.go
@@ -27,16 +27,16 @@ func (f *FileSystemMetricExtractor) HasValue(rawMetric RawMetric) bool {
 	return false
 }
 
-func (f *FileSystemMetricExtractor) GetValue(rawMetric RawMetric, _ cExtractor.CPUMemInfoProvider, containerType string) []*stores.RawContainerInsightsMetric {
+func (f *FileSystemMetricExtractor) GetValue(rawMetric RawMetric, _ cExtractor.CPUMemInfoProvider, containerType string) []*stores.CIMetricImpl {
 	if containerType == ci.TypePod {
 		return nil
 	}
 
 	containerType = getFSMetricType(containerType, f.logger)
-	metrics := make([]*stores.RawContainerInsightsMetric, 0, len(rawMetric.FileSystemStats))
+	metrics := make([]*stores.CIMetricImpl, 0, len(rawMetric.FileSystemStats))
 
 	for _, v := range rawMetric.FileSystemStats {
-		metric := stores.NewRawContainerInsightsMetric(containerType, f.logger)
+		metric := stores.NewCIMetric(containerType, f.logger)
 
 		metric.AddTag(ci.DiskDev, v.Device)
 		metric.AddTag(ci.FSType, v.Type)

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/fs_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/fs_extractor_test.go
@@ -27,7 +27,7 @@ func TestFSStats(t *testing.T) {
 	containerType := containerinsight.TypeNode
 	extractor := NewFileSystemMetricExtractor(nil)
 
-	var cMetrics []*stores.RawContainerInsightsMetric
+	var cMetrics []*stores.CIMetricImpl
 	if extractor.HasValue(nodeRawMetric) {
 		cMetrics = extractor.GetValue(nodeRawMetric, nil, containerType)
 	}

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/mem_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/mem_extractor.go
@@ -29,9 +29,9 @@ func (m *MemMetricExtractor) HasValue(rawMetric RawMetric) bool {
 	return false
 }
 
-func (m *MemMetricExtractor) GetValue(rawMetric RawMetric, mInfo cExtractor.CPUMemInfoProvider, containerType string) []*stores.RawContainerInsightsMetric {
-	var metrics []*stores.RawContainerInsightsMetric
-	metric := stores.NewRawContainerInsightsMetric(containerType, m.logger)
+func (m *MemMetricExtractor) GetValue(rawMetric RawMetric, mInfo cExtractor.CPUMemInfoProvider, containerType string) []*stores.CIMetricImpl {
+	var metrics []*stores.CIMetricImpl
+	metric := stores.NewCIMetric(containerType, m.logger)
 	identifier := rawMetric.Id
 
 	metric.AddField(ci.MetricName(containerType, ci.MemUsage), rawMetric.MemoryStats.UsageBytes)

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/mem_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/mem_extractor_test.go
@@ -29,7 +29,7 @@ func TestMemStats(t *testing.T) {
 	containerType := containerinsight.TypePod
 	extractor := NewMemMetricExtractor(nil)
 
-	var cMetrics []*stores.RawContainerInsightsMetric
+	var cMetrics []*stores.CIMetricImpl
 	if extractor.HasValue(podRawMetric) {
 		cMetrics = extractor.GetValue(podRawMetric, MockCPUMemInfo, containerType)
 	}

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/net_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/net_extractor.go
@@ -29,8 +29,8 @@ func (n *NetMetricExtractor) HasValue(rawMetric RawMetric) bool {
 	return false
 }
 
-func (n *NetMetricExtractor) GetValue(rawMetric RawMetric, mInfo cExtractor.CPUMemInfoProvider, containerType string) []*stores.RawContainerInsightsMetric {
-	var metrics []*stores.RawContainerInsightsMetric
+func (n *NetMetricExtractor) GetValue(rawMetric RawMetric, mInfo cExtractor.CPUMemInfoProvider, containerType string) []*stores.CIMetricImpl {
+	var metrics []*stores.CIMetricImpl
 
 	if containerType == ci.TypeContainer {
 		return nil
@@ -58,7 +58,7 @@ func (n *NetMetricExtractor) GetValue(rawMetric RawMetric, mInfo cExtractor.CPUM
 
 		netIfceMetrics[i] = netIfceMetric
 
-		metric := stores.NewRawContainerInsightsMetric(mType, n.logger)
+		metric := stores.NewCIMetric(mType, n.logger)
 		metric.AddTag(ci.NetIfce, intf.Name)
 		for k, v := range netIfceMetric {
 			metric.AddField(ci.MetricName(mType, k), v)
@@ -69,7 +69,7 @@ func (n *NetMetricExtractor) GetValue(rawMetric RawMetric, mInfo cExtractor.CPUM
 
 	aggregatedFields := ci.SumFields(netIfceMetrics)
 	if len(aggregatedFields) > 0 {
-		metric := stores.NewRawContainerInsightsMetric(containerType, n.logger)
+		metric := stores.NewCIMetric(containerType, n.logger)
 		for k, v := range aggregatedFields {
 			metric.AddField(ci.MetricName(containerType, k), v)
 		}

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/net_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/net_extractor_test.go
@@ -28,7 +28,7 @@ func TestNetStats(t *testing.T) {
 
 	containerType := ci.TypeNode
 	extractor := NewNetMetricExtractor(nil)
-	var cMetrics []*stores.RawContainerInsightsMetric
+	var cMetrics []*stores.CIMetricImpl
 	if extractor.HasValue(nodeRawMetric) {
 		cMetrics = extractor.GetValue(nodeRawMetric, nil, containerType)
 	}

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/hcsshim/hcsshim.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/hcsshim/hcsshim.go
@@ -66,8 +66,8 @@ func NewHnSProvider(logger *zap.Logger, info cExtractor.CPUMemInfoProvider, mext
 	return hp, nil
 }
 
-func (hp *HCSStatsProvider) GetMetrics() ([]*stores.RawContainerInsightsMetric, error) {
-	var metrics []*stores.RawContainerInsightsMetric
+func (hp *HCSStatsProvider) GetMetrics() ([]*stores.CIMetricImpl, error) {
+	var metrics []*stores.CIMetricImpl
 	if ci.IsWindowsHostProcessContainer() {
 		containerToEndpointMap, err := hp.getContainerToEndpointMap()
 		if err != nil {
@@ -115,7 +115,7 @@ func (hp *HCSStatsProvider) getContainerMetrics(containerId string) (extractors.
 	return stat, nil
 }
 
-func (hp *HCSStatsProvider) getPodMetrics() ([]*stores.RawContainerInsightsMetric, error) {
+func (hp *HCSStatsProvider) getPodMetrics() ([]*stores.CIMetricImpl, error) {
 	hp.logger.Debug("Getting pod stats using Microsoft HCS shim APIs")
 	podToContainerMap, err := hp.getPodToContainerMap()
 	if err != nil {
@@ -123,11 +123,11 @@ func (hp *HCSStatsProvider) getPodMetrics() ([]*stores.RawContainerInsightsMetri
 		return nil, err
 	}
 
-	var metrics []*stores.RawContainerInsightsMetric
+	var metrics []*stores.CIMetricImpl
 	var endpointMetricsCollected []string
 
 	for _, pod := range podToContainerMap {
-		var metricsPerPod []*stores.RawContainerInsightsMetric
+		var metricsPerPod []*stores.CIMetricImpl
 		tags := map[string]string{}
 
 		tags[ci.AttributePodID] = pod.PodId

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/k8swindows.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/k8swindows.go
@@ -97,9 +97,9 @@ func (k *K8sWindows) GetMetrics() []pmetric.Metrics {
 	return result
 }
 
-func (k *K8sWindows) decorateMetrics(windowsmetrics []*stores.RawContainerInsightsMetric) []*stores.RawContainerInsightsMetric {
+func (k *K8sWindows) decorateMetrics(windowsmetrics []*stores.CIMetricImpl) []*stores.CIMetricImpl {
 	//ebsVolumeIdsUsedAsPV := c.hostInfo.ExtractEbsIDsUsedByKubernetes()
-	var result []*stores.RawContainerInsightsMetric
+	var result []*stores.CIMetricImpl
 	for _, m := range windowsmetrics {
 		tags := m.GetTags()
 		//c.addEbsVolumeInfo(tags, ebsVolumeIdsUsedAsPV)
@@ -133,7 +133,7 @@ func (k *K8sWindows) decorateMetrics(windowsmetrics []*stores.RawContainerInsigh
 
 		out := k.k8sDecorator.Decorate(m)
 		if out != nil {
-			result = append(result, out.(*stores.RawContainerInsightsMetric))
+			result = append(result, out.(*stores.CIMetricImpl))
 		}
 	}
 	return result

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet/kubelet.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet/kubelet.go
@@ -50,8 +50,8 @@ func New(logger *zap.Logger, info cExtractor.CPUMemInfoProvider, mextractor []ex
 	return sp, nil
 }
 
-func (sp *SummaryProvider) GetMetrics() ([]*stores.RawContainerInsightsMetric, error) {
-	var metrics []*stores.RawContainerInsightsMetric
+func (sp *SummaryProvider) GetMetrics() ([]*stores.CIMetricImpl, error) {
+	var metrics []*stores.CIMetricImpl
 
 	summary, err := sp.kubeletProvider.GetSummary()
 	if err != nil {
@@ -76,8 +76,8 @@ func (sp *SummaryProvider) GetMetrics() ([]*stores.RawContainerInsightsMetric, e
 }
 
 // getContainerMetrics returns container level metrics from kubelet summary.
-func (sp *SummaryProvider) getContainerMetrics(pod stats.PodStats) ([]*stores.RawContainerInsightsMetric, error) {
-	var metrics []*stores.RawContainerInsightsMetric
+func (sp *SummaryProvider) getContainerMetrics(pod stats.PodStats) ([]*stores.CIMetricImpl, error) {
+	var metrics []*stores.CIMetricImpl
 
 	for _, container := range pod.Containers {
 		tags := map[string]string{}
@@ -106,15 +106,15 @@ func (sp *SummaryProvider) getContainerMetrics(pod stats.PodStats) ([]*stores.Ra
 }
 
 // getPodMetrics returns pod and container level metrics from kubelet summary.
-func (sp *SummaryProvider) getPodMetrics(summary *stats.Summary) ([]*stores.RawContainerInsightsMetric, error) {
-	var metrics []*stores.RawContainerInsightsMetric
+func (sp *SummaryProvider) getPodMetrics(summary *stats.Summary) ([]*stores.CIMetricImpl, error) {
+	var metrics []*stores.CIMetricImpl
 
 	if summary == nil {
 		return metrics, nil
 	}
 
 	for _, pod := range summary.Pods {
-		var metricsPerPod []*stores.RawContainerInsightsMetric
+		var metricsPerPod []*stores.CIMetricImpl
 
 		tags := map[string]string{}
 
@@ -146,8 +146,8 @@ func (sp *SummaryProvider) getPodMetrics(summary *stats.Summary) ([]*stores.RawC
 }
 
 // getNodeMetrics returns Node level metrics from kubelet summary.
-func (sp *SummaryProvider) getNodeMetrics(summary *stats.Summary) ([]*stores.RawContainerInsightsMetric, error) {
-	var metrics []*stores.RawContainerInsightsMetric
+func (sp *SummaryProvider) getNodeMetrics(summary *stats.Summary) ([]*stores.CIMetricImpl, error) {
+	var metrics []*stores.CIMetricImpl
 
 	if summary == nil {
 		return metrics, nil

--- a/receiver/awscontainerinsightreceiver/internal/prometheusscraper/decoratorconsumer/decorator.go
+++ b/receiver/awscontainerinsightreceiver/internal/prometheusscraper/decoratorconsumer/decorator.go
@@ -46,9 +46,9 @@ func (dc *DecorateConsumer) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 			for k := 0; k < ms.Len(); k++ {
 				m := ms.At(k)
 				converted := ci.ConvertToFieldsAndTags(m, dc.Logger)
-				var rcis []*stores.RawContainerInsightsMetric
+				var rcis []*stores.CIMetricImpl
 				for _, pair := range converted {
-					rcis = append(rcis, stores.NewRawContainerInsightsMetricWithData(dc.MetricType, pair.Fields, pair.Tags, dc.Logger))
+					rcis = append(rcis, stores.NewCIMetricWithData(dc.MetricType, pair.Fields, pair.Tags, dc.Logger))
 				}
 
 				decorated := dc.decorateMetrics(rcis)
@@ -67,8 +67,8 @@ type Decorator interface {
 	Shutdown() error
 }
 
-func (dc *DecorateConsumer) decorateMetrics(rcis []*stores.RawContainerInsightsMetric) []*stores.RawContainerInsightsMetric {
-	var result []*stores.RawContainerInsightsMetric
+func (dc *DecorateConsumer) decorateMetrics(rcis []*stores.CIMetricImpl) []*stores.CIMetricImpl {
+	var result []*stores.CIMetricImpl
 	if dc.ContainerOrchestrator != ci.EKS {
 		return result
 	}
@@ -76,13 +76,13 @@ func (dc *DecorateConsumer) decorateMetrics(rcis []*stores.RawContainerInsightsM
 		// add tags for EKS
 		out := dc.K8sDecorator.Decorate(rci)
 		if out != nil {
-			result = append(result, out.(*stores.RawContainerInsightsMetric))
+			result = append(result, out.(*stores.CIMetricImpl))
 		}
 	}
 	return result
 }
 
-func (dc *DecorateConsumer) updateAttributes(m pmetric.Metric, rcis []*stores.RawContainerInsightsMetric) {
+func (dc *DecorateConsumer) updateAttributes(m pmetric.Metric, rcis []*stores.CIMetricImpl) {
 	if len(rcis) == 0 {
 		return
 	}

--- a/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil/kubeletclient_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil/kubeletclient_test.go
@@ -33,7 +33,7 @@ func (f *fakeClient) Get(path string) ([]byte, error) {
 }
 
 func TestNewKubeletClient(t *testing.T) {
-	kubeletNewClientProvider = func(endpoint string, cfg *kube.ClientConfig, logger *zap.Logger) (kube.ClientProvider, error) {
+	kubeletNewClientProvider = func(endpoint string, cfg *kube.ClientConfig, _ *zap.Logger) (kube.ClientProvider, error) {
 		return &mockClientProvider{
 			endpoint: endpoint,
 			cfg:      cfg,

--- a/receiver/awscontainerinsightreceiver/internal/stores/localnode.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/localnode.go
@@ -1,0 +1,165 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package stores
+
+import (
+	"fmt"
+	"os"
+
+	"go.uber.org/zap"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+)
+
+type LocalNodeDecorator struct {
+	hostInfo              hostInfo
+	version               string
+	nodeName              string
+	containerOrchestrator string
+	ecsInfo               EcsInfo
+	logger                *zap.Logger
+	k8sDecorator          Decorator
+}
+
+type hostInfo interface {
+	GetClusterName() string
+	GetEBSVolumeID(string) string
+	ExtractEbsIDsUsedByKubernetes() map[string]string
+	GetInstanceID() string
+	GetInstanceType() string
+	GetAutoScalingGroupName() string
+}
+
+type EcsInfo interface {
+	GetContainerInstanceID() string
+	GetClusterName() string
+}
+
+type Decorator interface {
+	Decorate(CIMetric) CIMetric
+	Shutdown() error
+}
+
+func NewLocalNodeDecorator(logger *zap.Logger, containerOrchestrator string, hostInfo hostInfo, options ...Option) (*LocalNodeDecorator, error) {
+	nodeName := os.Getenv(ci.HostName)
+	if nodeName == "" && containerOrchestrator == ci.EKS {
+		return nil, fmt.Errorf("missing environment variable %s. Please check your deployment YAML config", ci.HostName)
+	}
+
+	d := &LocalNodeDecorator{
+		hostInfo:              hostInfo,
+		version:               "0",
+		nodeName:              nodeName,
+		containerOrchestrator: containerOrchestrator,
+		logger:                logger,
+	}
+
+	for _, option := range options {
+		option(d)
+	}
+
+	return d, nil
+}
+
+type Option func(decorator *LocalNodeDecorator)
+
+func WithK8sDecorator(d Decorator) Option {
+	return func(ld *LocalNodeDecorator) {
+		ld.k8sDecorator = d
+	}
+}
+
+func WithECSInfo(f EcsInfo) Option {
+	return func(c *LocalNodeDecorator) {
+		c.ecsInfo = f
+	}
+}
+
+func (d *LocalNodeDecorator) Decorate(m CIMetric) CIMetric {
+	result := m
+
+	ebsVolumeIDsUsedAsPV := d.hostInfo.ExtractEbsIDsUsedByKubernetes()
+	tags := m.GetTags()
+	d.addEbsVolumeInfo(tags, ebsVolumeIDsUsedAsPV)
+
+	// add version
+	tags[ci.Version] = d.version
+
+	// add NodeName for node, pod and container
+	metricType := tags[ci.MetricType]
+	if d.nodeName != "" && (ci.IsNode(metricType) || ci.IsInstance(metricType) ||
+		ci.IsPod(metricType) || ci.IsContainer(metricType)) {
+		tags[ci.NodeNameKey] = d.nodeName
+	}
+
+	// add instance id and type
+	if instanceID := d.hostInfo.GetInstanceID(); instanceID != "" {
+		tags[ci.InstanceID] = instanceID
+	}
+	if instanceType := d.hostInfo.GetInstanceType(); instanceType != "" {
+		tags[ci.InstanceType] = instanceType
+	}
+
+	// add scaling group name
+	tags[ci.AutoScalingGroupNameKey] = d.hostInfo.GetAutoScalingGroupName()
+
+	// add ECS cluster name and container instance id
+	if d.containerOrchestrator == ci.ECS {
+		d.addECSResources(m)
+	}
+
+	// add tags for EKS
+	if d.containerOrchestrator == ci.EKS {
+
+		tags[ci.ClusterNameKey] = d.hostInfo.GetClusterName()
+
+		if d.k8sDecorator != nil {
+			result = d.k8sDecorator.Decorate(m)
+		}
+	}
+
+	return result
+}
+
+func (d *LocalNodeDecorator) addEbsVolumeInfo(tags map[string]string, ebsVolumeIDsUsedAsPV map[string]string) {
+	deviceName, ok := tags[ci.DiskDev]
+	if !ok {
+		return
+	}
+
+	if d.hostInfo != nil {
+		if volID := d.hostInfo.GetEBSVolumeID(deviceName); volID != "" {
+			tags[ci.HostEbsVolumeID] = volID
+		}
+	}
+
+	if tags[ci.MetricType] == ci.TypeContainerFS || tags[ci.MetricType] == ci.TypeNodeFS ||
+		tags[ci.MetricType] == ci.TypeNodeDiskIO || tags[ci.MetricType] == ci.TypeContainerDiskIO {
+		if volID := ebsVolumeIDsUsedAsPV[deviceName]; volID != "" {
+			tags[ci.EbsVolumeID] = volID
+		}
+	}
+}
+
+func (d *LocalNodeDecorator) addECSResources(m CIMetric) {
+	tags := m.GetTags()
+
+	if d.ecsInfo.GetClusterName() == "" {
+		d.logger.Warn("Can't get cluster name")
+	} else {
+		tags[ci.ClusterNameKey] = d.ecsInfo.GetClusterName()
+	}
+
+	if d.ecsInfo.GetContainerInstanceID() == "" {
+		d.logger.Warn("Can't get containerInstanceId")
+	} else {
+		tags[ci.ContainerInstanceIDKey] = d.ecsInfo.GetContainerInstanceID()
+	}
+
+	TagMetricSource(m)
+}
+
+func (d *LocalNodeDecorator) Shutdown() error {
+	return nil
+}

--- a/receiver/awscontainerinsightreceiver/internal/stores/localnode_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/localnode_test.go
@@ -1,0 +1,142 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package stores
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils"
+)
+
+// get error when $HOST_NAME is not set
+// no error when it is set
+
+var logger = zap.NewNop()
+
+func TestNewLocalNodeDecorator(t *testing.T) {
+	// don't set HostName environment variable, expect error in eks
+	d, err := NewLocalNodeDecorator(logger, "eks", nil)
+	assert.Nil(t, d)
+	assert.Error(t, err)
+
+	// don't expect error in ecs
+	d, err = NewLocalNodeDecorator(logger, "ecs", nil)
+	assert.NotNil(t, d)
+	assert.NoError(t, err)
+
+	t.Setenv(ci.HostName, "host")
+	d, err = NewLocalNodeDecorator(logger, "eks", nil)
+	assert.NotNil(t, d)
+	assert.NoError(t, err)
+}
+
+func TestEbsVolumeInfo(t *testing.T) {
+	t.Setenv(ci.HostName, "host")
+	hostInfo := testutils.MockHostInfo{}
+	d, err := NewLocalNodeDecorator(logger, "eks", hostInfo)
+	assert.NotNil(t, d)
+	assert.NoError(t, err)
+
+	m := NewCIMetric("metric-type", logger)
+	result := d.Decorate(m)
+	assert.False(t, result.HasTag(ci.HostEbsVolumeID))
+	assert.False(t, result.HasTag(ci.EbsVolumeID))
+
+	m = NewCIMetricWithData("metric-type", map[string]any{}, map[string]string{ci.DiskDev: "my-disk"}, logger)
+	result = d.Decorate(m)
+	assert.True(t, result.HasTag(ci.HostEbsVolumeID))
+	assert.False(t, result.HasTag(ci.EbsVolumeID))
+
+	var deviceName string
+	for key := range hostInfo.ExtractEbsIDsUsedByKubernetes() {
+		deviceName = key
+		break
+	}
+	for _, mType := range []string{ci.TypeContainerFS, ci.TypeNodeFS, ci.TypeNodeDiskIO, ci.TypeContainerDiskIO} {
+		m = NewCIMetricWithData(mType, map[string]any{}, map[string]string{ci.DiskDev: deviceName}, logger)
+		result = d.Decorate(m)
+		assert.True(t, result.HasTag(ci.HostEbsVolumeID))
+		assert.True(t, result.HasTag(ci.EbsVolumeID))
+	}
+}
+
+type mockK8sDecorator struct{}
+
+func (d mockK8sDecorator) Decorate(m CIMetric) CIMetric {
+	m.AddTag("k8s-decorated", "true")
+	return m
+}
+func (d mockK8sDecorator) Shutdown() error {
+	return nil
+}
+
+func TestExpectedTags(t *testing.T) {
+	t.Setenv(ci.HostName, "host")
+	hostInfo := testutils.MockHostInfo{ClusterName: "my-cluster"}
+	k8sDecorator := mockK8sDecorator{}
+	ecsInfo := testutils.MockECSInfo{}
+
+	testCases := map[string]struct {
+		containerOrchestrator string
+		metricType            string
+		expectedTags          map[string]string
+	}{
+		"EksGenericMetricType": {
+			containerOrchestrator: "eks",
+			metricType:            "metric-type",
+			expectedTags: map[string]string{
+				ci.Version:                 "0",
+				ci.AutoScalingGroupNameKey: "asg",           // from MockHostInfo
+				ci.InstanceID:              "instance-id",   // from MockHostInfo
+				ci.InstanceType:            "instance-type", // from MockHostInfo
+				ci.ClusterNameKey:          "my-cluster",
+				"k8s-decorated":            "true",
+			},
+		},
+		"EksNodeMetricType": {
+			containerOrchestrator: "eks",
+			metricType:            ci.TypeNode,
+			expectedTags: map[string]string{
+				ci.Version:                 "0",
+				ci.AutoScalingGroupNameKey: "asg",           // from MockHostInfo
+				ci.InstanceID:              "instance-id",   // from MockHostInfo
+				ci.InstanceType:            "instance-type", // from MockHostInfo
+				ci.NodeNameKey:             "host",
+				ci.ClusterNameKey:          "my-cluster",
+				"k8s-decorated":            "true",
+			},
+		},
+		"EcsInstanceMetricType": {
+			containerOrchestrator: "ecs",
+			metricType:            ci.TypeInstance,
+			expectedTags: map[string]string{
+				ci.Version:                 "0",
+				ci.AutoScalingGroupNameKey: "asg",           // from MockHostInfo
+				ci.InstanceID:              "instance-id",   // from MockHostInfo
+				ci.InstanceType:            "instance-type", // from MockHostInfo
+				ci.NodeNameKey:             "host",
+				ci.ClusterNameKey:          "ecs-cluster", // from MockECSInfo
+				ci.ContainerInstanceIDKey:  "eeee12.dsfr", // from MockECSInfo
+				ci.SourcesKey:              "[\"cadvisor\",\"/proc\",\"ecsagent\",\"calculated\"]",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			d, err := NewLocalNodeDecorator(logger, testCase.containerOrchestrator, hostInfo, WithK8sDecorator(k8sDecorator), WithECSInfo(&ecsInfo))
+			assert.NotNil(t, d)
+			assert.NoError(t, err)
+
+			m := NewCIMetric(testCase.metricType, logger)
+			testCase.expectedTags[ci.MetricType] = testCase.metricType
+			result := d.Decorate(m)
+			assert.Equal(t, testCase.expectedTags, result.GetTags())
+		})
+	}
+}

--- a/receiver/awscontainerinsightreceiver/internal/stores/podresourcesstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podresourcesstore.go
@@ -56,6 +56,9 @@ func NewPodResourcesStore(logger *zap.Logger) (*PodResourcesStore, error) {
 	once.Do(func() {
 		podResourcesClient, err := kubeletutil.NewPodResourcesClient()
 		clientInitErr = err
+		if clientInitErr != nil {
+			return
+		}
 		ctx, cancel := context.WithCancel(context.Background())
 		instance = &PodResourcesStore{
 			containerInfoToResourcesMap: make(map[ContainerInfo][]ResourceInfo),

--- a/receiver/awscontainerinsightreceiver/internal/stores/podresourcesstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podresourcesstore_test.go
@@ -144,11 +144,8 @@ func (m *MockPodResourcesClient) Shutdown() {
 
 func TestNewPodResourcesStore(t *testing.T) {
 	logger := zap.NewNop()
-	store, err := NewPodResourcesStore(logger)
-	assert.Nil(t, err, "Error should be nil")
-	assert.NotNil(t, store, "PodResourcesStore should not be nil")
-	assert.NotNil(t, store.ctx, "Context should not be nil")
-	assert.NotNil(t, store.cancel, "Cancel function should not be nil")
+	_, err := NewPodResourcesStore(logger)
+	assert.Error(t, err, "Expected error creating pod resources store because the kubelet socket should not exist")
 }
 
 func TestRefreshTick(t *testing.T) {

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -914,7 +914,7 @@ func TestPodStore_RefreshTick(t *testing.T) {
 }
 
 func TestPodStore_decorateNode(t *testing.T) {
-	t.Setenv("HOST_NAME", "testNode1")
+	t.Setenv(ci.HostName, "testNode1")
 	pod := getBaseTestPodInfo()
 	podList := []corev1.Pod{*pod}
 	podStore := getPodStore()

--- a/receiver/awscontainerinsightreceiver/internal/stores/store.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/store.go
@@ -14,12 +14,15 @@ import (
 
 // CIMetric represents the raw metric interface for container insights
 type CIMetric interface {
+	GetMetricType() string
 	HasField(key string) bool
 	AddField(key string, val any)
 	GetField(key string) any
+	GetFields() map[string]any
 	HasTag(key string) bool
 	AddTag(key, val string)
 	GetTag(key string) string
+	GetTags() map[string]string
 	RemoveTag(key string)
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/stores/utils.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/utils.go
@@ -114,27 +114,35 @@ func tagMetricSourceLinux(metric CIMetric) {
 	var sources []string
 	switch metricType {
 	case ci.TypeNode:
-		sources = append(sources, []string{"cadvisor", "/proc", "pod", "calculated"}...)
+		sources = []string{"cadvisor", "/proc", "pod", "calculated"}
 	case ci.TypeNodeFS:
-		sources = append(sources, []string{"cadvisor", "calculated"}...)
+		sources = []string{"cadvisor", "calculated"}
 	case ci.TypeNodeNet:
-		sources = append(sources, []string{"cadvisor", "calculated"}...)
+		sources = []string{"cadvisor", "calculated"}
 	case ci.TypeNodeDiskIO:
-		sources = append(sources, []string{"cadvisor"}...)
+		sources = []string{"cadvisor"}
 	case ci.TypePod:
-		sources = append(sources, []string{"cadvisor", "pod", "calculated"}...)
+		sources = []string{"cadvisor", "pod", "calculated"}
 	case ci.TypePodNet:
-		sources = append(sources, []string{"cadvisor", "calculated"}...)
+		sources = []string{"cadvisor", "calculated"}
 	case ci.TypeContainer:
-		sources = append(sources, []string{"cadvisor", "pod", "calculated"}...)
+		sources = []string{"cadvisor", "pod", "calculated"}
 	case ci.TypeContainerFS:
-		sources = append(sources, []string{"cadvisor", "calculated"}...)
+		sources = []string{"cadvisor", "calculated"}
 	case ci.TypeContainerDiskIO:
-		sources = append(sources, []string{"cadvisor"}...)
-	case ci.TypeGpuContainer:
-		sources = append(sources, []string{"dcgm", "pod", "calculated"}...)
+		sources = []string{"cadvisor"}
+	case ci.TypeInstance:
+		sources = []string{"cadvisor", "/proc", "ecsagent", "calculated"}
+	case ci.TypeInstanceFS:
+		sources = []string{"cadvisor", "calculated"}
+	case ci.TypeInstanceNet:
+		sources = []string{"cadvisor", "calculated"}
+	case ci.TypeInstanceDiskIO:
+		sources = []string{"cadvisor"}
+	case ci.TypeContainerGPU:
+		sources = []string{"dcgm", "pod", "calculated"}
 	case ci.TypeNeuronContainer:
-		sources = append(sources, []string{"neuron", "pod", "calculated"}...)
+		sources = []string{"neuron", "pod", "calculated"}
 	}
 
 	if len(sources) > 0 {
@@ -226,7 +234,7 @@ func refreshWithTimeout(parentContext context.Context, refresh func(), timeout t
 	cancel()
 }
 
-type RawContainerInsightsMetric struct {
+type CIMetricImpl struct {
 	// source of the metric for debugging merge conflict
 	ContainerName string
 	// key/value pairs that are typed and contain the metric (numerical) data
@@ -236,10 +244,10 @@ type RawContainerInsightsMetric struct {
 	Logger *zap.Logger
 }
 
-var _ CIMetric = (*RawContainerInsightsMetric)(nil)
+var _ CIMetric = (*CIMetricImpl)(nil)
 
-func NewRawContainerInsightsMetric(mType string, logger *zap.Logger) *RawContainerInsightsMetric {
-	metric := &RawContainerInsightsMetric{
+func NewCIMetric(mType string, logger *zap.Logger) *CIMetricImpl {
+	metric := &CIMetricImpl{
 		Fields: make(map[string]any),
 		Tags:   make(map[string]string),
 		Logger: logger,
@@ -248,60 +256,65 @@ func NewRawContainerInsightsMetric(mType string, logger *zap.Logger) *RawContain
 	return metric
 }
 
-func NewRawContainerInsightsMetricWithData(mType string, fields map[string]any, tags map[string]string, logger *zap.Logger) *RawContainerInsightsMetric {
-	metric := NewRawContainerInsightsMetric(mType, logger)
-	metric.Fields = fields
-	metric.Tags = tags
+func NewCIMetricWithData(mType string, fields map[string]any, tags map[string]string, logger *zap.Logger) *CIMetricImpl {
+	metric := &CIMetricImpl{
+		Fields: fields,
+		Tags:   tags,
+		Logger: logger,
+	}
+	if _, ok := metric.Tags[ci.MetricType]; !ok {
+		metric.Tags[ci.MetricType] = mType
+	}
 	return metric
 }
 
-func (c *RawContainerInsightsMetric) GetTags() map[string]string {
+func (c *CIMetricImpl) GetTags() map[string]string {
 	return c.Tags
 }
 
-func (c *RawContainerInsightsMetric) GetFields() map[string]any {
+func (c *CIMetricImpl) GetFields() map[string]any {
 	return c.Fields
 }
 
-func (c *RawContainerInsightsMetric) GetMetricType() string {
+func (c *CIMetricImpl) GetMetricType() string {
 	return c.Tags[ci.MetricType]
 }
 
-func (c *RawContainerInsightsMetric) AddTags(tags map[string]string) {
+func (c *CIMetricImpl) AddTags(tags map[string]string) {
 	for k, v := range tags {
 		c.Tags[k] = v
 	}
 }
 
-func (c *RawContainerInsightsMetric) HasField(key string) bool {
+func (c *CIMetricImpl) HasField(key string) bool {
 	return c.Fields[key] != nil
 }
 
-func (c *RawContainerInsightsMetric) AddField(key string, val any) {
+func (c *CIMetricImpl) AddField(key string, val any) {
 	c.Fields[key] = val
 }
 
-func (c *RawContainerInsightsMetric) GetField(key string) any {
+func (c *CIMetricImpl) GetField(key string) any {
 	return c.Fields[key]
 }
 
-func (c *RawContainerInsightsMetric) HasTag(key string) bool {
+func (c *CIMetricImpl) HasTag(key string) bool {
 	return c.Tags[key] != ""
 }
 
-func (c *RawContainerInsightsMetric) AddTag(key, val string) {
+func (c *CIMetricImpl) AddTag(key, val string) {
 	c.Tags[key] = val
 }
 
-func (c *RawContainerInsightsMetric) GetTag(key string) string {
+func (c *CIMetricImpl) GetTag(key string) string {
 	return c.Tags[key]
 }
 
-func (c *RawContainerInsightsMetric) RemoveTag(key string) {
+func (c *CIMetricImpl) RemoveTag(key string) {
 	delete(c.Tags, key)
 }
 
-func (c *RawContainerInsightsMetric) Merge(src *RawContainerInsightsMetric) {
+func (c *CIMetricImpl) Merge(src *CIMetricImpl) {
 	// If there is any conflict, keep the Fields with earlier timestamp
 	for k, v := range src.Fields {
 		if _, ok := c.Fields[k]; ok {

--- a/receiver/awscontainerinsightreceiver/internal/stores/utils.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/utils.go
@@ -141,7 +141,7 @@ func tagMetricSourceLinux(metric CIMetric) {
 		sources = []string{"cadvisor"}
 	case ci.TypeContainerGPU:
 		sources = []string{"dcgm", "pod", "calculated"}
-	case ci.TypeNeuronContainer:
+	case ci.TypeContainerNeuron:
 		sources = []string{"neuron", "pod", "calculated"}
 	}
 

--- a/receiver/awscontainerinsightreceiver/internal/stores/utils_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/utils_test.go
@@ -192,7 +192,7 @@ func TestUtils_TagMetricSource(t *testing.T) {
 		ci.TypeInstanceNet,
 		ci.TypeInstanceDiskIO,
 		ci.TypeContainerGPU,
-		ci.TypeNeuronContainer,
+		ci.TypeContainerNeuron,
 	}
 
 	expectedSources := []string{

--- a/receiver/awscontainerinsightreceiver/internal/stores/utils_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/utils_test.go
@@ -20,6 +20,18 @@ type mockCIMetric struct {
 	fields map[string]any
 }
 
+func (m *mockCIMetric) GetMetricType() string {
+	return "dummy_type"
+}
+
+func (m *mockCIMetric) GetFields() map[string]any {
+	return m.fields
+}
+
+func (m *mockCIMetric) GetTags() map[string]string {
+	return m.tags
+}
+
 func (m *mockCIMetric) HasField(key string) bool {
 	return m.fields[key] != nil
 }
@@ -175,7 +187,11 @@ func TestUtils_TagMetricSource(t *testing.T) {
 		ci.TypeContainer,
 		ci.TypeContainerFS,
 		ci.TypeContainerDiskIO,
-		ci.TypeGpuContainer,
+		ci.TypeInstance,
+		ci.TypeInstanceFS,
+		ci.TypeInstanceNet,
+		ci.TypeInstanceDiskIO,
+		ci.TypeContainerGPU,
 		ci.TypeNeuronContainer,
 	}
 
@@ -188,6 +204,10 @@ func TestUtils_TagMetricSource(t *testing.T) {
 		"[\"cadvisor\",\"pod\",\"calculated\"]",
 		"[\"cadvisor\",\"calculated\"]",
 		"[\"cadvisor\",\"pod\",\"calculated\"]",
+		"[\"cadvisor\",\"calculated\"]",
+		"[\"cadvisor\"]",
+		"[\"cadvisor\",\"/proc\",\"ecsagent\",\"calculated\"]",
+		"[\"cadvisor\",\"calculated\"]",
 		"[\"cadvisor\",\"calculated\"]",
 		"[\"cadvisor\"]",
 		"[\"dcgm\",\"pod\",\"calculated\"]",

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -20,6 +20,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor"
 	ecsinfo "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/ecsInfo"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/efa"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/gpu"
 	hostInfo "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/host"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8sapiserver"
@@ -43,13 +44,14 @@ type awsContainerInsightReceiver struct {
 	nextConsumer             consumer.Metrics
 	config                   *Config
 	cancel                   context.CancelFunc
+	decorators               []stores.Decorator
 	containerMetricsProvider metricsProvider
 	k8sapiserver             metricsProvider
 	prometheusScraper        *k8sapiserver.PrometheusScraper
-	k8sDecorator             *stores.K8sDecorator
 	podResourcesStore        *stores.PodResourcesStore
 	dcgmScraper              *prometheusscraper.SimplePrometheusScraper
 	neuronMonitorScraper     *prometheusscraper.SimplePrometheusScraper
+	efaSysfsScraper          *efa.Scraper
 }
 
 // newAWSContainerInsightReceiver creates the aws container insight receiver with the given parameters.
@@ -79,19 +81,27 @@ func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host compone
 	}
 
 	if acir.config.ContainerOrchestrator == ci.EKS {
-		acir.k8sDecorator, err = stores.NewK8sDecorator(ctx, acir.config.TagService, acir.config.PrefFullPodName, acir.config.AddFullPodNameMetricLabel, acir.config.AddContainerNameMetricLabel, acir.config.EnableControlPlaneMetrics, acir.settings.Logger)
+		k8sDecorator, err := stores.NewK8sDecorator(ctx, acir.config.TagService, acir.config.PrefFullPodName, acir.config.AddFullPodNameMetricLabel, acir.config.AddContainerNameMetricLabel, acir.config.EnableControlPlaneMetrics, acir.settings.Logger)
+		acir.decorators = append(acir.decorators, k8sDecorator)
 		if err != nil {
 			return err
 		}
 
 		if runtime.GOOS == ci.OperatingSystemWindows {
-			acir.containerMetricsProvider, err = k8swindows.New(acir.settings.Logger, acir.k8sDecorator, *hostinfo)
+			acir.containerMetricsProvider, err = k8swindows.New(acir.settings.Logger, k8sDecorator, *hostinfo)
 			if err != nil {
 				return err
 			}
 		} else {
-			decoratorOption := cadvisor.WithDecorator(acir.k8sDecorator)
-			acir.containerMetricsProvider, err = cadvisor.New(acir.config.ContainerOrchestrator, hostinfo, acir.settings.Logger, decoratorOption)
+			localnodeDecorator, err := stores.NewLocalNodeDecorator(acir.settings.Logger, acir.config.ContainerOrchestrator,
+				hostinfo, stores.WithK8sDecorator(k8sDecorator))
+			if err != nil {
+				return err
+			}
+			acir.decorators = append(acir.decorators, localnodeDecorator)
+
+			acir.containerMetricsProvider, err = cadvisor.New(acir.config.ContainerOrchestrator, hostinfo,
+				acir.settings.Logger, cadvisor.WithDecorator(localnodeDecorator))
 			if err != nil {
 				return err
 			}
@@ -111,26 +121,39 @@ func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host compone
 			if err != nil {
 				acir.settings.Logger.Debug("Unable to start kube apiserver prometheus scraper", zap.Error(err))
 			}
-			err = acir.initDcgmScraper(ctx, host, hostinfo, acir.k8sDecorator)
+			err = acir.initDcgmScraper(ctx, host, hostinfo, k8sDecorator)
 			if err != nil {
 				acir.settings.Logger.Debug("Unable to start dcgm scraper", zap.Error(err))
 			}
-			err = acir.initNeuronScraper(ctx, host, hostinfo, acir.k8sDecorator)
+			err = acir.initPodResourcesStore()
+			if err != nil {
+				acir.settings.Logger.Debug("Unable to start pod resources store", zap.Error(err))
+			}
+			err = acir.initNeuronScraper(ctx, host, hostinfo, k8sDecorator)
 			if err != nil {
 				acir.settings.Logger.Debug("Unable to start neuron scraper", zap.Error(err))
+			}
+			err = acir.initEfaSysfsScraper(localnodeDecorator)
+			if err != nil {
+				acir.settings.Logger.Debug("Unable to start EFA scraper", zap.Error(err))
 			}
 		}
 	}
 	if acir.config.ContainerOrchestrator == ci.ECS {
-
 		ecsInfo, err := ecsinfo.NewECSInfo(acir.config.CollectionInterval, hostinfo, host, acir.settings, ecsinfo.WithClusterName(acir.config.ClusterName))
 		if err != nil {
 			return err
 		}
 
-		ecsOption := cadvisor.WithECSInfoCreator(ecsInfo)
+		localnodeDecorator, err := stores.NewLocalNodeDecorator(acir.settings.Logger, acir.config.ContainerOrchestrator,
+			hostinfo, stores.WithECSInfo(ecsInfo))
+		if err != nil {
+			return err
+		}
+		acir.decorators = append(acir.decorators, localnodeDecorator)
 
-		acir.containerMetricsProvider, err = cadvisor.New(acir.config.ContainerOrchestrator, hostinfo, acir.settings.Logger, ecsOption)
+		acir.containerMetricsProvider, err = cadvisor.New(acir.config.ContainerOrchestrator, hostinfo,
+			acir.settings.Logger, cadvisor.WithECSInfoCreator(ecsInfo), cadvisor.WithDecorator(localnodeDecorator))
 		if err != nil {
 			return err
 		}
@@ -202,7 +225,7 @@ func (acir *awsContainerInsightReceiver) initDcgmScraper(ctx context.Context, ho
 	decoConsumer := decoratorconsumer.DecorateConsumer{
 		ContainerOrchestrator: ci.EKS,
 		NextConsumer:          acir.nextConsumer,
-		MetricType:            ci.TypeGpuContainer,
+		MetricType:            ci.TypeContainerGPU,
 		MetricToUnitMap:       gpu.MetricToUnit,
 		K8sDecorator:          decorator,
 		Logger:                acir.settings.Logger,
@@ -220,6 +243,12 @@ func (acir *awsContainerInsightReceiver) initDcgmScraper(ctx context.Context, ho
 
 	var err error
 	acir.dcgmScraper, err = prometheusscraper.NewSimplePrometheusScraper(scraperOpts)
+	return err
+}
+
+func (acir *awsContainerInsightReceiver) initPodResourcesStore() error {
+	var err error
+	acir.podResourcesStore, err = stores.NewPodResourcesStore(acir.settings.Logger)
 	return err
 }
 
@@ -241,12 +270,11 @@ func (acir *awsContainerInsightReceiver) initNeuronScraper(ctx context.Context, 
 		NextConsumer: &decoConsumer,
 		Logger:       acir.settings.Logger,
 	}
-  
-	acir.podResourcesStore, err = stores.NewPodResourcesStore(acir.settings.Logger)
-	if err != nil {
-		return err
+
+	if acir.podResourcesStore == nil {
+		return errors.New("pod resources store was not initialized")
 	}
-  
+
 	acir.podResourcesStore.AddResourceName("aws.amazon.com/neuroncore")
 	acir.podResourcesStore.AddResourceName("aws.amazon.com/neuron")
 	acir.podResourcesStore.AddResourceName("aws.amazon.com/neurondevice")
@@ -271,6 +299,18 @@ func (acir *awsContainerInsightReceiver) initNeuronScraper(ctx context.Context, 
 	return err
 }
 
+func (acir *awsContainerInsightReceiver) initEfaSysfsScraper(localnodeDecorator stores.Decorator) error {
+	if !acir.config.EnableAcceleratedComputeMetrics {
+		return nil
+	}
+
+	if acir.podResourcesStore == nil {
+		return errors.New("pod resources store was not initialized")
+	}
+	acir.efaSysfsScraper = efa.NewEfaSyfsScraper(acir.settings.Logger, localnodeDecorator, acir.podResourcesStore)
+	return nil
+}
+
 // Shutdown stops the awsContainerInsightReceiver receiver.
 func (acir *awsContainerInsightReceiver) Shutdown(context.Context) error {
 	if acir.prometheusScraper != nil {
@@ -290,17 +330,19 @@ func (acir *awsContainerInsightReceiver) Shutdown(context.Context) error {
 	if acir.containerMetricsProvider != nil {
 		errs = errors.Join(errs, acir.containerMetricsProvider.Shutdown())
 	}
-
 	if acir.dcgmScraper != nil {
 		acir.dcgmScraper.Shutdown()
 	}
-
 	if acir.neuronMonitorScraper != nil {
 		acir.neuronMonitorScraper.Shutdown()
 	}
-
-	if acir.k8sDecorator != nil {
-		errs = errors.Join(errs, acir.k8sDecorator.Shutdown())
+	if acir.efaSysfsScraper != nil {
+		acir.efaSysfsScraper.Shutdown()
+	}
+	if acir.decorators != nil {
+		for i := len(acir.decorators) - 1; i >= 0; i-- {
+			errs = errors.Join(errs, acir.decorators[i].Shutdown())
+		}
 	}
 
 	if acir.podResourcesStore != nil {
@@ -340,6 +382,10 @@ func (acir *awsContainerInsightReceiver) collectData(ctx context.Context) error 
 
 	if acir.neuronMonitorScraper != nil {
 		acir.neuronMonitorScraper.GetMetrics() //nolint:errcheck
+	}
+
+	if acir.efaSysfsScraper != nil {
+		mds = append(mds, acir.efaSysfsScraper.GetMetrics()...)
 	}
 
 	for _, md := range mds {

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -261,7 +261,7 @@ func (acir *awsContainerInsightReceiver) initNeuronScraper(ctx context.Context, 
 	decoConsumer := decoratorconsumer.DecorateConsumer{
 		ContainerOrchestrator: ci.EKS,
 		NextConsumer:          acir.nextConsumer,
-		MetricType:            ci.TypeNeuronContainer,
+		MetricType:            ci.TypeContainerNeuron,
 		K8sDecorator:          decorator,
 		Logger:                acir.settings.Logger,
 	}


### PR DESCRIPTION
Add Elastic Fabric Adapter (EFA) metric collection to awscontainerinsightreceiver.

The new component scrapes hardware counters from /sys/class/infiniband on disk.  The layout of that directory is:

```
/sys/class/infiniband/<device name>
└── ports
    └── 1
        └── hw_counters
            ├── rdma_read_bytes
            ├── rdma_write_bytes
            ├── rdma_write_recv_bytes
            ├── rx_bytes
            ├── rx_drops
            └── tx_bytes
```

These are cumulative counters and so they are converted to deltas before sending down the pipeline.
We sum up data from all ports.

The device data is joined with data from the kubelet podresources API which tells us which container a given device is
assigned to.

The metrics are reported at container, pod, and node levels.

This commit also refactors some metric decoration code from cadvisor to a common localnode decorator, intended to be
used by any awscontainerinsightreceiver component that gathers metrics from the local node (as oppoosed to e.g. the k8s
control plane scraper).  This is because we want to share the logic of populating PodName, Kubernetes labels, etc.

I also renamed RawContainerInsightsMetric to CIMetricImpl for brevity.

See also accompanying cloudwatch-agent PR: https://github.com/aws/amazon-cloudwatch-agent/pull/1098