### PR TITLE
[processor/resourcedetection] Fix EKS detector nil panic.

### DIFF
--- a/processor/resourcedetectionprocessor/internal/aws/eks/detector.go
+++ b/processor/resourcedetectionprocessor/internal/aws/eks/detector.go
@@ -53,7 +53,6 @@ type eksDetectorUtils struct {
 type detector struct {
 	utils  detectorUtils
 	logger *zap.Logger
-	err    error
 	ra     metadata.ResourceAttributesConfig
 	rb     *metadata.ResourceBuilder
 }
@@ -66,11 +65,12 @@ var _ detectorUtils = (*eksDetectorUtils)(nil)
 func NewDetector(set processor.Settings, dcfg internal.DetectorConfig) (internal.Detector, error) {
 	cfg := dcfg.(Config)
 	utils, err := newK8sDetectorUtils()
-
+	if err != nil {
+		return nil, err
+	}
 	return &detector{
 		utils:  utils,
 		logger: set.Logger,
-		err:    err,
 		ra:     cfg.ResourceAttributes,
 		rb:     metadata.NewResourceBuilder(cfg.ResourceAttributes),
 	}, nil

--- a/processor/resourcedetectionprocessor/internal/aws/eks/detector_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/eks/detector_test.go
@@ -43,8 +43,8 @@ func (detectorUtils *MockDetectorUtils) getClusterNameTagFromReservations(_ []*e
 func TestNewDetector(t *testing.T) {
 	dcfg := CreateDefaultConfig()
 	detector, err := NewDetector(processortest.NewNopSettings(), dcfg)
-	assert.NoError(t, err)
-	assert.NotNil(t, detector)
+	assert.Error(t, err)
+	assert.Nil(t, detector)
 }
 
 // Tests EKS resource detector running in EKS environment
@@ -55,7 +55,7 @@ func TestEKS(t *testing.T) {
 	t.Setenv("KUBERNETES_SERVICE_HOST", "localhost")
 	detectorUtils.On("getConfigMap", authConfigmapNS, authConfigmapName).Return(map[string]string{conventions.AttributeK8SClusterName: clusterName}, nil)
 	// Call EKS Resource detector to detect resources
-	eksResourceDetector := &detector{utils: detectorUtils, err: nil, ra: metadata.DefaultResourceAttributesConfig(), rb: metadata.NewResourceBuilder(metadata.DefaultResourceAttributesConfig())}
+	eksResourceDetector := &detector{utils: detectorUtils, ra: metadata.DefaultResourceAttributesConfig(), rb: metadata.NewResourceBuilder(metadata.DefaultResourceAttributesConfig())}
 	res, _, err := eksResourceDetector.Detect(ctx)
 	require.NoError(t, err)
 


### PR DESCRIPTION
**Description:** If `newK8sDetectorUtils` encounters an error, it will return a nil util and an error. Currently, the error is never logged and the detector is created. When the `Detect` function is called, the nil util is passed into the function and a nil panic occurs.

Changed the constructor function to return the error if the util constructor fails.

**Testing:**  Updated unit tests.