### PR TITLE
use protobuf content type instead of json for k8s client

### DIFF
--- a/internal/aws/k8s/k8sclient/clientset.go
+++ b/internal/aws/k8s/k8sclient/clientset.go
@@ -280,6 +280,8 @@ func (c *K8sClient) init(logger *zap.Logger, options ...Option) error {
 			return err
 		}
 	}
+	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	config.ContentType = "application/vnd.kubernetes.protobuf"
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		c.logger.Error("failed to build ClientSet", zap.Error(err))


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

This MR is a part of effort to elevate single eks cluster performance by migrating the EKS components to use protobuf instead of json.

Modify kubeconfig type to use content type `application/vnd.kubernetes.protobuf` instead of json for performance gain.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>