### PR TITLE
Add Hash For Custom Built Jar With Tomcat Bean Name

### DIFF
--- a/receiver/jmxreceiver/supported_jars.go
+++ b/receiver/jmxreceiver/supported_jars.go
@@ -31,6 +31,10 @@ func oldFormatProperties(c *Config, j supportedJar) error {
 // If you change this variable name, please open an issue in opentelemetry-java-contrib
 // so that repository's release automation can be updated
 var jmxMetricsGathererVersions = map[string]supportedJar{
+	"e2b30287e82f5b4c929e14b9411939cf86db4190f2484aca3974830ca9b8607d": {
+		version: "1.35.0-alpha",
+		jar:     "JMX metrics gatherer",
+	},
 	"9f4f7ab6fe7040dbeb91fae75dc17199c408a6339eb498d2f29088b78c621c2c": {
 		version: "1.31.0-alpha",
 		jar:     "JMX metrics gatherer",


### PR DESCRIPTION
**Description:** 
Tomcat Version 10.1.19 Spring Boot 3.2.4 Tomcat Bean Name Is Tomcat Not Catalina

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-java-contrib/issues/1270

**Testing:** 
Take test jar with tomcat in cwa. Run with tomcat springboot server. See tomcat metrics in CW.
<img width="1728" alt="Screenshot 2024-04-12 at 1 31 30 PM" src="https://github.com/open-telemetry/opentelemetry-collector-contrib/assets/81644108/85ebadb7-81c3-4224-ba5b-30cd54d4c919">

**Documentation:** 
N/A