### PR TITLE
[WIP] Implementing changes for CI on systemd

### DIFF
--- a/receiver/awscontainerinsightreceiver/config.go
+++ b/receiver/awscontainerinsightreceiver/config.go
@@ -60,4 +60,7 @@ type Config struct {
 
 	// EnableAcceleratedComputeMetrics enabled features with accelerated compute resources where metrics are scraped from vendor specific sources
 	EnableAcceleratedComputeMetrics bool `mapstructure:"accelerated_compute_metrics"`
+
+	// KubeConfigPath is an optional attribute to override the default kube config path in an EKS environment
+	KubeConfigPath string `mapstructure:"kube_config_path"`
 }

--- a/receiver/awscontainerinsightreceiver/config_test.go
+++ b/receiver/awscontainerinsightreceiver/config_test.go
@@ -87,6 +87,17 @@ func TestLoadConfig(t *testing.T) {
 				EnableControlPlaneMetrics: true,
 			},
 		},
+		{
+			id: component.NewIDWithName(metadata.Type, "custom_kube_config_path"),
+			expected: &Config{
+				CollectionInterval:    60 * time.Second,
+				ContainerOrchestrator: "eks",
+				TagService:            true,
+				PrefFullPodName:       false,
+				LeaderLockName:        "otel-container-insight-clusterleader",
+				KubeConfigPath:        "custom_kube_config_path",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -122,7 +122,7 @@ type PodStore struct {
 	includeEnhancedMetrics    bool
 }
 
-func NewPodStore(hostIP string, prefFullPodName bool, addFullPodNameMetricLabel bool, includeEnhancedMetrics bool, logger *zap.Logger) (*PodStore, error) {
+func NewPodStore(hostIP string, prefFullPodName bool, addFullPodNameMetricLabel bool, includeEnhancedMetrics bool, kubeConfigPath string, logger *zap.Logger) (*PodStore, error) {
 	podClient, err := kubeletutil.NewKubeletClient(hostIP, ci.KubeSecurePort, logger)
 	if err != nil {
 		return nil, err
@@ -142,6 +142,15 @@ func NewPodStore(hostIP string, prefFullPodName bool, addFullPodNameMetricLabel 
 		k8sclient.NodeSelector(fields.OneTermEqualSelector("metadata.name", nodeName)),
 		k8sclient.CaptureNodeLevelInfo(true),
 	)
+
+	if kubeConfigPath != "" {
+		k8sClient = k8sclient.Get(logger,
+			k8sclient.NodeSelector(fields.OneTermEqualSelector("metadata.name", nodeName)),
+			k8sclient.CaptureNodeLevelInfo(true),
+			k8sclient.KubeConfigPath(kubeConfigPath),
+		)
+	}
+
 	if k8sClient == nil {
 		return nil, errors.New("failed to start pod store because k8sclient is nil")
 	}

--- a/receiver/awscontainerinsightreceiver/internal/stores/servicestore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/servicestore.go
@@ -29,12 +29,18 @@ type ServiceStore struct {
 	logger                  *zap.Logger
 }
 
-func NewServiceStore(logger *zap.Logger) (*ServiceStore, error) {
+func NewServiceStore(kubeConfigPath string, logger *zap.Logger) (*ServiceStore, error) {
 	s := &ServiceStore{
 		podKeyToServiceNamesMap: make(map[string][]string),
 		logger:                  logger,
 	}
 	k8sClient := k8sclient.Get(logger)
+	if kubeConfigPath != "" {
+		k8sClient = k8sclient.Get(logger,
+			k8sclient.KubeConfigPath(kubeConfigPath),
+		)
+	}
+
 	if k8sClient == nil {
 		return nil, errors.New("failed to start service store because k8sclient is nil")
 	}

--- a/receiver/awscontainerinsightreceiver/internal/stores/store.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/store.go
@@ -43,7 +43,7 @@ type K8sDecorator struct {
 	podStore *PodStore
 }
 
-func NewK8sDecorator(ctx context.Context, tagService bool, prefFullPodName bool, addFullPodNameMetricLabel bool, addContainerNameMetricLabel bool, includeEnhancedMetrics bool, logger *zap.Logger) (*K8sDecorator, error) {
+func NewK8sDecorator(ctx context.Context, tagService bool, prefFullPodName bool, addFullPodNameMetricLabel bool, addContainerNameMetricLabel bool, includeEnhancedMetrics bool, kubeConfigPath string, logger *zap.Logger) (*K8sDecorator, error) {
 	hostIP := os.Getenv("HOST_IP")
 	if hostIP == "" {
 		return nil, errors.New("environment variable HOST_IP is not set in k8s deployment config")
@@ -54,7 +54,7 @@ func NewK8sDecorator(ctx context.Context, tagService bool, prefFullPodName bool,
 		addContainerNameMetricLabel: addContainerNameMetricLabel,
 	}
 
-	podstore, err := NewPodStore(hostIP, prefFullPodName, addFullPodNameMetricLabel, includeEnhancedMetrics, logger)
+	podstore, err := NewPodStore(hostIP, prefFullPodName, addFullPodNameMetricLabel, includeEnhancedMetrics, kubeConfigPath, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func NewK8sDecorator(ctx context.Context, tagService bool, prefFullPodName bool,
 	k.stores = append(k.stores, podstore)
 
 	if tagService {
-		servicestore, err := NewServiceStore(logger)
+		servicestore, err := NewServiceStore(kubeConfigPath, logger)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
1. Add new flag - kubeConfigPath for awscontainerinsights receiver
2. Modify internal kubelet-client for additional authorization using kubeconfig in addition to service-account
3. Support initializing the kube-client using custom kubeConfigPath in pod-store and service-store
4. Handling errors in the awscontainersinsights receiver if the leader-election/api-server/prometheus server fails to boot-up