### PR TITLE
[processor/resourcedetection] Make detect no-op for non-EKS environments

### DIFF
--- a/processor/resourcedetectionprocessor/internal/aws/eks/detector.go
+++ b/processor/resourcedetectionprocessor/internal/aws/eks/detector.go
@@ -66,7 +66,7 @@ func NewDetector(set processor.Settings, dcfg internal.DetectorConfig) (internal
 	cfg := dcfg.(Config)
 	utils, err := newK8sDetectorUtils()
 	if err != nil {
-		return nil, err
+		set.Logger.Debug("Unable to setup K8s detector", zap.Error(err))
 	}
 	return &detector{
 		utils:  utils,
@@ -78,6 +78,10 @@ func NewDetector(set processor.Settings, dcfg internal.DetectorConfig) (internal
 
 // Detect returns a Resource describing the Amazon EKS environment being run in.
 func (d *detector) Detect(ctx context.Context) (resource pcommon.Resource, schemaURL string, err error) {
+	// Error is already logged in the constructor
+	if d.utils == nil {
+		return pcommon.NewResource(), "", nil
+	}
 	// Check if running on EKS.
 	isEKS, err := isEKS(ctx, d.utils)
 	if !isEKS {

--- a/processor/resourcedetectionprocessor/internal/aws/eks/detector_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/eks/detector_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/processor/processortest"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 	"go.uber.org/zap"
@@ -43,8 +44,13 @@ func (detectorUtils *MockDetectorUtils) getClusterNameTagFromReservations(_ []*e
 func TestNewDetector(t *testing.T) {
 	dcfg := CreateDefaultConfig()
 	detector, err := NewDetector(processortest.NewNopSettings(), dcfg)
-	assert.Error(t, err)
-	assert.Nil(t, detector)
+	assert.NoError(t, err)
+	assert.NotNil(t, detector)
+	// no-op
+	gotResource, gotSchema, gotErr := detector.Detect(context.Background())
+	assert.NoError(t, gotErr)
+	assert.Equal(t, pcommon.NewResource(), gotResource)
+	assert.Empty(t, gotSchema)
 }
 
 // Tests EKS resource detector running in EKS environment


### PR DESCRIPTION
**Description:** Instead of erroring out in the constructor, log the error as a debug log and make the `Detect` function a no-op. Similar to `ecs` detector https://github.com/amazon-contributing/opentelemetry-collector-contrib/blob/76facad52e8fc5e32459d1023eef9e64608ddb6b/processor/resourcedetectionprocessor/internal/aws/ecs/ecs.go#L52-L55

**Link to tracking Issue:** N/A

**Testing:** Updated unit tests.