### PR TITLE
Re-enable EFA metric collection and fix nil pointer bug.

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs.go
+++ b/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs.go
@@ -130,7 +130,13 @@ func (s *Scraper) GetMetrics() []pmetric.Metrics {
 	var result []pmetric.Metrics
 
 	store := s.store
+	if store == nil || (*store).devices == nil {
+		return result
+	}
 	for deviceName, counters := range *store.devices {
+		if counters == nil {
+			continue
+		}
 		containerInfo := s.podResourcesStore.GetContainerInfo(string(deviceName), efaK8sResourceName)
 
 		nodeMetric := stores.NewCIMetric(ci.TypeNodeEFA, s.logger)

--- a/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs.go
+++ b/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs.go
@@ -130,7 +130,7 @@ func (s *Scraper) GetMetrics() []pmetric.Metrics {
 	var result []pmetric.Metrics
 
 	store := s.store
-	if store == nil || (*store).devices == nil {
+	if store == nil || store.devices == nil {
 		return result
 	}
 	for deviceName, counters := range *store.devices {

--- a/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs_test.go
@@ -238,6 +238,16 @@ func TestGetMetrics(t *testing.T) {
 	checkExpectations(t, expectedMetrics, result)
 }
 
+func TestGetMetricsBeforeSuccessfulScrape(t *testing.T) {
+	s := NewEfaSyfsScraper(zap.NewNop(), mockDecorator{}, mockPodResourcesStore{})
+
+	result := s.GetMetrics()
+	assert.Empty(t, result)
+	result = s.GetMetrics()
+	assert.Empty(t, result)
+	checkExpectations(t, []expectation{}, result)
+}
+
 type mockPodResourcesStoreMissingOneDevice struct{}
 
 var _ podResourcesStore = (*mockPodResourcesStoreMissingOneDevice)(nil)


### PR DESCRIPTION
**Description:**
If the EFA scraper is enabled but was unable to actually scrape the metrics from disk, then we were getting a nil pointer trying to compute metrics.

**Testing:**
New test before the code change:
```
% go test -count=1 -run TestGetMetricsBeforeSuccessfulScrape ./internal/efa/...
--- FAIL: TestGetMetricsBeforeSuccessfulScrape (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x148a155]

goroutine 6 [running]:
testing.tRunner.func1.2({0x15b57c0, 0x25a1120})
        /usr/local/go/src/testing/testing.go:1631 +0x24a
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1634 +0x377
panic({0x15b57c0?, 0x25a1120?})
        /usr/local/go/src/runtime/panic.go:770 +0x132
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/efa.(*Scraper).GetMetrics(0xc00044dc00)
        /home/straussb/workspace/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs.go:133 +0x35
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/efa.TestGetMetricsBeforeSuccessfulScrape(0xc000414820)
        /home/straussb/workspace/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs_test.go:244 +0x11f
testing.tRunner(0xc000414820, 0x188a7c8)
        /usr/local/go/src/testing/testing.go:1689 +0xfb
created by testing.(*T).Run in goroutine 1
        /usr/local/go/src/testing/testing.go:1742 +0x390
FAIL    github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/efa     0.015s
FAIL
```

After the code change:
```
% go test -count=1 -run TestGetMetricsBeforeSuccessfulScrape ./internal/efa/...
ok      github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/efa     0.019
```