### PR TITLE
Use HostInfo to populate instanceId, InstanceType

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/neuron/neuron_monitor_scraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/neuron/neuron_monitor_scraper_config.go
@@ -71,14 +71,14 @@ func GetNeuronMetricRelabelConfigs(hostinfo prometheusscraper.HostInfoProvider) 
 			SourceLabels: model.LabelNames{"instance_id"},
 			TargetLabel:  ci.InstanceID,
 			Regex:        relabel.MustNewRegexp("(.*)"),
-			Replacement:  "${1}",
+			Replacement:  hostinfo.GetInstanceID(),
 			Action:       relabel.Replace,
 		},
 		{
 			SourceLabels: model.LabelNames{"instance_type"},
 			TargetLabel:  ci.InstanceType,
 			Regex:        relabel.MustNewRegexp("(.*)"),
-			Replacement:  "${1}",
+			Replacement:  hostinfo.GetInstanceType(),
 			Action:       relabel.Replace,
 		},
 		{

--- a/receiver/awscontainerinsightreceiver/internal/neuron/neuron_monitor_scraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/neuron/neuron_monitor_scraper_test.go
@@ -39,6 +39,7 @@ hardware_ecc_events_total{availability_zone="us-east-1c",event_type="sram_ecc_un
 const dummyClusterName = "cluster-name"
 const dummyHostName = "i-000000000"
 const dummyNodeName = "dummy-nodeName"
+const dummyInstanceType = "instance-type"
 
 type mockHostInfoProvider struct {
 }
@@ -51,13 +52,17 @@ func (m mockHostInfoProvider) GetInstanceID() string {
 	return dummyHostName
 }
 
+func (m mockHostInfoProvider) GetInstanceType() string {
+	return dummyInstanceType
+}
+
 func TestNewNeuronScraperEndToEnd(t *testing.T) {
 	t.Setenv("HOST_NAME", dummyNodeName)
 	expectedMetrics := make(map[string]prometheusscraper.ExpectedMetricStruct)
 	expectedMetrics["neuroncore_utilization_ratio"] = prometheusscraper.ExpectedMetricStruct{
 		MetricValue: 0.1,
 		MetricLabels: []prometheusscraper.MetricLabel{
-			{LabelName: "InstanceId", LabelValue: "i-09db9b55e0095612f"},
+			{LabelName: "InstanceId", LabelValue: dummyHostName},
 			{LabelName: "ClusterName", LabelValue: dummyClusterName},
 			{LabelName: "NeuronCore", LabelValue: "0"},
 			{LabelName: "NodeName", LabelValue: dummyNodeName},
@@ -66,7 +71,7 @@ func TestNewNeuronScraperEndToEnd(t *testing.T) {
 	expectedMetrics["neurondevice_hw_ecc_events_total_mem_ecc_corrected"] = prometheusscraper.ExpectedMetricStruct{
 		MetricValue: 3,
 		MetricLabels: []prometheusscraper.MetricLabel{
-			{LabelName: "InstanceId", LabelValue: "i-09db9b55e0095612f"},
+			{LabelName: "InstanceId", LabelValue: dummyHostName},
 			{LabelName: "ClusterName", LabelValue: dummyClusterName},
 			{LabelName: "NeuronDevice", LabelValue: "5"},
 			{LabelName: "NodeName", LabelValue: dummyNodeName},
@@ -75,7 +80,7 @@ func TestNewNeuronScraperEndToEnd(t *testing.T) {
 	expectedMetrics["neuron_runtime_memory_used_bytes"] = prometheusscraper.ExpectedMetricStruct{
 		MetricValue: 9.043968e+06,
 		MetricLabels: []prometheusscraper.MetricLabel{
-			{LabelName: "InstanceId", LabelValue: "i-09db9b55e0095612f"},
+			{LabelName: "InstanceId", LabelValue: dummyHostName},
 			{LabelName: "ClusterName", LabelValue: dummyClusterName},
 			{LabelName: "NodeName", LabelValue: dummyNodeName},
 		},
@@ -84,7 +89,7 @@ func TestNewNeuronScraperEndToEnd(t *testing.T) {
 	expectedMetrics["execution_errors_created"] = prometheusscraper.ExpectedMetricStruct{
 		MetricValue: 1.7083389404380567e+09,
 		MetricLabels: []prometheusscraper.MetricLabel{
-			{LabelName: "InstanceId", LabelValue: "i-09db9b55e0095612f"},
+			{LabelName: "InstanceId", LabelValue: dummyHostName},
 			{LabelName: "ClusterName", LabelValue: dummyClusterName},
 			{LabelName: "NodeName", LabelValue: dummyNodeName},
 		},
@@ -93,7 +98,7 @@ func TestNewNeuronScraperEndToEnd(t *testing.T) {
 	expectedMetrics["system_memory_total_bytes"] = prometheusscraper.ExpectedMetricStruct{
 		MetricValue: 5.32523487232e+011,
 		MetricLabels: []prometheusscraper.MetricLabel{
-			{LabelName: "InstanceId", LabelValue: "i-09db9b55e0095612f"},
+			{LabelName: "InstanceId", LabelValue: dummyHostName},
 			{LabelName: "ClusterName", LabelValue: dummyClusterName},
 			{LabelName: "NodeName", LabelValue: dummyNodeName},
 		},
@@ -102,7 +107,7 @@ func TestNewNeuronScraperEndToEnd(t *testing.T) {
 	expectedMetrics["hardware_ecc_events_total"] = prometheusscraper.ExpectedMetricStruct{
 		MetricValue: 864.0,
 		MetricLabels: []prometheusscraper.MetricLabel{
-			{LabelName: "InstanceId", LabelValue: "i-09db9b55e0095612f"},
+			{LabelName: "InstanceId", LabelValue: dummyHostName},
 			{LabelName: "ClusterName", LabelValue: dummyClusterName},
 			{LabelName: "NodeName", LabelValue: dummyNodeName},
 		},

--- a/receiver/awscontainerinsightreceiver/internal/prometheusscraper/simple_prometheus_scraper.go
+++ b/receiver/awscontainerinsightreceiver/internal/prometheusscraper/simple_prometheus_scraper.go
@@ -41,6 +41,7 @@ type SimplePrometheusScraperOpts struct {
 type HostInfoProvider interface {
 	GetClusterName() string
 	GetInstanceID() string
+	GetInstanceType() string
 }
 
 func NewSimplePrometheusScraper(opts SimplePrometheusScraperOpts) (*SimplePrometheusScraper, error) {

--- a/receiver/awscontainerinsightreceiver/internal/prometheusscraper/simple_prometheus_scraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/prometheusscraper/simple_prometheus_scraper_test.go
@@ -23,6 +23,10 @@ func (m mockHostInfoProvider) GetInstanceID() string {
 	return "i-000000000"
 }
 
+func (m mockHostInfoProvider) GetInstanceType() string {
+	return "instance-type"
+}
+
 func TestSimplePrometheusScraperBadInputs(t *testing.T) {
 	settings := componenttest.NewNopTelemetrySettings()
 	settings.Logger, _ = zap.NewDevelopment()


### PR DESCRIPTION
**Description:** 
PR to fix NeuronMonitor, NeuronMonitor depends on IMDS and wont be able to set instanceId and NodeName  from inside the hyperpod  instances, so we are removing dependency of populating the Instance dimension away from Prom labe


**Testing:**

Hyperpod metrics being published

<img width="1599" alt="image" src="https://github.com/user-attachments/assets/f1c748f8-d263-4a53-979b-adb3ae08246a">
