### PR TITLE
[awsxrayexporter] Allow sending spans in otlp format with a new config

### DIFF
--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -64,7 +64,7 @@ func newTracesExporter(
 			logger.Debug("TracesExporter", typeLog, nameLog, zap.Int("#spans", td.SpanCount()))
 
 			var documents []*string
-			if cfg.TransitSpanInOtlpFormat {
+			if cfg.TransitSpansInOtlpFormat {
 				documents, err = encodeOtlpAsBase64(td, cfg)
 				if err != nil {
 					return err

--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -5,7 +5,9 @@ package awsxrayexporter // import "github.com/open-telemetry/opentelemetry-colle
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
+	"fmt"
 
 	"github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -24,7 +26,10 @@ import (
 )
 
 const (
-	maxSegmentsPerPut = int(50) // limit imposed by PutTraceSegments API
+	maxSegmentsPerPut               = int(50) // limit imposed by PutTraceSegments API
+	otlpFormatPrefix                = "T1S"   // X-Ray PutTraceSegment API uses this prefix to detect the format
+	otlpFormatKeyIndexAllAttributes = "aws.xray.exporter.config.index_all_attributes"
+	otlpFormatKeyIndexAttributes    = "aws.xray.exporter.config.indexed_attributes"
 )
 
 // newTracesExporter creates an exporter.Traces that converts to an X-Ray PutTraceSegments
@@ -57,7 +62,15 @@ func newTracesExporter(
 			var err error
 			logger.Debug("TracesExporter", typeLog, nameLog, zap.Int("#spans", td.SpanCount()))
 
-			documents := extractResourceSpans(cfg, logger, td)
+			var documents []*string
+			if cfg.TransitSpanInOtlpFormat {
+				documents, err = encodeOtlpAsBase64(td, cfg)
+				if err != nil {
+					return err
+				}
+			} else { // by default use xray format
+				documents = extractResourceSpans(cfg, logger, td)
+			}
 
 			for offset := 0; offset < len(documents); offset += maxSegmentsPerPut {
 				var nextOffset int
@@ -136,4 +149,39 @@ func wrapErrorIfBadRequest(err error) error {
 		return consumererror.NewPermanent(err)
 	}
 	return err
+}
+
+// encodeOtlpAsBase64 builds bytes from traces and generate base64 value for them
+func encodeOtlpAsBase64(td ptrace.Traces, cfg *Config) ([]*string, error) {
+	var documents []*string
+	marshaller := &ptrace.ProtoMarshaler{}
+	for i := 0; i < td.ResourceSpans().Len(); i++ {
+		// 1. build a new trace with one resource span
+		singleTrace := ptrace.NewTraces()
+		td.ResourceSpans().At(i).CopyTo(singleTrace.ResourceSpans().AppendEmpty())
+
+		// 2. append index configuration to resource span as attributes, such that X-Ray Service build indexes based on them.
+		injectIndexConfigIntoOtlpPayload(singleTrace.ResourceSpans().At(0), cfg)
+
+		// 3. Marshal single trace into proto bytes
+		bytes, err := marshaller.MarshalTraces(singleTrace)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal traces: %w", err)
+		}
+
+		// 4. build bytes into base64 and append with PROTOCOL HEADER at the beginning
+		base64Str := otlpFormatPrefix + base64.StdEncoding.EncodeToString(bytes)
+		documents = append(documents, &base64Str)
+	}
+
+	return documents, nil
+}
+
+func injectIndexConfigIntoOtlpPayload(resourceSpan ptrace.ResourceSpans, cfg *Config) {
+	attributes := resourceSpan.Resource().Attributes()
+	attributes.PutBool(otlpFormatKeyIndexAllAttributes, cfg.IndexAllAttributes)
+	indexAttributes := attributes.PutEmptySlice(otlpFormatKeyIndexAttributes)
+	for _, indexAttribute := range cfg.IndexedAttributes {
+		indexAttributes.AppendEmpty().SetStr(indexAttribute)
+	}
 }

--- a/exporter/awsxrayexporter/awsxray_test.go
+++ b/exporter/awsxrayexporter/awsxray_test.go
@@ -123,7 +123,7 @@ func TestMiddleware(t *testing.T) {
 
 func TestTraceExportOtlpFormat(t *testing.T) {
 	config := generateConfig(t)
-	config.TransitSpanInOtlpFormat = true
+	config.TransitSpansInOtlpFormat = true
 
 	traceExporter := initializeTracesExporter(t, generateConfig(t), telemetrytest.NewNopRegistry())
 	ctx := context.Background()

--- a/exporter/awsxrayexporter/awsxray_test.go
+++ b/exporter/awsxrayexporter/awsxray_test.go
@@ -6,6 +6,7 @@ package awsxrayexporter
 import (
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/binary"
 	"fmt"
 	"testing"
@@ -120,6 +121,79 @@ func TestMiddleware(t *testing.T) {
 	handler.AssertCalled(t, "HandleResponse", mock.Anything, mock.Anything)
 }
 
+func TestTraceExportOtlpFormat(t *testing.T) {
+	config := generateConfig(t)
+	config.TransitSpanInOtlpFormat = true
+
+	traceExporter := initializeTracesExporter(t, generateConfig(t), telemetrytest.NewNopRegistry())
+	ctx := context.Background()
+	td := constructSpanData()
+	err := traceExporter.ConsumeTraces(ctx, td)
+	assert.Error(t, err)
+	err = traceExporter.Shutdown(ctx)
+	assert.NoError(t, err)
+}
+
+func TestEncodingOtlpFormat(t *testing.T) {
+	config1 := generateConfig(t)
+	config1.IndexAllAttributes = true
+	config1.IndexedAttributes = []string{"test", "test1", "test2"}
+	testEncodingOtlpFormatWithIndexConfiguration(t, config1)
+
+	config2 := generateConfig(t)
+	config2.IndexedAttributes = []string{"test", "test1", "test2"}
+	testEncodingOtlpFormatWithIndexConfiguration(t, config2)
+
+	config3 := generateConfig(t)
+	config3.IndexAllAttributes = true
+	testEncodingOtlpFormatWithIndexConfiguration(t, config3)
+
+	config4 := generateConfig(t)
+	config4.IndexedAttributes = []string{}
+	testEncodingOtlpFormatWithIndexConfiguration(t, config4)
+
+	config5 := generateConfig(t)
+	config5.IndexAllAttributes = false
+	testEncodingOtlpFormatWithIndexConfiguration(t, config5)
+
+	config6 := generateConfig(t)
+	config6.IndexAllAttributes = false
+	config6.IndexedAttributes = []string{}
+	testEncodingOtlpFormatWithIndexConfiguration(t, config6)
+}
+
+func testEncodingOtlpFormatWithIndexConfiguration(t *testing.T, config *Config) {
+	// 1. prepare 50 resource spans and encode them
+	td := constructMultiSpanData(50)
+	documents, err := encodeOtlpAsBase64(td, config)
+	assert.NoError(t, err)
+	assert.EqualValues(t, td.ResourceSpans().Len(), len(documents), "ensure #resourcespans same as #documents")
+
+	// 2. ensure documents can be decoded back
+	unmarshaler := &ptrace.ProtoUnmarshaler{}
+	for i, document := range documents {
+		assert.EqualValues(t, "T1S", (*document)[0:3], "ensure protocol prefix")
+		decodedBytes, err := base64.StdEncoding.DecodeString((*document)[3:])
+		assert.NoError(t, err)
+
+		trace, err := unmarshaler.UnmarshalTraces(decodedBytes)
+		assert.NoError(t, err)
+
+		trace.CopyTo(trace)
+
+		// 3. ensure index configurations are carried
+		injectIndexConfigIntoOtlpPayload(td.ResourceSpans().At(i), config)
+		assert.EqualValues(t, td.ResourceSpans().At(i), trace.ResourceSpans().At(0))
+	}
+}
+
+func TestEncodingOtlpFormatWithEmptySpans(t *testing.T) {
+	td := constructMultiSpanData(0)
+	documents, err := encodeOtlpAsBase64(td, generateConfig(t))
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, len(documents), "expect 0 document")
+}
+
 func BenchmarkForTracesExporter(b *testing.B) {
 	traceExporter := initializeTracesExporter(b, generateConfig(b), telemetrytest.NewNopRegistry())
 	for i := 0; i < b.N; i++ {
@@ -156,12 +230,23 @@ func generateConfig(t testing.TB) *Config {
 
 func constructSpanData() ptrace.Traces {
 	resource := constructResource()
-
 	traces := ptrace.NewTraces()
 	rspans := traces.ResourceSpans().AppendEmpty()
 	resource.CopyTo(rspans.Resource())
 	ispans := rspans.ScopeSpans().AppendEmpty()
 	constructXrayTraceSpanData(ispans)
+	return traces
+}
+
+func constructMultiSpanData(numSpans int) ptrace.Traces {
+	traces := ptrace.NewTraces()
+	for range numSpans {
+		resource := constructResource()
+		rspans := traces.ResourceSpans().AppendEmpty()
+		resource.CopyTo(rspans.Resource())
+		ispans := rspans.ScopeSpans().AppendEmpty()
+		constructXrayTraceSpanData(ispans)
+	}
 	return traces
 }
 

--- a/exporter/awsxrayexporter/config.go
+++ b/exporter/awsxrayexporter/config.go
@@ -30,6 +30,9 @@ type Config struct {
 	// AWS client.
 	MiddlewareID *component.ID `mapstructure:"middleware,omitempty"`
 
+	// X-Ray Export sends spans in its original otlp format to X-Ray Service when this flag is on
+	TransitSpanInOtlpFormat bool `mapstructure:"transit_spans_in_otlp_format,omitempty"`
+
 	// skipTimestampValidation if enabled, will skip timestamp validation logic on the trace ID
 	skipTimestampValidation bool
 }

--- a/exporter/awsxrayexporter/config.go
+++ b/exporter/awsxrayexporter/config.go
@@ -31,7 +31,7 @@ type Config struct {
 	MiddlewareID *component.ID `mapstructure:"middleware,omitempty"`
 
 	// X-Ray Export sends spans in its original otlp format to X-Ray Service when this flag is on
-	TransitSpanInOtlpFormat bool `mapstructure:"transit_spans_in_otlp_format,omitempty"`
+	TransitSpansInOtlpFormat bool `mapstructure:"transit_spans_in_otlp_format,omitempty"`
 
 	// skipTimestampValidation if enabled, will skip timestamp validation logic on the trace ID
 	skipTimestampValidation bool


### PR DESCRIPTION
**Description:** 

This PR adds a configuration `transit_spans_in_otlp_format` in X-Ray Exporter to allow customers to choose to send spans in otlp format. 


**Testing:** 

unit-tests done.
tested with cloudwatch agent, by running a sample app in EKS and verified the data received in X-Ray contains `aws.xray.exporter.config.index_all_attributes` and `aws.xray.exporter.config.indexed_attributes`. 

```
{
    "resource": {
        "attributes": {
            "service.name": "nginx-proxy",
            "cloud.region": "sa-east-1",
            "host.image.id": "ami-05bf16341c7ebb2e4",
            "host.type": "m5.large",
            "ec2.tag.aws:autoscaling:groupName": "eks-ng-23d4a773-82c9130c-e74b-0945-e092-86ea527a4e35",
            "cloud.availability_zone": "sa-east-1a",
            "telemetry.sdk.name": "opentelemetry",
            "aws.xray.exporter.config.index_all_attributes": false,
            "aws.xray.exporter.config.indexed_attributes": ["aws.local.service", "aws.local.operation", "aws.local.environment", "aws.remote.service", "aws.remote.operation", "aws.remote.environment", "aws.remote.resource.identifier", "aws.remote.resource.type"],
            "telemetry.sdk.language": "cpp",
            "cloud.provider": "aws",
            "cloud.account.id": "045274034697",
            "aws.log.group.names": "/aws/containerinsights/yingying2/application",
            "telemetry.sdk.version": "1.8.1",
            "host.name": "ip-192-168-44-197.sa-east-1.compute.internal",
            "ec2.tag.kubernetes.io/cluster/yingying2": "owned",
            "cloud.platform": "aws_eks",
            "host.id": "i-047a17e9780258540"
        }
    },
    "scope": {
        "name": "nginx",
        "version": ""
    },
    "traceId": "dcba8a4a111f2bdec9053b2d4be421c0",
    "spanId": "c85649574f8d75b5",
    "flags": 0,
    "name": "HTTP GET pet-clinic-frontend-java",
    "kind": "SERVER",
    "startTimeUnixNano": 1727825661174485223,
    "endTimeUnixNano": 1727825661177039102,
    "durationNano": 2553879,
    "attributes": {
        "EC2.AutoScalingGroup": "eks-ng-23d4a773-82c9130c-e74b-0945-e092-86ea527a4e35",
        "net.peer.port": 28459,
        "http.target": "/scripts/visits/visits.js",
        "http.flavor": "1.1",
        "Host": "ip-192-168-44-197.sa-east-1.compute.internal",
        "net.peer.ip": "192.168.66.126",
        "http.host": "a9b4d587d6cc9486ea60d63807c00fd7-421249312.sa-east-1.elb.amazonaws.com",
        "aws.local.environment": "eks:yingying2/UnknownNamespace",
        "K8s.Namespace": "UnknownNamespace",
        "http.status_code": 200,
        "http.server_name": "_",
        "http.user_agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/111.0.5563.146 Safari/537.36 CloudWatchSynthetics/arn:aws:synthetics:sa-east-1:045274034697:canary:pc-visit-billings",
        "net.host.port": 80,
        "EC2.InstanceId": "i-047a17e9780258540",
        "EKS.Cluster": "yingying2",
        "PlatformType": "AWS::EKS",
        "http.method": "GET",
        "http.scheme": "http"
    }
}
```