### PR TITLE
fix nil referencing issue in cadvisor during metric decoration

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
@@ -228,6 +228,9 @@ func (c *Cadvisor) GetMetrics() []pmetric.Metrics {
 	}
 
 	for _, cadvisorMetric := range results {
+		if cadvisorMetric == nil {
+			continue
+		}
 		md := ci.ConvertToOTLPMetrics(cadvisorMetric.GetFields(), cadvisorMetric.GetTags(), c.logger)
 		result = append(result, md)
 	}


### PR DESCRIPTION
**Description:**
cadvisor is throwing an error while decorating metrics with k8s stores. The issue caused the agent pods to go into `CrashLoop` by throwing error in the agent logs:
```
goroutine 1076 [running]:
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor.(*Cadvisor).GetMetrics(0xc001a80180)
	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver@v0.89.0/internal/cadvisor/cadvisor_linux.go:231 +0x461
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver.(*awsContainerInsightReceiver).collectData(0xc000b23d40, {0x4c3b158, 0xc000485ef0})
	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver@v0.89.0/receiver.go:351 +0x83
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver.(*awsContainerInsightReceiver).Start.func1()
	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver@v0.89.0/receiver.go:172 +0xe5
created by github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver.(*awsContainerInsightReceiver).Start in goroutine 1
	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver@v0.89.0/receiver.go:158 +0x113f
```

**Testing:** 
Tested on a cluster that was exhibiting the issue. 

**Documentation:** <Describe the documentation added.>