### PR TITLE
Delete Attribute By Key And Value

### DIFF
--- a/internal/coreinternal/attraction/attraction.go
+++ b/internal/coreinternal/attraction/attraction.go
@@ -218,7 +218,7 @@ func NewAttrProc(settings *Settings) (*AttrProc, error) {
 				action.FromContext = a.FromContext
 			}
 		case HASH, DELETE:
-			if a.Value != nil || a.FromAttribute != "" {
+			if a.FromAttribute != "" {
 				return nil, fmt.Errorf("error creating AttrProc. Action \"%s\" does not use \"value\" or \"from_attribute\" field. These must not be specified for %d-th action", a.Action, i)
 			}
 
@@ -290,6 +290,12 @@ func (ap *AttrProc) Process(ctx context.Context, logger *zap.Logger, attrs pcomm
 		// and could impact performance.
 		switch action.Action {
 		case DELETE:
+			if action.AttributeValue != nil && action.AttributeValue.AsString() != "" {
+				value, contains := attrs.Get(action.Key)
+				if !contains || value.AsString() != action.AttributeValue.AsString() {
+					continue
+				}
+			}
 			attrs.Remove(action.Key)
 
 			for _, k := range getMatchingKeys(action.Regex, attrs) {


### PR DESCRIPTION
**Description:** 
You can only delete an attribute by key or pattern. We need to delete an attribute only if the key has a specific value. 

**Link to tracking Issue:** 
N/A

**Testing:** 
Make the change. Take in cwa. Add a delete with service.name removed when value is unknow_service:java
```
2024/05/14 19:23:26 I! Config has been translated into TOML /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml 
2024/05/14 19:23:26 D! config [agent]
  collection_jitter = "0s"
  debug = true
  flush_interval = "1s"
  flush_jitter = "0s"
  hostname = ""
  interval = "60s"
  logfile = "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log"
  logtarget = "lumberjack"
  metric_batch_size = 1000
  metric_buffer_limit = 10000
  omit_hostname = false
  precision = ""
  quiet = false
  round_interval = false

[outputs]

  [[outputs.cloudwatch]]
2024/05/14 19:23:26 I! Config has been translated into YAML /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.yaml 
2024/05/14 19:23:26 D! config exporters:
    awscloudwatch:
        force_flush_interval: 1m0s
        max_datums_per_call: 1000
        max_values_per_datum: 150
        middleware: agenthealth/metrics
        namespace: JMX
        region: us-west-2
        resource_to_telemetry_conversion:
            enabled: true
extensions:
    agenthealth/metrics:
        is_usage_data_enabled: true
        stats:
            operations:
                - PutMetricData
            usage_flags:
                mode: EC2
                region_type: EC2M
processors:
    filter/jmx/0:
        error_mode: propagate
        logs: {}
        metrics:
            include:
                match_type: regexp
                metric_names:
                    - jvm\..*
        spans: {}
        traces: {}
    resource/jmx:
        attributes:
            - action: delete
              converted_type: ""
              from_attribute: ""
              from_context: ""
              key: ""
              pattern: telemetry.sdk.*
            - action: delete
              converted_type: ""
              from_attribute: ""
              from_context: ""
              key: service.name
              pattern: ""
              value: unknown_service:java
receivers:
    jmx/0:
        collection_interval: 10s
        endpoint: localhost:2020
        jar_path: /opt/aws/amazon-cloudwatch-agent/bin/opentelemetry-jmx-metrics.jar
        otlp:
            endpoint: 0.0.0.0:0
            timeout: 5s
        target_system: jvm
service:
    extensions:
        - agenthealth/metrics
    pipelines:
        metrics/jmx/0:
            exporters:
                - awscloudwatch
            processors:
                - resource/jmx
                - filter/jmx/0
            receivers:
                - jmx/0
    telemetry:
        logs:
            development: false
            disable_caller: false
            disable_stacktrace: false
            encoding: console
            level: debug
            output_paths:
                - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
            sampling:
                enabled: true
                initial: 2
                thereafter: 500
                tick: 10s
        metrics:
            address: ""
            level: None
        traces: {}
```
<img width="1728" alt="Screenshot 2024-05-14 at 3 37 51 PM" src="https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/81644108/0f0aa2bf-1e47-415f-9349-df99eea6879d">

<img width="1728" alt="Screenshot 2024-05-14 at 3 38 07 PM" src="https://github.com/amazon-contributing/opentelemetry-collector-contrib/assets/81644108/cd518c7c-174c-433b-9f05-e9abe52856fa">


**Documentation:** 
N/A