### PR TITLE
Support Latest Released Jar Of JMX metrics gatherer

### DIFF
--- a/receiver/jmxreceiver/supported_jars.go
+++ b/receiver/jmxreceiver/supported_jars.go
@@ -31,8 +31,12 @@ func oldFormatProperties(c *Config, j supportedJar) error {
 // If you change this variable name, please open an issue in opentelemetry-java-contrib
 // so that repository's release automation can be updated
 var jmxMetricsGathererVersions = map[string]supportedJar{
-	"e2b30287e82f5b4c929e14b9411939cf86db4190f2484aca3974830ca9b8607d": {
+	"60b2ee1a798c35d10f6e3602ea46f1b1c0298080262636d73b4fc652b7dcd0da": {
 		version: "1.35.0-alpha",
+		jar:     "JMX metrics gatherer",
+	},
+	"a939251bbdb91ede2b5fbe891fd50775dd21f41c3369b5abec7dd74e4bf1a9fd": {
+		version: "1.34.0-alpha",
 		jar:     "JMX metrics gatherer",
 	},
 	"50ad8ed45fa17bc6edafe4649008d1f0b57181d3162e64c76d6da9a49272db33": {


### PR DESCRIPTION
**Description:** 
Take latest release version of JMX gather jar hash as valid

**Link to tracking Issue:** 
N/A

**Testing:** 
N/A

**Documentation:** 
N/A