### PR TITLE
Update empty metric decorator

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/neuron/metric_name.go
+++ b/receiver/awscontainerinsightreceiver/internal/neuron/metric_name.go
@@ -10,7 +10,7 @@ const (
 	NeuronCoreMemoryUtilizationSharedScratchpad = "neuroncore_memory_usage_model_shared_scratchpad"
 	NeuronCoreMemoryUtilizationRuntimeMemory    = "neuroncore_memory_usage_runtime_memory"
 	NeuronCoreMemoryUtilizationTensors          = "neuroncore_memory_usage_tensors"
-	NeuronDeviceHardwareEccEvents               = "neurondevice_hw_ecc_events_total"
+	NeuronDeviceHardwareEccEvents               = "hardware_ecc_events_total"
 	NeuronExecutionStatus                       = "execution_status_total"
 	NeuronExecutionErrors                       = "execution_errors_total"
 	NeuronRuntimeMemoryUsage                    = "neuron_runtime_memory_used_bytes"

--- a/receiver/awscontainerinsightreceiver/internal/neuron/neuron_empty_metric_decorator.go
+++ b/receiver/awscontainerinsightreceiver/internal/neuron/neuron_empty_metric_decorator.go
@@ -16,6 +16,7 @@ import (
 const (
 	statusType     = "status_type"
 	errorType      = "error_type"
+	eventType      = "event_type"
 	memoryLocation = "memory_location"
 	percentile     = "percentile"
 )
@@ -31,13 +32,15 @@ var attributeConfig = map[string][]string{
 	NeuronCoreMemoryUtilizationSharedScratchpad: {neuronCoreAttributeKey, neuronDeviceAttributeKey},
 	NeuronCoreMemoryUtilizationRuntimeMemory:    {neuronCoreAttributeKey, neuronDeviceAttributeKey},
 	NeuronCoreMemoryUtilizationTensors:          {neuronCoreAttributeKey, neuronDeviceAttributeKey},
+	NeuronDeviceHardwareEccEvents:               {eventType, neuronDeviceAttributeKey},
 }
 
-var nonCoreAttributeValues = map[string]string{
+var defaultAttributeValues = map[string]string{
 	statusType:     "completed",
 	errorType:      "generic",
 	memoryLocation: "neuron_device",
 	percentile:     "p50",
+	eventType:      "mem_ecc_corrected",
 }
 
 // The decorator is used to add metric with zero dataPoint values, if not present
@@ -65,6 +68,7 @@ func (ed *EmptyMetricDecorator) ConsumeMetrics(ctx context.Context, md pmetric.M
 			neuronHardwareInfo, neuronHardwareInfoFound := findNeuronHardwareInfo(metrics)
 			if neuronHardwareInfoFound {
 				ed.addEmptyMetrics(neuronHardwareInfo, metrics)
+				break
 			}
 		}
 	}
@@ -88,9 +92,12 @@ func (ed *EmptyMetricDecorator) addEmptyMetrics(hardwareInfo pmetric.Metric, met
 		if v {
 			continue
 		}
-		if strings.Contains(k, "core") {
-			populateCoreMetrics(metrics, k, hardwareInfo)
-		} else {
+		switch {
+		case strings.Contains(k, "core"):
+			populateCoreMetrics(metrics, k, attributeConfig[k], hardwareInfo)
+		case k == NeuronDeviceHardwareEccEvents:
+			populateDeviceMetrics(metrics, k, attributeConfig[k], hardwareInfo)
+		default:
 			populateNonCoreMetrics(metrics, k, attributeConfig[k], hardwareInfo)
 		}
 	}
@@ -102,14 +109,17 @@ func populateNonCoreMetrics(metrics pmetric.MetricSlice, metricName string, attr
 	metricBody := metricToAdd.Gauge().DataPoints().At(0)
 
 	for _, attribute := range attributesToAdd {
-		metricBody.Attributes().PutStr(attribute, nonCoreAttributeValues[attribute])
+		defaultAttributeValue, defaultValueExists := defaultAttributeValues[attribute]
+		if defaultValueExists {
+			metricBody.Attributes().PutStr(attribute, defaultAttributeValue)
+		}
 	}
 
 	metricToAdd.CopyTo(metrics.AppendEmpty())
 }
 
 // method populates per core metrics, thus empty metrics are added per core
-func populateCoreMetrics(metrics pmetric.MetricSlice, metricName string, hardwareInfo pmetric.Metric) {
+func populateCoreMetrics(metrics pmetric.MetricSlice, metricName string, attributesToAdd []string, hardwareInfo pmetric.Metric) {
 	neuronCoresPerDevice, foundCoresPerDevice := getNeuronCoresPerDevice(hardwareInfo)
 	neuronDeviceCount, foundDeviceCount := getNeuronDeviceCount(hardwareInfo)
 	if !(foundCoresPerDevice && foundDeviceCount) {
@@ -120,11 +130,41 @@ func populateCoreMetrics(metrics pmetric.MetricSlice, metricName string, hardwar
 		metricToAdd := createNewMetricFromHardwareInfo(hardwareInfo, metricName)
 		metricBody := metricToAdd.Gauge().DataPoints().At(0)
 
+		for _, attribute := range attributesToAdd {
+			attributeValue, defaultValueExists := defaultAttributeValues[attribute]
+			if defaultValueExists {
+				metricBody.Attributes().PutStr(attribute, attributeValue)
+			}
+		}
+
 		metricBody.Attributes().PutStr(neuronCoreAttributeKey, strconv.Itoa(coreIndex))
 		metricBody.Attributes().PutStr(neuronDeviceAttributeKey, strconv.Itoa(coreIndex/neuronCoresPerDevice))
 		metricToAdd.CopyTo(metrics.AppendEmpty())
 	}
 
+}
+
+// method populates per device metrics, thus empty metrics are added per device
+func populateDeviceMetrics(metrics pmetric.MetricSlice, metricName string, attributesToAdd []string, hardwareInfo pmetric.Metric) {
+	neuronDeviceCount, foundDeviceCount := getNeuronDeviceCount(hardwareInfo)
+	if !(foundDeviceCount) {
+		return
+	}
+
+	for deviceIndex := 0; deviceIndex < neuronDeviceCount; deviceIndex++ {
+		metricToAdd := createNewMetricFromHardwareInfo(hardwareInfo, metricName)
+		metricBody := metricToAdd.Gauge().DataPoints().At(0)
+
+		for _, attribute := range attributesToAdd {
+			attributeValue, defaultValueExists := defaultAttributeValues[attribute]
+			if defaultValueExists {
+				metricBody.Attributes().PutStr(attribute, attributeValue)
+			}
+		}
+
+		metricBody.Attributes().PutStr(neuronDeviceAttributeKey, strconv.Itoa(deviceIndex))
+		metricToAdd.CopyTo(metrics.AppendEmpty())
+	}
 }
 
 // returns the device count for neuron from the hardwareInfo metric

--- a/receiver/awscontainerinsightreceiver/internal/neuron/neuron_empty_metric_decorator_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/neuron/neuron_empty_metric_decorator_test.go
@@ -279,6 +279,23 @@ func TestConsumeMetricsForNeuronEmptyMetricsDecorator(t *testing.T) {
 						"runtime_tag":                 "default",
 					},
 				},
+
+				{Name: NeuronDeviceHardwareEccEvents, MetricType: pmetric.MetricTypeGauge, DataValue: 0}: {
+					{
+						neuronCorePerDeviceKey:        "2",
+						neuronDeviceCountAttributeKey: "2",
+						neuronDeviceAttributeKey:      "0",
+						eventType:                     "mem_ecc_corrected",
+						"runtime_tag":                 "default",
+					},
+					{
+						neuronCorePerDeviceKey:        "2",
+						neuronDeviceCountAttributeKey: "2",
+						neuronDeviceAttributeKey:      "1",
+						eventType:                     "mem_ecc_corrected",
+						"runtime_tag":                 "default",
+					},
+				},
 			}),
 			ShouldError: false,
 		},
@@ -521,6 +538,23 @@ func TestConsumeMetricsForNeuronEmptyMetricsDecorator(t *testing.T) {
 						neuronDeviceCountAttributeKey: "2",
 						neuronCoreAttributeKey:        "3",
 						neuronDeviceAttributeKey:      "1",
+						"runtime_tag":                 "default",
+					},
+				},
+
+				{Name: NeuronDeviceHardwareEccEvents, MetricType: pmetric.MetricTypeGauge, DataValue: 0}: {
+					{
+						neuronCorePerDeviceKey:        "2",
+						neuronDeviceCountAttributeKey: "2",
+						neuronDeviceAttributeKey:      "0",
+						eventType:                     "mem_ecc_corrected",
+						"runtime_tag":                 "default",
+					},
+					{
+						neuronCorePerDeviceKey:        "2",
+						neuronDeviceCountAttributeKey: "2",
+						neuronDeviceAttributeKey:      "1",
+						eventType:                     "mem_ecc_corrected",
 						"runtime_tag":                 "default",
 					},
 				},

--- a/receiver/awscontainerinsightreceiver/internal/prometheusscraper/decoratorconsumer/decorator_testutils.go
+++ b/receiver/awscontainerinsightreceiver/internal/prometheusscraper/decoratorconsumer/decorator_testutils.go
@@ -27,14 +27,14 @@ type TestCase struct {
 }
 
 func RunDecoratorTestScenarios(ctx context.Context, t *testing.T, dc consumer.Metrics, testcases map[string]TestCase) {
-	for _, tc := range testcases {
+	for testCaseName, tc := range testcases {
 		err := dc.ConsumeMetrics(ctx, tc.Metrics)
 		if tc.ShouldError {
-			assert.Error(t, err)
+			assert.Error(t, err, testCaseName)
 			return
 		}
 		require.NoError(t, err)
-		assert.Equal(t, tc.Want.MetricCount(), tc.Metrics.MetricCount())
+		assert.Equal(t, tc.Want.MetricCount(), tc.Metrics.MetricCount(), testCaseName)
 		if tc.Want.MetricCount() == 0 {
 			continue
 		}
@@ -49,16 +49,16 @@ func RunDecoratorTestScenarios(ctx context.Context, t *testing.T, dc consumer.Me
 		for i := 0; i < wants.Len(); i++ {
 			actual := actuals.At(i)
 			want := wants.At(i)
-			assert.Equal(t, want.Name(), actual.Name())
-			assert.Equal(t, want.Unit(), actual.Unit())
-			assert.Equal(t, getDataValue(&want), getDataValue(&actual))
+			assert.Equal(t, want.Name(), actual.Name(), testCaseName)
+			assert.Equal(t, want.Unit(), actual.Unit(), testCaseName)
+			assert.Equal(t, getDataValue(&want), getDataValue(&actual), testCaseName)
 			actualAttrs := getAttributesFromMetric(&actual)
 			wantAttrs := getAttributesFromMetric(&want)
-			assert.Equal(t, wantAttrs.Len(), actualAttrs.Len())
+			assert.Equal(t, wantAttrs.Len(), actualAttrs.Len(), testCaseName)
 			wantAttrs.Range(func(k string, v pcommon.Value) bool {
 				av, ok := actualAttrs.Get(k)
-				assert.True(t, ok)
-				assert.Equal(t, v, av)
+				assert.True(t, ok, testCaseName)
+				assert.Equal(t, v, av, testCaseName)
 				return true
 			})
 		}


### PR DESCRIPTION
**Description:** 
update empty metric decorator to also add hardware ecc metrics which are per device instead of per core



**Testing:** 

tested in test cluster:
```
{
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName"
                ],
                [
                    "ClusterName",
                    "InstanceId",
                    "NodeName"
                ],
                [
                    "ClusterName",
                    "InstanceId",
                    "NeuronDevice",
                    "NodeName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "node_neurondevice_hw_ecc_events_total",
                    "Unit": "Count"
                }
            ]
        }
    ],
    "ClusterName": "my-trn1-cluster",
    "InstanceId": "i-03bc297e46c221919",
    "InstanceType": "trn1n.32xlarge",
    "NeuronDevice": "device2",
    "NodeName": "ip-192-168-68-42.ec2.internal",
    "OTelLib": "otelcol/prometheusreceiver",
    "Timestamp": "1713889169491",
    "Type": "NodeAWSNeuronDevice",
    "Version": "0",
    "availability_zone": "us-east-1c",
    "http.scheme": "https",
    "k8s.namespace.name": "amazon-cloudwatch",
    "kubernetes": {
        "host": "ip-192-168-68-42.ec2.internal"
    },
    "net.host.name": "neuron-monitor-service.amazon-cloudwatch.svc",
    "net.host.port": "8000",
    "node_neurondevice_hw_ecc_events_mem_ecc_corrected": 0,
    "region": "us-east-1",
    "runtime_tag": "default",
    "service.instance.id": "neuron-monitor-service.amazon-cloudwatch.svc:8000",
    "service.name": "containerInsightsNeuronMonitorScraper",
    "subnet_id": "subnet-06a7754948e8a000f",
    "node_neurondevice_hw_ecc_events_total": 0
}
```