### PR TITLE
Move GPU metrics for request, limit, usage & reserved_capacity into pod store

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -141,9 +141,10 @@ const (
 	EfaRxDropped          = "rx_dropped"
 	EfaTxBytes            = "tx_bytes"
 
-	GpuLimit   = "gpu_limit"
-	GpuTotal   = "gpu_total"
-	GpuRequest = "gpu_request"
+	GpuLimit            = "gpu_limit"
+	GpuUsageTotal       = "gpu_usage_total"
+	GpuRequest          = "gpu_request"
+	GpuReservedCapacity = "gpu_reserved_capacity"
 
 	// Define the metric types
 	TypeCluster            = "Cluster"
@@ -325,8 +326,9 @@ func init() {
 		EfaRxDropped:          UnitCountPerSec,
 		EfaTxBytes:            UnitBytesPerSec,
 
-		GpuLimit:   UnitCount,
-		GpuTotal:   UnitCount,
-		GpuRequest: UnitCount,
+		GpuLimit:            UnitCount,
+		GpuUsageTotal:       UnitCount,
+		GpuRequest:          UnitCount,
+		GpuReservedCapacity: UnitPercent,
 	}
 }

--- a/internal/aws/containerinsight/utils_test.go
+++ b/internal/aws/containerinsight/utils_test.go
@@ -431,6 +431,10 @@ func TestConvertToOTLPMetricsForNodeMetrics(t *testing.T) {
 		"node_network_tx_packets":             37.802748111760124,
 		"node_number_of_running_containers":   int32(7),
 		"node_number_of_running_pods":         int64(7),
+		"node_gpu_request":                    int32(7),
+		"node_gpu_limit":                      int32(7),
+		"node_gpu_usage_total":                int32(7),
+		"node_gpu_reserved_capacity":          3.0093851356081194,
 	}
 	expectedUnits = map[string]string{
 		"node_cpu_limit":                      "",
@@ -467,6 +471,10 @@ func TestConvertToOTLPMetricsForNodeMetrics(t *testing.T) {
 		"node_network_tx_packets":             UnitCountPerSec,
 		"node_number_of_running_containers":   UnitCount,
 		"node_number_of_running_pods":         UnitCount,
+		"node_gpu_request":                    UnitCount,
+		"node_gpu_limit":                      UnitCount,
+		"node_gpu_usage_total":                UnitCount,
+		"node_gpu_reserved_capacity":          UnitPercent,
 	}
 	tags = map[string]string{
 		"AutoScalingGroupName": "eks-a6bb9db9-267c-401c-db55-df8ef645b06f",
@@ -716,6 +724,10 @@ func TestConvertToOTLPMetricsForPodMetrics(t *testing.T) {
 		"pod_status_unknown":                    0,
 		"pod_status_ready":                      1,
 		"pod_status_scheduled":                  1,
+		"pod_gpu_request":                       1,
+		"pod_gpu_limit":                         1,
+		"pod_gpu_usage_total":                   1,
+		"pod_gpu_reserved_capacity":             2.3677681271483983,
 	}
 	expectedUnits = map[string]string{
 		"pod_cpu_limit":                         "",
@@ -762,6 +774,10 @@ func TestConvertToOTLPMetricsForPodMetrics(t *testing.T) {
 		"pod_status_unknown":                    UnitCount,
 		"pod_status_ready":                      UnitCount,
 		"pod_status_scheduled":                  UnitCount,
+		"pod_gpu_request":                       UnitCount,
+		"pod_gpu_limit":                         UnitCount,
+		"pod_gpu_usage_total":                   UnitCount,
+		"pod_gpu_reserved_capacity":             UnitPercent,
 	}
 	tags = map[string]string{
 		"ClusterName":  "eks-aoc",
@@ -907,40 +923,6 @@ func TestConvertToOTLPMetricsForPodEfaMetrics(t *testing.T) {
 		"PodName":       "cloudwatch-agent",
 		"ContainerName": "cloudwatch-agent",
 		"Type":          "PodEFA",
-		"Version":       "0",
-		"Timestamp":     timestamp,
-	}
-	md = ConvertToOTLPMetrics(fields, tags, zap.NewNop())
-	checkMetricsAreExpected(t, md, fields, tags, expectedUnits)
-}
-
-func TestConvertToOTLPMetricsForAcceleratorCountMetrics(t *testing.T) {
-	var fields map[string]any
-	var expectedUnits map[string]string
-	var tags map[string]string
-	var md pmetric.Metrics
-	now := time.Now()
-	timestamp := strconv.FormatInt(now.UnixNano(), 10)
-
-	fields = map[string]any{
-		"pod_gpu_limit":   int64(3),
-		"pod_gpu_total":   int64(3),
-		"pod_gpu_request": int64(3),
-	}
-	expectedUnits = map[string]string{
-		"pod_gpu_limit":   UnitCount,
-		"pod_gpu_total":   UnitCount,
-		"pod_gpu_request": UnitCount,
-	}
-	tags = map[string]string{
-		"ClusterName":   "eks-aoc",
-		"InstanceId":    "i-01bf9fb097cbf3205",
-		"InstanceType":  "t2.xlarge",
-		"Namespace":     "amazon-cloudwatch",
-		"NodeName":      "ip-192-168-12-170.ec2.internal",
-		"PodName":       "cloudwatch-agent",
-		"ContainerName": "cloudwatch-agent",
-		"Type":          "PodGPU",
 		"Version":       "0",
 		"Timestamp":     timestamp,
 	}

--- a/internal/aws/k8s/k8sclient/node.go
+++ b/internal/aws/k8s/k8sclient/node.go
@@ -18,11 +18,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-const (
-	instanceTypeLabelKey     = "node.kubernetes.io/instance-type"
-	instanceTypeLabelKeyBeta = "beta.kubernetes.io/instance-type"
-)
-
 // This needs to be reviewed for newer versions of k8s.
 var failedNodeConditions = map[v1.NodeConditionType]bool{
 	v1.NodeMemoryPressure:     true,
@@ -32,7 +27,6 @@ var failedNodeConditions = map[v1.NodeConditionType]bool{
 }
 
 type NodeClient interface {
-	NodeInfos() map[string]*NodeInfo
 	// Get the number of failed nodes for current cluster
 	ClusterFailedNodeCount() int
 	// Get the number of nodes for current cluster
@@ -78,21 +72,11 @@ type nodeClient struct {
 	captureNodeLevelInfo bool
 
 	mu                     sync.RWMutex
-	nodeInfos              map[string]*NodeInfo
 	clusterFailedNodeCount int
 	clusterNodeCount       int
 	nodeToCapacityMap      map[string]v1.ResourceList
 	nodeToAllocatableMap   map[string]v1.ResourceList
 	nodeToConditionsMap    map[string]map[v1.NodeConditionType]v1.ConditionStatus
-}
-
-func (c *nodeClient) NodeInfos() map[string]*NodeInfo {
-	if c.store.GetResetRefreshStatus() {
-		c.refresh()
-	}
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.nodeInfos
 }
 
 func (c *nodeClient) ClusterFailedNodeCount() int {
@@ -161,26 +145,24 @@ func (c *nodeClient) refresh() {
 	nodeToAllocatableMap := make(map[string]v1.ResourceList)
 	nodeToConditionsMap := make(map[string]map[v1.NodeConditionType]v1.ConditionStatus)
 
-	nodeInfos := map[string]*NodeInfo{}
 	for _, obj := range objsList {
-		node := obj.(*NodeInfo)
-		nodeInfos[node.Name] = node
+		node := obj.(*nodeInfo)
 
 		if c.captureNodeLevelInfo {
-			nodeToCapacityMap[node.Name] = node.Capacity
-			nodeToAllocatableMap[node.Name] = node.Allocatable
+			nodeToCapacityMap[node.name] = node.capacity
+			nodeToAllocatableMap[node.name] = node.allocatable
 			conditionsMap := make(map[v1.NodeConditionType]v1.ConditionStatus)
-			for _, condition := range node.Conditions {
+			for _, condition := range node.conditions {
 				conditionsMap[condition.Type] = condition.Status
 			}
-			nodeToConditionsMap[node.Name] = conditionsMap
+			nodeToConditionsMap[node.name] = conditionsMap
 		}
 		clusterNodeCountNew++
 
 		failed := false
 
 	Loop:
-		for _, condition := range node.Conditions {
+		for _, condition := range node.conditions {
 			if _, ok := failedNodeConditions[condition.Type]; ok {
 				// match the failedNodeConditions type we care about
 				if condition.Status != v1.ConditionFalse {
@@ -196,7 +178,6 @@ func (c *nodeClient) refresh() {
 		}
 	}
 
-	c.nodeInfos = nodeInfos
 	c.clusterFailedNodeCount = clusterFailedNodeCountNew
 	c.clusterNodeCount = clusterNodeCountNew
 	c.nodeToCapacityMap = nodeToCapacityMap
@@ -241,23 +222,13 @@ func transformFuncNode(obj any) (any, error) {
 	if !ok {
 		return nil, fmt.Errorf("input obj %v is not Node type", obj)
 	}
-	info := new(NodeInfo)
-	info.Name = node.Name
-	info.Capacity = node.Status.Capacity
-	info.Allocatable = node.Status.Allocatable
-	info.Conditions = []*NodeCondition{}
-	info.ProviderID = node.Spec.ProviderID
-	if instanceType, ok := node.Labels[instanceTypeLabelKey]; ok {
-		info.InstanceType = instanceType
-	} else {
-		// fallback for compatibility with k8s versions older than v1.17
-		// https://kubernetes.io/docs/reference/labels-annotations-taints/#beta-kubernetes-io-instance-type-deprecated
-		if instanceType, ok := node.Labels[instanceTypeLabelKeyBeta]; ok {
-			info.InstanceType = instanceType
-		}
-	}
+	info := new(nodeInfo)
+	info.name = node.Name
+	info.capacity = node.Status.Capacity
+	info.allocatable = node.Status.Allocatable
+	info.conditions = []*NodeCondition{}
 	for _, condition := range node.Status.Conditions {
-		info.Conditions = append(info.Conditions, &NodeCondition{
+		info.conditions = append(info.conditions, &NodeCondition{
 			Type:   condition.Type,
 			Status: condition.Status,
 		})

--- a/internal/aws/k8s/k8sclient/node_info.go
+++ b/internal/aws/k8s/k8sclient/node_info.go
@@ -7,13 +7,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-type NodeInfo struct {
-	Name         string
-	Conditions   []*NodeCondition
-	Capacity     v1.ResourceList
-	Allocatable  v1.ResourceList
-	ProviderID   string
-	InstanceType string
+type nodeInfo struct {
+	name        string
+	conditions  []*NodeCondition
+	capacity    v1.ResourceList
+	allocatable v1.ResourceList
 }
 
 type NodeCondition struct {

--- a/internal/aws/k8s/k8sclient/node_test.go
+++ b/internal/aws/k8s/k8sclient/node_test.go
@@ -36,7 +36,6 @@ var nodeArray = []any{
 				"failure-domain.beta.kubernetes.io/region": "eu-west-1",
 				"failure-domain.beta.kubernetes.io/zone":   "eu-west-1c",
 				"kubernetes.io/hostname":                   "ip-192-168-200-63.eu-west-1.compute.internal",
-				"node.kubernetes.io/instance-type":         "t3.medium",
 			},
 			Annotations: map[string]string{
 				"node.alpha.kubernetes.io/ttl":                           "0",
@@ -112,9 +111,6 @@ var nodeArray = []any{
 				OperatingSystem:         "linux",
 				Architecture:            "amd64",
 			},
-		},
-		Spec: v1.NodeSpec{
-			ProviderID: "aws:///eu-west-1c/i-09087f37a14b9ded1",
 		},
 	},
 	&v1.Node{
@@ -213,9 +209,6 @@ var nodeArray = []any{
 				Architecture:            "amd64",
 			},
 		},
-		Spec: v1.NodeSpec{
-			ProviderID: "aws:///eu-west-1a/i-09087f37a14b9ded2",
-		},
 	},
 	&v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -312,9 +305,6 @@ var nodeArray = []any{
 				Architecture:            "amd64",
 			},
 		},
-		Spec: v1.NodeSpec{
-			ProviderID: "aws:///eu-west-1b/i-09087f37a14b9ded3",
-		},
 	},
 }
 
@@ -333,95 +323,6 @@ func TestNodeClient(t *testing.T) {
 				"nodeToCapacityMap":      map[string]v1.ResourceList{},                             // Node level info is not captured by default
 				"nodeToAllocatableMap":   map[string]v1.ResourceList{},                             // Node level info is not captured by default
 				"nodeToConditionsMap":    map[string]map[v1.NodeConditionType]v1.ConditionStatus{}, // Node level info is not captured by default
-				"nodeInfos": map[string]*NodeInfo{
-					"ip-192-168-200-63.eu-west-1.compute.internal": {
-						Name: "ip-192-168-200-63.eu-west-1.compute.internal",
-						Conditions: []*NodeCondition{
-							{
-								Type:   v1.NodeConditionType("MemoryPressure"),
-								Status: v1.ConditionFalse,
-							},
-							{
-								Type:   v1.NodeConditionType("DiskPressure"),
-								Status: v1.ConditionFalse,
-							},
-							{
-								Type:   v1.NodeConditionType("PIDPressure"),
-								Status: v1.ConditionFalse,
-							},
-							{
-								Type:   v1.NodeConditionType("Ready"),
-								Status: v1.ConditionTrue,
-							},
-						},
-						Allocatable: v1.ResourceList{
-							v1.ResourcePods: *resource.NewQuantity(5, resource.DecimalSI),
-						},
-						Capacity: v1.ResourceList{
-							v1.ResourcePods: *resource.NewQuantity(5, resource.DecimalSI),
-						},
-						ProviderID:   "aws:///eu-west-1c/i-09087f37a14b9ded1",
-						InstanceType: "t3.medium",
-					},
-					"ip-192-168-76-61.eu-west-1.compute.internal": {
-						Name: "ip-192-168-76-61.eu-west-1.compute.internal",
-						Conditions: []*NodeCondition{
-							{
-								Type:   v1.NodeConditionType("MemoryPressure"),
-								Status: v1.ConditionFalse,
-							},
-							{
-								Type:   v1.NodeConditionType("DiskPressure"),
-								Status: v1.ConditionFalse,
-							},
-							{
-								Type:   v1.NodeConditionType("PIDPressure"),
-								Status: v1.ConditionFalse,
-							},
-							{
-								Type:   v1.NodeConditionType("Ready"),
-								Status: v1.ConditionTrue,
-							},
-						},
-						Allocatable: v1.ResourceList{
-							v1.ResourcePods: *resource.NewQuantity(10, resource.DecimalSI),
-						},
-						Capacity: v1.ResourceList{
-							v1.ResourcePods: *resource.NewQuantity(10, resource.DecimalSI),
-						},
-						ProviderID:   "aws:///eu-west-1a/i-09087f37a14b9ded2",
-						InstanceType: "t3.medium",
-					},
-					"ip-192-168-153-1.eu-west-1.compute.internal": {
-						Name: "ip-192-168-153-1.eu-west-1.compute.internal",
-						Conditions: []*NodeCondition{
-							{
-								Type:   v1.NodeConditionType("MemoryPressure"),
-								Status: v1.ConditionFalse,
-							},
-							{
-								Type:   v1.NodeConditionType("DiskPressure"),
-								Status: v1.ConditionTrue,
-							},
-							{
-								Type:   v1.NodeConditionType("PIDPressure"),
-								Status: v1.ConditionFalse,
-							},
-							{
-								Type:   v1.NodeConditionType("Ready"),
-								Status: v1.ConditionFalse,
-							},
-						},
-						Allocatable: v1.ResourceList{
-							v1.ResourcePods: *resource.NewQuantity(1, resource.DecimalSI),
-						},
-						Capacity: v1.ResourceList{
-							v1.ResourcePods: *resource.NewQuantity(5, resource.DecimalSI),
-						},
-						ProviderID:   "aws:///eu-west-1b/i-09087f37a14b9ded3",
-						InstanceType: "t3.medium",
-					},
-				},
 			},
 		},
 		"CaptureNodeLevelInfo": {
@@ -474,95 +375,6 @@ func TestNodeClient(t *testing.T) {
 						"Ready":          "False",
 					},
 				},
-				"nodeInfos": map[string]*NodeInfo{
-					"ip-192-168-200-63.eu-west-1.compute.internal": {
-						Name: "ip-192-168-200-63.eu-west-1.compute.internal",
-						Conditions: []*NodeCondition{
-							{
-								Type:   v1.NodeConditionType("MemoryPressure"),
-								Status: v1.ConditionFalse,
-							},
-							{
-								Type:   v1.NodeConditionType("DiskPressure"),
-								Status: v1.ConditionFalse,
-							},
-							{
-								Type:   v1.NodeConditionType("PIDPressure"),
-								Status: v1.ConditionFalse,
-							},
-							{
-								Type:   v1.NodeConditionType("Ready"),
-								Status: v1.ConditionTrue,
-							},
-						},
-						Allocatable: v1.ResourceList{
-							v1.ResourcePods: *resource.NewQuantity(5, resource.DecimalSI),
-						},
-						Capacity: v1.ResourceList{
-							v1.ResourcePods: *resource.NewQuantity(5, resource.DecimalSI),
-						},
-						ProviderID:   "aws:///eu-west-1c/i-09087f37a14b9ded1",
-						InstanceType: "t3.medium",
-					},
-					"ip-192-168-76-61.eu-west-1.compute.internal": {
-						Name: "ip-192-168-76-61.eu-west-1.compute.internal",
-						Conditions: []*NodeCondition{
-							{
-								Type:   v1.NodeConditionType("MemoryPressure"),
-								Status: v1.ConditionFalse,
-							},
-							{
-								Type:   v1.NodeConditionType("DiskPressure"),
-								Status: v1.ConditionFalse,
-							},
-							{
-								Type:   v1.NodeConditionType("PIDPressure"),
-								Status: v1.ConditionFalse,
-							},
-							{
-								Type:   v1.NodeConditionType("Ready"),
-								Status: v1.ConditionTrue,
-							},
-						},
-						Allocatable: v1.ResourceList{
-							v1.ResourcePods: *resource.NewQuantity(10, resource.DecimalSI),
-						},
-						Capacity: v1.ResourceList{
-							v1.ResourcePods: *resource.NewQuantity(10, resource.DecimalSI),
-						},
-						ProviderID:   "aws:///eu-west-1a/i-09087f37a14b9ded2",
-						InstanceType: "t3.medium",
-					},
-					"ip-192-168-153-1.eu-west-1.compute.internal": {
-						Name: "ip-192-168-153-1.eu-west-1.compute.internal",
-						Conditions: []*NodeCondition{
-							{
-								Type:   v1.NodeConditionType("MemoryPressure"),
-								Status: v1.ConditionFalse,
-							},
-							{
-								Type:   v1.NodeConditionType("DiskPressure"),
-								Status: v1.ConditionTrue,
-							},
-							{
-								Type:   v1.NodeConditionType("PIDPressure"),
-								Status: v1.ConditionFalse,
-							},
-							{
-								Type:   v1.NodeConditionType("Ready"),
-								Status: v1.ConditionFalse,
-							},
-						},
-						Allocatable: v1.ResourceList{
-							v1.ResourcePods: *resource.NewQuantity(1, resource.DecimalSI),
-						},
-						Capacity: v1.ResourceList{
-							v1.ResourcePods: *resource.NewQuantity(5, resource.DecimalSI),
-						},
-						ProviderID:   "aws:///eu-west-1b/i-09087f37a14b9ded3",
-						InstanceType: "t3.medium",
-					},
-				},
 			},
 		},
 	}
@@ -577,7 +389,6 @@ func TestNodeClient(t *testing.T) {
 			require.Equal(t, testCase.want["nodeToCapacityMap"], client.NodeToCapacityMap())
 			require.Equal(t, testCase.want["nodeToAllocatableMap"], client.NodeToAllocatableMap())
 			require.Equal(t, testCase.want["nodeToConditionsMap"], client.NodeToConditionsMap())
-			require.EqualValues(t, testCase.want["nodeInfos"], client.NodeInfos())
 
 			client.shutdown()
 			assert.True(t, client.stopped)

--- a/internal/aws/k8s/k8sclient/pod.go
+++ b/internal/aws/k8s/k8sclient/pod.go
@@ -128,15 +128,6 @@ func transformFuncPod(obj any) (any, error) {
 	info.OwnerReferences = pod.OwnerReferences
 	info.Phase = pod.Status.Phase
 	info.Conditions = pod.Status.Conditions
-	containerInfos := make([]*ContainerInfo, 0)
-	for _, container := range pod.Spec.Containers {
-		containerInfos = append(containerInfos, &ContainerInfo{
-			Name:      container.Name,
-			Resources: container.Resources,
-		})
-	}
-	info.Containers = containerInfos
-	info.NodeName = pod.Spec.NodeName
 	return info, nil
 }
 

--- a/internal/aws/k8s/k8sclient/pod_info.go
+++ b/internal/aws/k8s/k8sclient/pod_info.go
@@ -16,11 +16,4 @@ type PodInfo struct {
 	OwnerReferences []metaV1.OwnerReference
 	Phase           v1.PodPhase
 	Conditions      []v1.PodCondition
-	NodeName        string
-	Containers      []*ContainerInfo
-}
-
-type ContainerInfo struct {
-	Name      string
-	Resources v1.ResourceRequirements
 }

--- a/internal/aws/k8s/k8sclient/pod_test.go
+++ b/internal/aws/k8s/k8sclient/pod_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -211,22 +210,6 @@ func TestPodClient_PodInfos(t *testing.T) {
 			Status: v1.PodStatus{
 				Phase: "Running",
 			},
-			Spec: v1.PodSpec{
-				NodeName: "node-1",
-				Containers: []v1.Container{
-					{
-						Name: "container-1",
-						Resources: v1.ResourceRequirements{
-							Limits: v1.ResourceList{
-								"nvidia.com/gpu": resource.MustParse("1"),
-							},
-							Requests: v1.ResourceList{
-								"nvidia.com/gpu": resource.MustParse("1"),
-							},
-						},
-					},
-				},
-			},
 		},
 	}
 
@@ -243,21 +226,7 @@ func TestPodClient_PodInfos(t *testing.T) {
 			Labels: map[string]string{
 				"key": "value",
 			},
-			Phase:    v1.PodRunning,
-			NodeName: "node-1",
-			Containers: []*ContainerInfo{
-				{
-					Name: "container-1",
-					Resources: v1.ResourceRequirements{
-						Limits: v1.ResourceList{
-							"nvidia.com/gpu": resource.MustParse("1"),
-						},
-						Requests: v1.ResourceList{
-							"nvidia.com/gpu": resource.MustParse("1"),
-						},
-					},
-				},
-			},
+			Phase: v1.PodRunning,
 		},
 	}
 

--- a/internal/aws/k8s/k8sutil/util.go
+++ b/internal/aws/k8s/k8sutil/util.go
@@ -5,7 +5,6 @@ package k8sutil // import "github.com/open-telemetry/opentelemetry-collector-con
 
 import (
 	"fmt"
-	"strings"
 )
 
 // CreatePodKey concatenates namespace and podName to get a pod key
@@ -22,12 +21,4 @@ func CreateContainerKey(namespace, podName, containerName string) string {
 		return ""
 	}
 	return fmt.Sprintf("namespace:%s,podName:%s,containerName:%s", namespace, podName, containerName)
-}
-
-// ParseInstanceIDFromProviderID parses EC2 instance id from node's provider id which has format of aws:///<subnet>/<instanceId>
-func ParseInstanceIDFromProviderID(providerID string) string {
-	if providerID == "" || !strings.HasPrefix(providerID, "aws://") {
-		return ""
-	}
-	return providerID[strings.LastIndex(providerID, "/")+1:]
 }

--- a/internal/aws/k8s/k8sutil/util_test.go
+++ b/internal/aws/k8s/k8sutil/util_test.go
@@ -22,10 +22,3 @@ func TestCreateContainerKey(t *testing.T) {
 	assert.Equal(t, "", CreateContainerKey("default", "", "testContainer"))
 	assert.Equal(t, "", CreateContainerKey("default", "testPod", ""))
 }
-
-func TestParseInstanceIdFromProviderId(t *testing.T) {
-	assert.Equal(t, "i-0b00e07ccd388f915", ParseInstanceIDFromProviderID("aws:///us-west-2b/i-0b00e07ccd388f915"))
-	assert.Equal(t, "i-0b00e07ccd388f915", ParseInstanceIDFromProviderID("aws:///us-east-1c/i-0b00e07ccd388f915"))
-	assert.Equal(t, "", ParseInstanceIDFromProviderID(":///us-east-1c/i-0b00e07ccd388f915"))
-	assert.Equal(t, "", ParseInstanceIDFromProviderID(""))
-}

--- a/receiver/awscontainerinsightreceiver/config.go
+++ b/receiver/awscontainerinsightreceiver/config.go
@@ -58,7 +58,7 @@ type Config struct {
 	// The default value is false.
 	EnableControlPlaneMetrics bool `mapstructure:"enable_control_plane_metrics"`
 
-	// EnableAcceleratedComputeMetrics enabled features with accelerated compute resources where metrics are scraped from vendor specific sources
+	// EnableAcceleratedComputeMetrics enables features with accelerated compute resources where metrics are scraped from vendor specific sources
 	EnableAcceleratedComputeMetrics bool `mapstructure:"accelerated_compute_metrics"`
 
 	// KubeConfigPath is an optional attribute to override the default kube config path in an EC2 environment

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/utils.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/utils.go
@@ -19,8 +19,6 @@ const (
 	splitRegexStr              = "\\.|-"
 	KubeProxy                  = "kube-proxy"
 	cronJobAllowedString       = "0123456789"
-	resourceSpecNvidiaGpuKey   = "nvidia.com/gpu"
-	pendingNodeName            = "pending"
 )
 
 var (

--- a/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo_test.go
@@ -103,9 +103,9 @@ func TestGetNodeStatusCapacityGPUs(t *testing.T) {
 	assert.True(t, valid)
 	assert.Equal(t, uint64(20), nodeStatusCapacityGPUs)
 
-	nodeInfo = newNodeInfo("testNodeNonExistent", &mockNodeInfoProvider{}, zap.NewNop())
-	nodeStatusCapacityGPUs, valid = nodeInfo.getNodeStatusAllocatablePods()
-	assert.False(t, valid)
+	nodeInfo = newNodeInfo("testNode2", &mockNodeInfoProvider{}, zap.NewNop())
+	nodeStatusCapacityGPUs, valid = nodeInfo.getNodeStatusCapacityGPUs()
+	assert.True(t, valid)
 	assert.Equal(t, uint64(0), nodeStatusCapacityGPUs)
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo_test.go
@@ -97,6 +97,18 @@ func TestGetNodeStatusAllocatablePods(t *testing.T) {
 	assert.Equal(t, uint64(0), nodeStatusAllocatablePods)
 }
 
+func TestGetNodeStatusCapacityGPUs(t *testing.T) {
+	nodeInfo := newNodeInfo("testNode1", &mockNodeInfoProvider{}, zap.NewNop())
+	nodeStatusCapacityGPUs, valid := nodeInfo.getNodeStatusCapacityGPUs()
+	assert.True(t, valid)
+	assert.Equal(t, uint64(20), nodeStatusCapacityGPUs)
+
+	nodeInfo = newNodeInfo("testNodeNonExistent", &mockNodeInfoProvider{}, zap.NewNop())
+	nodeStatusCapacityGPUs, valid = nodeInfo.getNodeStatusAllocatablePods()
+	assert.False(t, valid)
+	assert.Equal(t, uint64(0), nodeStatusCapacityGPUs)
+}
+
 func TestGetNodeStatusCondition(t *testing.T) {
 	nodeInfo := newNodeInfo("testNode1", &mockNodeInfoProvider{}, zap.NewNop())
 	nodeStatusCondition, valid := nodeInfo.getNodeStatusCondition(v1.NodeReady)

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -414,11 +414,9 @@ func (p *PodStore) decorateGPU(metric CIMetric, pod *corev1.Pod) {
 	if p.includeEnhancedMetrics && p.enableAcceleratedComputeMetrics && metric.GetTag(ci.MetricType) == ci.TypePod &&
 		pod.Status.Phase != corev1.PodSucceeded && pod.Status.Phase != corev1.PodFailed {
 
-		if podGpuRequest, ok := getResourceSettingForPod(pod, 0, gpuKey, getRequestForContainer); ok {
-			metric.AddField(ci.MetricName(ci.TypePod, ci.GpuRequest), podGpuRequest)
-		}
-
 		if podGpuLimit, ok := getResourceSettingForPod(pod, 0, gpuKey, getLimitForContainer); ok {
+			podGpuRequest, _ := getResourceSettingForPod(pod, 0, gpuKey, getRequestForContainer)
+			metric.AddField(ci.MetricName(ci.TypePod, ci.GpuRequest), podGpuRequest)
 			metric.AddField(ci.MetricName(ci.TypePod, ci.GpuLimit), podGpuLimit)
 			var podGpuUsageTotal uint64
 			if pod.Status.Phase == corev1.PodRunning { // Set the GPU limit as the usage_total for running pods only

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -311,11 +311,12 @@ func (p *PodStore) refreshInternal(now time.Time, podList []corev1.Pod) {
 			cpuRequest += tmpCPUReq
 			tmpMemReq, _ := getResourceSettingForPod(&pod, p.nodeInfo.getMemCapacity(), memoryKey, getRequestForContainer)
 			memRequest += tmpMemReq
-			if tmpGpuReq, ok := getResourceSettingForPod(&pod, 0, gpuKey, getRequestForContainer); ok {
+			if tmpGpuLimit, ok := getResourceSettingForPod(&pod, 0, gpuKey, getLimitForContainer); ok {
+				tmpGpuReq, _ := getResourceSettingForPod(&pod, 0, gpuKey, getRequestForContainer)
 				gpuRequest += tmpGpuReq
-			}
-			if tmpGpuLimit, ok := getResourceSettingForPod(&pod, 0, gpuKey, getLimitForContainer); ok && pod.Status.Phase == corev1.PodRunning {
-				gpuUsageTotal += tmpGpuLimit
+				if pod.Status.Phase == corev1.PodRunning {
+					gpuUsageTotal += tmpGpuLimit
+				}
 			}
 		}
 		if pod.Status.Phase == corev1.PodRunning {

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -28,6 +28,7 @@ const (
 	podsExpiry         = 2 * time.Minute
 	memoryKey          = "memory"
 	cpuKey             = "cpu"
+	gpuKey             = "nvidia.com/gpu"
 	splitRegexStr      = "\\.|-"
 	kubeProxy          = "kube-proxy"
 )
@@ -109,19 +110,19 @@ type podClient interface {
 type PodStore struct {
 	cache *mapWithExpiry
 	// prevMeasurements per each Type (Pod, Container, etc)
-	prevMeasurements          sync.Map // map[string]*mapWithExpiry
-	podClient                 podClient
-	k8sClient                 replicaSetInfoProvider
-	lastRefreshed             time.Time
-	nodeInfo                  *nodeInfo
-	prefFullPodName           bool
-	logger                    *zap.Logger
-	addFullPodNameMetricLabel bool
-	includeEnhancedMetrics    bool
+	prevMeasurements                sync.Map // map[string]*mapWithExpiry
+	podClient                       podClient
+	k8sClient                       replicaSetInfoProvider
+	lastRefreshed                   time.Time
+	nodeInfo                        *nodeInfo
+	prefFullPodName                 bool
+	logger                          *zap.Logger
+	addFullPodNameMetricLabel       bool
+	includeEnhancedMetrics          bool
+	enableAcceleratedComputeMetrics bool
 }
 
-func NewPodStore(client podClient, prefFullPodName bool, addFullPodNameMetricLabel bool,
-	includeEnhancedMetrics bool, hostName string, isSystemdEnabled bool, logger *zap.Logger) (*PodStore, error) {
+func NewPodStore(client podClient, prefFullPodName bool, addFullPodNameMetricLabel bool, includeEnhancedMetrics bool, enableAcceleratedComputeMetrics bool, hostName string, isSystemdEnabled bool, logger *zap.Logger) (*PodStore, error) {
 	if hostName == "" {
 		return nil, fmt.Errorf("missing environment variable %s. Please check your deployment YAML config or passed as part of the agent config", ci.HostName)
 	}
@@ -147,13 +148,14 @@ func NewPodStore(client podClient, prefFullPodName bool, addFullPodNameMetricLab
 		cache:            newMapWithExpiry(podsExpiry),
 		prevMeasurements: sync.Map{},
 		//prevMeasurements:          make(map[string]*mapWithExpiry),
-		podClient:                 client,
-		nodeInfo:                  nodeInfo,
-		prefFullPodName:           prefFullPodName,
-		includeEnhancedMetrics:    includeEnhancedMetrics,
-		k8sClient:                 k8sClient,
-		logger:                    logger,
-		addFullPodNameMetricLabel: addFullPodNameMetricLabel,
+		podClient:                       client,
+		nodeInfo:                        nodeInfo,
+		prefFullPodName:                 prefFullPodName,
+		includeEnhancedMetrics:          includeEnhancedMetrics,
+		enableAcceleratedComputeMetrics: enableAcceleratedComputeMetrics,
+		k8sClient:                       k8sClient,
+		logger:                          logger,
+		addFullPodNameMetricLabel:       addFullPodNameMetricLabel,
 	}
 
 	return podStore, nil
@@ -239,6 +241,7 @@ func (p *PodStore) Decorate(ctx context.Context, metric CIMetric, kubernetesBlob
 		if entry.pod.Name != "" {
 			p.decorateCPU(metric, &entry.pod)
 			p.decorateMem(metric, &entry.pod)
+			p.decorateGPU(metric, &entry.pod)
 			p.addStatus(metric, &entry.pod)
 			addContainerCount(metric, &entry.pod)
 			addContainerID(&entry.pod, metric, kubernetesBlob, p.logger)
@@ -292,6 +295,8 @@ func (p *PodStore) refreshInternal(now time.Time, podList []corev1.Pod) {
 	var containerCount int
 	var cpuRequest uint64
 	var memRequest uint64
+	var gpuRequest uint64
+	var gpuUsageTotal uint64
 
 	for i := range podList {
 		pod := podList[i]
@@ -306,6 +311,12 @@ func (p *PodStore) refreshInternal(now time.Time, podList []corev1.Pod) {
 			cpuRequest += tmpCPUReq
 			tmpMemReq, _ := getResourceSettingForPod(&pod, p.nodeInfo.getMemCapacity(), memoryKey, getRequestForContainer)
 			memRequest += tmpMemReq
+			if tmpGpuReq, ok := getResourceSettingForPod(&pod, 0, gpuKey, getRequestForContainer); ok {
+				gpuRequest += tmpGpuReq
+			}
+			if tmpGpuLimit, ok := getResourceSettingForPod(&pod, 0, gpuKey, getLimitForContainer); ok && pod.Status.Phase == corev1.PodRunning {
+				gpuUsageTotal += tmpGpuLimit
+			}
 		}
 		if pod.Status.Phase == corev1.PodRunning {
 			podCount++
@@ -319,10 +330,18 @@ func (p *PodStore) refreshInternal(now time.Time, podList []corev1.Pod) {
 
 		p.setCachedEntry(podKey, &cachedEntry{
 			pod:      pod,
-			creation: now})
+			creation: now,
+		})
 	}
 
-	p.nodeInfo.setNodeStats(nodeStats{podCnt: podCount, containerCnt: containerCount, memReq: memRequest, cpuReq: cpuRequest})
+	p.nodeInfo.setNodeStats(nodeStats{
+		podCnt:        podCount,
+		containerCnt:  containerCount,
+		memReq:        memRequest,
+		cpuReq:        cpuRequest,
+		gpuReq:        gpuRequest,
+		gpuUsageTotal: gpuUsageTotal,
+	})
 }
 
 func (p *PodStore) decorateNode(metric CIMetric) {
@@ -379,6 +398,36 @@ func (p *PodStore) decorateNode(metric CIMetric) {
 		}
 		if nodeStatusConditionUnknown, ok := p.nodeInfo.getNodeConditionUnknown(); ok {
 			metric.AddField(ci.MetricName(ci.TypeNode, ci.StatusConditionUnknown), nodeStatusConditionUnknown)
+		}
+		if p.enableAcceleratedComputeMetrics {
+			if nodeStatusCapacityGPUs, ok := p.nodeInfo.getNodeStatusCapacityGPUs(); ok && nodeStatusCapacityGPUs != 0 {
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.GpuRequest), nodeStats.gpuReq)
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.GpuLimit), nodeStatusCapacityGPUs)
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.GpuUsageTotal), nodeStats.gpuUsageTotal)
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.GpuReservedCapacity), float64(nodeStats.gpuReq)/float64(nodeStatusCapacityGPUs)*100)
+			}
+		}
+	}
+}
+
+func (p *PodStore) decorateGPU(metric CIMetric, pod *corev1.Pod) {
+	if p.includeEnhancedMetrics && p.enableAcceleratedComputeMetrics && metric.GetTag(ci.MetricType) == ci.TypePod &&
+		pod.Status.Phase != corev1.PodSucceeded && pod.Status.Phase != corev1.PodFailed {
+
+		if podGpuRequest, ok := getResourceSettingForPod(pod, 0, gpuKey, getRequestForContainer); ok {
+			metric.AddField(ci.MetricName(ci.TypePod, ci.GpuRequest), podGpuRequest)
+		}
+
+		if podGpuLimit, ok := getResourceSettingForPod(pod, 0, gpuKey, getLimitForContainer); ok {
+			metric.AddField(ci.MetricName(ci.TypePod, ci.GpuLimit), podGpuLimit)
+			var podGpuUsageTotal uint64
+			if pod.Status.Phase == corev1.PodRunning { // Set the GPU limit as the usage_total for running pods only
+				podGpuUsageTotal = podGpuLimit
+			}
+			metric.AddField(ci.MetricName(ci.TypePod, ci.GpuUsageTotal), podGpuUsageTotal)
+			if nodeStatusCapacityGPUs, ok := p.nodeInfo.getNodeStatusCapacityGPUs(); ok && nodeStatusCapacityGPUs != 0 {
+				metric.AddField(ci.MetricName(ci.TypePod, ci.GpuReservedCapacity), float64(podGpuLimit)/float64(nodeStatusCapacityGPUs)*100)
+			}
 		}
 	}
 }

--- a/receiver/awscontainerinsightreceiver/internal/stores/store.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/store.go
@@ -43,15 +43,16 @@ type K8sDecorator struct {
 	podStore *PodStore
 }
 
-func NewK8sDecorator(ctx context.Context, kubeletClient *kubeletutil.KubeletClient, tagService bool, prefFullPodName bool, addFullPodNameMetricLabel bool,
-	addContainerNameMetricLabel bool, includeEnhancedMetrics bool, kubeConfigPath string,
-	hostName string, isSystemd bool, logger *zap.Logger) (*K8sDecorator, error) {
+func NewK8sDecorator(ctx context.Context, kubeletClient *kubeletutil.KubeletClient, tagService bool, prefFullPodName bool,
+	addFullPodNameMetricLabel bool, addContainerNameMetricLabel bool, includeEnhancedMetrics bool, enableAcceleratedComputeMetrics bool,
+	kubeConfigPath string, hostName string, isSystemd bool, logger *zap.Logger) (*K8sDecorator, error) {
+
 	k := &K8sDecorator{
 		ctx:                         ctx,
 		addContainerNameMetricLabel: addContainerNameMetricLabel,
 	}
 
-	podstore, err := NewPodStore(kubeletClient, prefFullPodName, addFullPodNameMetricLabel, includeEnhancedMetrics, hostName, isSystemd, logger)
+	podstore, err := NewPodStore(kubeletClient, prefFullPodName, addFullPodNameMetricLabel, includeEnhancedMetrics, enableAcceleratedComputeMetrics, hostName, isSystemd, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/awscontainerinsightreceiver/internal/stores/utils.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/utils.go
@@ -22,6 +22,7 @@ const (
 	// https://github.com/kubernetes/apimachinery/blob/master/pkg/util/rand/rand.go#L83
 	kubeAllowedStringAlphaNums = "bcdfghjklmnpqrstvwxz2456789"
 	cronJobAllowedString       = "0123456789"
+	resourceSpecNvidiaGpuKey   = "nvidia.com/gpu"
 )
 
 func createPodKeyFromMetaData(pod *corev1.Pod) string {

--- a/receiver/awscontainerinsightreceiver/internal/stores/utils_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/utils_test.go
@@ -70,8 +70,7 @@ func (m *mockNodeInfoProvider) NodeToCapacityMap() map[string]v1.ResourceList {
 			"nvidia.com/gpu": *resource.NewQuantity(20, resource.DecimalExponent),
 		},
 		"testNode2": {
-			"pods":           *resource.NewQuantity(10, resource.DecimalSI),
-			"nvidia.com/gpu": *resource.NewQuantity(30, resource.DecimalExponent),
+			"pods": *resource.NewQuantity(10, resource.DecimalSI),
 		},
 	}
 }
@@ -83,8 +82,7 @@ func (m *mockNodeInfoProvider) NodeToAllocatableMap() map[string]v1.ResourceList
 			"nvidia.com/gpu": *resource.NewQuantity(20, resource.DecimalExponent),
 		},
 		"testNode2": {
-			"pods":           *resource.NewQuantity(20, resource.DecimalSI),
-			"nvidia.com/gpu": *resource.NewQuantity(30, resource.DecimalExponent),
+			"pods": *resource.NewQuantity(20, resource.DecimalSI),
 		},
 	}
 }

--- a/receiver/awscontainerinsightreceiver/internal/stores/utils_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/utils_test.go
@@ -66,10 +66,12 @@ type mockNodeInfoProvider struct {
 func (m *mockNodeInfoProvider) NodeToCapacityMap() map[string]v1.ResourceList {
 	return map[string]v1.ResourceList{
 		"testNode1": {
-			"pods": *resource.NewQuantity(5, resource.DecimalSI),
+			"pods":           *resource.NewQuantity(5, resource.DecimalSI),
+			"nvidia.com/gpu": *resource.NewQuantity(20, resource.DecimalExponent),
 		},
 		"testNode2": {
-			"pods": *resource.NewQuantity(10, resource.DecimalSI),
+			"pods":           *resource.NewQuantity(10, resource.DecimalSI),
+			"nvidia.com/gpu": *resource.NewQuantity(30, resource.DecimalExponent),
 		},
 	}
 }
@@ -77,10 +79,12 @@ func (m *mockNodeInfoProvider) NodeToCapacityMap() map[string]v1.ResourceList {
 func (m *mockNodeInfoProvider) NodeToAllocatableMap() map[string]v1.ResourceList {
 	return map[string]v1.ResourceList{
 		"testNode1": {
-			"pods": *resource.NewQuantity(15, resource.DecimalSI),
+			"pods":           *resource.NewQuantity(15, resource.DecimalSI),
+			"nvidia.com/gpu": *resource.NewQuantity(20, resource.DecimalExponent),
 		},
 		"testNode2": {
-			"pods": *resource.NewQuantity(20, resource.DecimalSI),
+			"pods":           *resource.NewQuantity(20, resource.DecimalSI),
+			"nvidia.com/gpu": *resource.NewQuantity(30, resource.DecimalExponent),
 		},
 	}
 }

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -142,7 +142,7 @@ func (acir *awsContainerInsightReceiver) initEKS(ctx context.Context, host compo
 	hostName string, kubeletClient *kubeletutil.KubeletClient) error {
 	k8sDecorator, err := stores.NewK8sDecorator(ctx, kubeletClient, acir.config.TagService, acir.config.PrefFullPodName,
 		acir.config.AddFullPodNameMetricLabel, acir.config.AddContainerNameMetricLabel,
-		acir.config.EnableControlPlaneMetrics, acir.config.KubeConfigPath, hostName,
+		acir.config.EnableControlPlaneMetrics, acir.config.EnableAcceleratedComputeMetrics, acir.config.KubeConfigPath, hostName,
 		acir.config.RunOnSystemd, acir.settings.Logger)
 	if err != nil {
 		acir.settings.Logger.Warn("Unable to start K8s decorator", zap.Error(err))
@@ -177,7 +177,7 @@ func (acir *awsContainerInsightReceiver) initEKS(ctx context.Context, host compo
 			acir.settings.Logger.Warn("Unable to elect leader node", zap.Error(err))
 		}
 
-		acir.k8sapiserver, err = k8sapiserver.NewK8sAPIServer(hostInfo, acir.settings.Logger, leaderElection, acir.config.AddFullPodNameMetricLabel, acir.config.EnableControlPlaneMetrics, acir.config.EnableAcceleratedComputeMetrics)
+		acir.k8sapiserver, err = k8sapiserver.NewK8sAPIServer(hostInfo, acir.settings.Logger, leaderElection, acir.config.AddFullPodNameMetricLabel, acir.config.EnableControlPlaneMetrics)
 		if err != nil {
 			acir.k8sapiserver = nil
 			acir.settings.Logger.Warn("Unable to connect to api-server", zap.Error(err))


### PR DESCRIPTION
**Description:** 
https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/214 introduced NVIDIA GPU count metrics to track request, limit & usage counts at a pod, node & cluster level. However, this implementation was scraping all the metrics from the leader node for the entire cluster and introducing new log events of `PodGPU` Type.

This change moves the scraping of these metrics into the pod store such that they are scraped on each agent/collector pod as opposed to just the leader and they are now emitted as part of the existing Type `Pod` and Type `Node` log events (similar to the cpu & mem metrics).

This change also tweaks the metrics to more closely match the cpu metrics. 
  * Rename (pod|node)_gpu_total -> (pod|node)_gpu_usage_total
  * Add (pod|node)_gpu_reserved_capacity
 
**Testing:** Deployed changes to a test cluster running a mix of GPU and non-GPU nodes.
* Validated overall EMF logs count remains the same before & after changes
* Validated EMF log events corresponding to pods and nodes that are not related to GPU workloads remain un-impacted
* Validated EMF log events for GPU pods and nodes now publish metrics as expected.