### PR TITLE
Add hash for OTEL JMX Gatherer JAR with Tomcat metrics fix

### DIFF
--- a/receiver/jmxreceiver/supported_jars.go
+++ b/receiver/jmxreceiver/supported_jars.go
@@ -31,6 +31,11 @@ func oldFormatProperties(c *Config, j supportedJar) error {
 // If you change this variable name, please open an issue in opentelemetry-java-contrib
 // so that repository's release automation can be updated
 var jmxMetricsGathererVersions = map[string]supportedJar{
+	// Remove once https://github.com/open-telemetry/opentelemetry-java-contrib/pull/1366 has been merged and released.
+	"14f28b1c45e6ad91faa7f25462bfd96e6ab3b6980afe5534f92b8a4973895cbb": {
+		version: "1.37.0-fix",
+		jar:     "JMX metrics gatherer w/ Tomcat metrics fix",
+	},
 	"60b2ee1a798c35d10f6e3602ea46f1b1c0298080262636d73b4fc652b7dcd0da": {
 		version: "1.35.0-alpha",
 		jar:     "JMX metrics gatherer",


### PR DESCRIPTION
**Description:** Updates the set of supported OTEL JMX Gatherer versions to include a build until the fix has been accepted and released by OTEL.

**Testing:** See https://github.com/aws/amazon-cloudwatch-agent/pull/1240 for testing.