### PR TITLE
allow multiple log group names/arns to be set in environmental variables for xray exporter

### DIFF
--- a/exporter/awsxrayexporter/README.md
+++ b/exporter/awsxrayexporter/README.md
@@ -91,8 +91,11 @@ following values that are evaluated in this order:
 In the case of multiple values are defined, the value with higher precedence will be used to set the `cloudwatch_logs` AWS Property.
 
 `aws.log.group.arns` and `aws.log.group.names` are slice resource attributes that can be set programmatically.
-Alternatively those resource attributes can be set using the [`OTEL_RESOURCE_ATTRIBUTES` environment variable](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable). In this case only a single log group/log group arn can
-be provided as a string rather than a slice.
+Alternatively those resource attributes can be set using the [`OTEL_RESOURCE_ATTRIBUTES` environment variable](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable). To set multiple log group names /log group arns, you can use `&`
+to separate them. For example, 3 log groups `log-group1`, `log-group2`, and `log-group3` are set in the following command:
+```
+export OTEL_RESOURCE_ATTRIBUTES="aws.log.group.names=log-group1&log-group2&log-group3"
+```
 
 ## AWS Credential Configuration
 

--- a/exporter/awsxrayexporter/internal/translator/aws.go
+++ b/exporter/awsxrayexporter/internal/translator/aws.go
@@ -272,16 +272,35 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 	return filtered, awsData
 }
 
+func getLogGroupNamesOrArns(logGroupNamesOrArns string) []string {
+	// Split the input string by '&'
+	items := strings.Split(logGroupNamesOrArns, "&")
+
+	// Filter out empty strings
+	var result []string
+	for _, item := range items {
+		if item != "" {
+			result = append(result, item)
+		}
+	}
+
+	return result
+}
+
 // Normalize value to slice.
-// 1. String values are converted to a slice of size 1 so that we can also handle resource
+// 1. String values are converted to a slice so that we can also handle resource
 // attributes that are set using the OTEL_RESOURCE_ATTRIBUTES
+// (multiple log group names or arns are separate by & like this "log-group1&log-group2&log-group3")
 // 2. Slices are kept as they are
 // 3. Other types will result in a empty slice so that we avoid panic.
 func normalizeToSlice(v pcommon.Value) pcommon.Slice {
 	switch v.Type() {
 	case pcommon.ValueTypeStr:
 		s := pcommon.NewSlice()
-		s.AppendEmpty().SetStr(v.Str())
+		logGroupNamesOrArns := getLogGroupNamesOrArns(v.Str())
+		for _, logGroupOrArn := range logGroupNamesOrArns {
+			s.AppendEmpty().SetStr(logGroupOrArn)
+		}
 		return s
 	case pcommon.ValueTypeSlice:
 		return v.Slice()

--- a/exporter/awsxrayexporter/internal/translator/aws_test.go
+++ b/exporter/awsxrayexporter/internal/translator/aws_test.go
@@ -475,6 +475,61 @@ func TestLogGroupsFromStringResourceAttribute(t *testing.T) {
 	assert.Contains(t, awsData.CWLogs, cwl1)
 }
 
+func TestLogGroupsWithAmpersandFromStringResourceAttribute(t *testing.T) {
+	cwl1 := awsxray.LogGroupMetadata{
+		LogGroup: awsxray.String("group1"),
+	}
+	cwl2 := awsxray.LogGroupMetadata{
+		LogGroup: awsxray.String("group2"),
+	}
+
+	attributes := make(map[string]pcommon.Value)
+	resource := pcommon.NewResource()
+
+	// normal cases
+	resource.Attributes().PutStr(conventions.AttributeAWSLogGroupNames, "group1&group2")
+	filtered, awsData := makeAws(attributes, resource, nil)
+	assert.NotNil(t, filtered)
+	assert.NotNil(t, awsData)
+	assert.Equal(t, 2, len(awsData.CWLogs))
+	assert.Contains(t, awsData.CWLogs, cwl1)
+	assert.Contains(t, awsData.CWLogs, cwl2)
+
+	// with extra & at end
+	resource.Attributes().PutStr(conventions.AttributeAWSLogGroupNames, "group1&group2&")
+	filtered, awsData = makeAws(attributes, resource, nil)
+	assert.NotNil(t, filtered)
+	assert.NotNil(t, awsData)
+	assert.Equal(t, 2, len(awsData.CWLogs))
+	assert.Contains(t, awsData.CWLogs, cwl1)
+	assert.Contains(t, awsData.CWLogs, cwl2)
+
+	// with extra & in the middle
+	resource.Attributes().PutStr(conventions.AttributeAWSLogGroupNames, "group1&&group2")
+	filtered, awsData = makeAws(attributes, resource, nil)
+	assert.NotNil(t, filtered)
+	assert.NotNil(t, awsData)
+	assert.Equal(t, 2, len(awsData.CWLogs))
+	assert.Contains(t, awsData.CWLogs, cwl1)
+	assert.Contains(t, awsData.CWLogs, cwl2)
+
+	// with extra & at the beginning
+	resource.Attributes().PutStr(conventions.AttributeAWSLogGroupNames, "&group1&group2")
+	filtered, awsData = makeAws(attributes, resource, nil)
+	assert.NotNil(t, filtered)
+	assert.NotNil(t, awsData)
+	assert.Equal(t, 2, len(awsData.CWLogs))
+	assert.Contains(t, awsData.CWLogs, cwl1)
+	assert.Contains(t, awsData.CWLogs, cwl2)
+
+	// with only &
+	resource.Attributes().PutStr(conventions.AttributeAWSLogGroupNames, "&")
+	filtered, awsData = makeAws(attributes, resource, nil)
+	assert.NotNil(t, filtered)
+	assert.NotNil(t, awsData)
+	assert.Equal(t, 0, len(awsData.CWLogs))
+}
+
 func TestLogGroupsInvalidType(t *testing.T) {
 	attributes := make(map[string]pcommon.Value)
 	resource := pcommon.NewResource()
@@ -506,6 +561,32 @@ func TestLogGroupsArnsFromStringResourceAttributes(t *testing.T) {
 	assert.NotNil(t, awsData)
 	assert.Equal(t, 1, len(awsData.CWLogs))
 	assert.Contains(t, awsData.CWLogs, cwl1)
+}
+
+func TestLogGroupsArnsWithAmpersandFromStringResourceAttributes(t *testing.T) {
+	group1 := "arn:aws:logs:us-east-1:123456789123:log-group:group1"
+	group2 := "arn:aws:logs:us-east-1:123456789123:log-group:group2"
+
+	cwl1 := awsxray.LogGroupMetadata{
+		LogGroup: awsxray.String("group1"),
+		Arn:      awsxray.String(group1),
+	}
+	cwl2 := awsxray.LogGroupMetadata{
+		LogGroup: awsxray.String("group2"),
+		Arn:      awsxray.String(group2),
+	}
+
+	attributes := make(map[string]pcommon.Value)
+	resource := pcommon.NewResource()
+	resource.Attributes().PutStr(conventions.AttributeAWSLogGroupARNs, "arn:aws:logs:us-east-1:123456789123:log-group:group1&arn:aws:logs:us-east-1:123456789123:log-group:group2")
+
+	filtered, awsData := makeAws(attributes, resource, nil)
+
+	assert.NotNil(t, filtered)
+	assert.NotNil(t, awsData)
+	assert.Equal(t, 2, len(awsData.CWLogs))
+	assert.Contains(t, awsData.CWLogs, cwl1)
+	assert.Contains(t, awsData.CWLogs, cwl2)
 }
 
 func TestLogGroupsFromConfig(t *testing.T) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

This commit is to allow users to set multiple log group names or arns using environmental variable. We choose to use `&` to separate individual log group name or arn because `&` is not allowed in log group names (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogGroup.html) and `&` implicitly means 'AND'. 

**Link to tracking Issue:** <Issue number if applicable>
N/A

**Testing:** <Describe what testing was performed and which tests were added.>

Unit tests.

Manual end 2 end test confirmed that we get 2 log groups in the raw trace with the change. Note the `cloudwatch_logs` field below:

```
{
    "Id": "1-667339a9-c872ab16dbc29a0c11b60c8d",
    "Duration": 0.001,
    "LimitExceeded": false,
    "Segments": [
        {
            "Id": "c1e85cd075339ff9",
            "Document": {
                "id": "c1e85cd075339ff9",
                "name": "vets-service-ec2-java",
                "start_time": 1718827433.377284,
                "trace_id": "1-667339a9-c872ab16dbc29a0c11b60c8d",
                "end_time": 1718827433.3779771,
                "fault": false,
                "error": false,
                "throttle": false,
                "http": {
                    "request": {
                        "url": "http://172.31.47.118:36131/actuator/health",
                        "method": "GET",
                        "user_agent": "ReactorNetty/1.0.18"
                    },
                    "response": {
                        "status": 200,
                        "content_length": 0
                    }
                },
                "aws": {
                    "account_id": "868155213681",
                    "ec2": {
                        "availability_zone": "us-east-1b",
                        "instance_id": "i-0f496fe9393def8f7",
                        "instance_size": "t3.medium",
                        "ami_id": "ami-03934437c323e0de2"
                    },
                    "xray": {
                        "auto_instrumentation": true,
                        "sdk_version": "1.34.1",
                        "sdk": "opentelemetry for java"
                    },
                    "cloudwatch_logs": [
                        {
                            "log_group": "/aws/application-signals/data"
                        },
                        {
                            "log_group": "/aws/appsignals/generic"
                        }
                    ]
                },
                "annotations": {
                    "aws.local.service": "vets-service-ec2-java",
                    "aws.local.operation": "GET /actuator/health",
                    "aws.local.environment": "ec2:default"
                },
                "metadata": {
                    "default": {
                        "net.sock.peer.addr": "172.31.39.3",
                        "otel.resource.process.command_args": [
                            "/usr/lib/jvm/java-17-amazon-corretto.x86_64/bin/java",
                            "-jar",
                            "spring-petclinic-vets-service-2.6.7.jar"
                        ],
                        "otel.resource.host.arch": "amd64",
                        "otel.resource.host.name": "ip-172-31-47-118.ec2.internal",
                        "otel.resource.aws.log.group.names": "/aws/application-signals/data&/aws/appsignals/generic",
                        "thread.name": "http-nio-auto-1-exec-4",
                        "otel.resource.service.name": "vets-service-ec2-java",
                        "otel.resource.telemetry.auto.version": "1.32.2-aws",
                        "aws.span.kind": "LOCAL_ROOT",
                        "net.sock.host.addr": "172.31.47.118",
                        "otel.resource.process.pid": 472258,
                        "otel.resource.os.description": "Linux 6.1.91-99.172.amzn2023.x86_64",
                        "net.protocol.name": "http",
                        "otel.resource.cloud.platform": "aws_ec2",
                        "otel.resource.os.type": "linux",
                        "net.sock.peer.port": 51588,
                        "otel.resource.cloud.region": "us-east-1",
                        "otel.resource.host.type": "t3.medium",
                        "thread.id": 43,
                        "otel.resource.telemetry.sdk.name": "opentelemetry",
                        "otel.resource.service.version": "2.6.7",
                        "otel.resource.cloud.availability_zone": "us-east-1b",
                        "otel.resource.host.image.id": "ami-03934437c323e0de2",
                        "otel.resource.process.runtime.description": "Amazon.com Inc. OpenJDK 64-Bit Server VM 17.0.11+9-LTS",
                        "otel.resource.process.runtime.version": "17.0.11+9-LTS",
                        "Host": "ip-172-31-47-118.ec2.internal",
                        "otel.resource.host.id": "i-0f496fe9393def8f7",
                        "otel.resource.cloud.account.id": "868155213681",
                        "otel.resource.process.executable.path": "/usr/lib/jvm/java-17-amazon-corretto.x86_64/bin/java",
                        "otel.resource.telemetry.sdk.version": "1.34.1",
                        "http.route": "/actuator/health",
                        "EC2.InstanceId": "i-0f496fe9393def8f7",
                        "PlatformType": "AWS::EC2",
                        "otel.resource.process.runtime.name": "OpenJDK Runtime Environment",
                        "otel.resource.telemetry.sdk.language": "java",
                        "otel.resource.cloud.provider": "aws",
                        "net.protocol.version": "1.1",
                        "net.sock.host.port": 36131
                    }
                },
                "service": {
                    "version": "2.6.7"
                },
                "origin": "AWS::EC2::Instance",
                "subsegments": [
                    {
                        "id": "51aaeb8354a93a73",
                        "name": "OperationHandler.handle",
                        "start_time": 1718827433.3773975,
                        "end_time": 1718827433.3779185,
                        "fault": false,
                        "error": false,
                        "throttle": false,
                        "aws": {
                            "account_id": "868155213681",
                            "ec2": {
                                "availability_zone": "us-east-1b",
                                "instance_id": "i-0f496fe9393def8f7",
                                "instance_size": "t3.medium",
                                "ami_id": "ami-03934437c323e0de2"
                            },
                            "xray": {
                                "auto_instrumentation": true,
                                "sdk_version": "1.34.1",
                                "sdk": "opentelemetry for java"
                            },
                            "cloudwatch_logs": [
                                {
                                    "log_group": "/aws/application-signals/data"
                                },
                                {
                                    "log_group": "/aws/appsignals/generic"
                                }
                            ]
                        },
                        "annotations": {
                            "aws.local.operation": "GET /actuator/health",
                            "aws.local.environment": "ec2:default"
                        },
                        "metadata": {
                            "default": {
                                "EC2.InstanceId": "i-0f496fe9393def8f7",
                                "Host": "ip-172-31-47-118.ec2.internal",
                                "PlatformType": "AWS::EC2",
                                "thread.name": "http-nio-auto-1-exec-4",
                                "thread.id": 43
                            }
                        }
                    }
                ]
            }
        }
    ]
}
```


**Documentation:** <Describe the documentation added.>
An example in the readme for xray exporter