### PR TITLE
Updating hyper_pod_* metric names to hyperpod_*

### DIFF
--- a/internal/aws/containerinsight/utils.go
+++ b/internal/aws/containerinsight/utils.go
@@ -108,7 +108,7 @@ func getPrefixByMetricType(mType string) string {
 	instanceNetPrefix := "instance_interface_"
 	nodeNetPrefix := "node_interface_"
 	nodeEfaPrefix := "node_efa_"
-	hyperPodNodeHealthStatus := "hyper_pod_node_health_status_"
+	hyperPodNodeHealthStatus := "hyperpod_node_health_status_"
 	podPrefix := "pod_"
 	podNetPrefix := "pod_interface_"
 	podEfaPrefix := "pod_efa_"

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
@@ -441,10 +441,10 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 			assert.Equal(t, "HyperPodNode", getStringAttrVal(metric, ci.MetricType))
 			assert.Equal(t, "ip-192-168-57-23.us-west-2.compute.internal", getStringAttrVal(metric, ci.NodeNameKey))
 			assert.Equal(t, "ip-192-168-57-23.us-west-2.compute.internal", getStringAttrVal(metric, ci.InstanceID))
-			assertMetricValueEqual(t, metric, "hyper_pod_node_health_status_unschedulable_pending_reboot", int64(0))
-			assertMetricValueEqual(t, metric, "hyper_pod_node_health_status_schedulable", int64(1))
-			assertMetricValueEqual(t, metric, "hyper_pod_node_health_status_unschedulable", int64(0))
-			assertMetricValueEqual(t, metric, "hyper_pod_node_health_status_unschedulable_pending_replacement", int64(0))
+			assertMetricValueEqual(t, metric, "hyperpod_node_health_status_unschedulable_pending_reboot", int64(0))
+			assertMetricValueEqual(t, metric, "hyperpod_node_health_status_schedulable", int64(1))
+			assertMetricValueEqual(t, metric, "hyperpod_node_health_status_unschedulable", int64(0))
+			assertMetricValueEqual(t, metric, "hyperpod_node_health_status_unschedulable_pending_replacement", int64(0))
 		default:
 			assert.Fail(t, "Unexpected metric type: "+metricType)
 		}


### PR DESCRIPTION
**Description:** Update the hyper_pod_* metric names after consultation with the Sagemaker HyperPod team.

**Testing:** Built a custom image and deployed on a Cluster to Test.

![image](https://github.com/user-attachments/assets/fe4018ab-e4c4-403a-8a42-48e5148dce15)