### PR TITLE
adding scrape protocol and ID for prometheus receiver

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_config.go
@@ -38,11 +38,12 @@ func GetScraperConfig(hostInfoProvider hostInfoProvider) *config.ScrapeConfig {
 				InsecureSkipVerify: false,
 			},
 		},
-		ScrapeInterval: model.Duration(collectionInterval),
-		ScrapeTimeout:  model.Duration(collectionInterval),
-		JobName:        jobName,
-		Scheme:         "https",
-		MetricsPath:    scraperMetricsPath,
+		ScrapeInterval:  model.Duration(collectionInterval),
+		ScrapeTimeout:   model.Duration(collectionInterval),
+		ScrapeProtocols: config.DefaultScrapeProtocols,
+		JobName:         jobName,
+		Scheme:          "https",
+		MetricsPath:     scraperMetricsPath,
 		ServiceDiscoveryConfigs: discovery.Configs{
 			&kubernetes.SDConfig{
 				Role: kubernetes.RoleService,

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
@@ -106,6 +106,7 @@ func NewPrometheusScraper(opts PrometheusScraperOpts) (*PrometheusScraper, error
 		},
 		ScrapeInterval:  model.Duration(collectionInterval),
 		ScrapeTimeout:   model.Duration(collectionInterval),
+		ScrapeProtocols: config.DefaultScrapeProtocols,
 		JobName:         fmt.Sprintf("%s/%s", jobName, opts.Endpoint),
 		HonorTimestamps: true,
 		Scheme:          "https",

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
@@ -160,6 +160,7 @@ func NewPrometheusScraper(opts PrometheusScraperOpts) (*PrometheusScraper, error
 	}
 
 	params := receiver.CreateSettings{
+		ID:                component.MustNewID(jobName),
 		TelemetrySettings: opts.TelemetrySettings,
 	}
 

--- a/receiver/awscontainerinsightreceiver/internal/prometheusscraper/simple_prometheus_scraper.go
+++ b/receiver/awscontainerinsightreceiver/internal/prometheusscraper/simple_prometheus_scraper.go
@@ -61,6 +61,7 @@ func NewSimplePrometheusScraper(opts SimplePrometheusScraperOpts) (*SimplePromet
 	}
 
 	params := receiver.CreateSettings{
+		ID:                component.MustNewID(opts.ScraperConfigs.JobName),
 		TelemetrySettings: opts.TelemetrySettings,
 	}
 


### PR DESCRIPTION
**Description:**
- add `scrapeProtocals` config for DCGM prometheus scraper
- add ID to simple prometheus scraper settings

With a recent change to prometheus receiver, we need to pass IDs to create a multiple instances of prometheus receivers within the same process (eg. aws CI receiver).

Related ticket: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32123

**Testing:**
Validated with a test cluster that contains both Tranium and NVIDIA instances

**Documentation:** <Describe the documentation added.>