### PR TITLE
Attach AwsAccountId as a KeyAttribute for Compass Entity

### DIFF
--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -48,7 +48,9 @@ const (
 	keyAttributeEntityResourceType          = AWSEntityPrefix + "resource.type"
 	resourceType                            = "ResourceType"
 	keyAttributeEntityIdentifier            = AWSEntityPrefix + "resource.identifier"
+	keyAttributeEntityAwsAccountId          = AWSEntityPrefix + "aws.account.id"
 	identifier                              = "Identifier"
+	awsAccountId                            = "AwsAccountId"
 	attributeEntityCluster                  = AWSEntityPrefix + "k8s.cluster.name"
 	cluster                                 = "Cluster"
 	attributeEntityNamespace                = AWSEntityPrefix + "k8s.namespace.name"
@@ -71,6 +73,7 @@ var keyAttributeEntityToShortNameMap = map[string]string{
 	keyAttributeEntityType:                  entityType,
 	keyAttributeEntityResourceType:          resourceType,
 	keyAttributeEntityIdentifier:            identifier,
+	keyAttributeEntityAwsAccountId:          awsAccountId,
 	keyAttributeEntityServiceName:           serviceName,
 	keyAttributeEntityDeploymentEnvironment: deploymentEnvironment,
 	keyAttributeEntityServiceNameSource:     source,

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -2582,6 +2582,7 @@ func TestFetchEntityFields(t *testing.T) {
 	resourceMetrics.Resource().Attributes().PutStr(keyAttributeEntityType, "Service")
 	resourceMetrics.Resource().Attributes().PutStr(keyAttributeEntityDeploymentEnvironment, "my-environment")
 	resourceMetrics.Resource().Attributes().PutStr(keyAttributeEntityServiceName, "my-service")
+	resourceMetrics.Resource().Attributes().PutStr(keyAttributeEntityAwsAccountId, "0123456789012")
 	resourceMetrics.Resource().Attributes().PutStr(attributeEntityNode, "my-node")
 	resourceMetrics.Resource().Attributes().PutStr(attributeEntityCluster, "my-cluster")
 	resourceMetrics.Resource().Attributes().PutStr(attributeEntityNamespace, "my-namespace")
@@ -2590,6 +2591,7 @@ func TestFetchEntityFields(t *testing.T) {
 	expectedEntity := cloudwatchlogs.Entity{KeyAttributes: map[string]*string{
 		entityType:            aws.String(service),
 		serviceName:           aws.String("my-service"),
+		awsAccountId:          aws.String("0123456789012"),
 		deploymentEnvironment: aws.String("my-environment"),
 	},
 		Attributes: map[string]*string{
@@ -2601,7 +2603,6 @@ func TestFetchEntityFields(t *testing.T) {
 	}
 	entity := fetchEntityFields(resourceMetrics.Resource().Attributes())
 	assert.Equal(t, expectedEntity, entity)
-
 }
 
 func generateTestMetrics(tm testMetric) pmetric.Metrics {

--- a/exporter/awsemfexporter/util_test.go
+++ b/exporter/awsemfexporter/util_test.go
@@ -382,6 +382,7 @@ func TestProcessAttributes(t *testing.T) {
 			resourceAttributes: map[string]any{
 				keyAttributeEntityServiceName:           "my-service",
 				keyAttributeEntityDeploymentEnvironment: "my-environment",
+				keyAttributeEntityAwsAccountId:          "0123456789012",
 			},
 			wantedAttributes: map[string]*string{
 				serviceName:           aws.String("my-service"),
@@ -412,6 +413,7 @@ func TestProcessAttributes(t *testing.T) {
 			resourceAttributes: map[string]any{
 				keyAttributeEntityServiceName:           "my-service",
 				keyAttributeEntityDeploymentEnvironment: "my-environment",
+				keyAttributeEntityAwsAccountId:          "0123456789012",
 				attributeEntityCluster:                  "my-cluster",
 				attributeEntityNamespace:                "my-namespace",
 				attributeEntityNode:                     "my-node",
@@ -420,6 +422,7 @@ func TestProcessAttributes(t *testing.T) {
 			wantedAttributes: map[string]*string{
 				serviceName:           aws.String("my-service"),
 				deploymentEnvironment: aws.String("my-environment"),
+				awsAccountId:          aws.String("0123456789012"),
 				cluster:               aws.String("my-cluster"),
 				namespace:             aws.String("my-namespace"),
 				node:                  aws.String("my-node"),
@@ -434,6 +437,7 @@ func TestProcessAttributes(t *testing.T) {
 				"extra_attribute":                       "extra_value",
 				keyAttributeEntityServiceName:           "my-service",
 				keyAttributeEntityDeploymentEnvironment: "my-environment",
+				keyAttributeEntityAwsAccountId:          "0123456789012",
 				attributeEntityCluster:                  "my-cluster",
 				attributeEntityNamespace:                "my-namespace",
 				attributeEntityNode:                     "my-node",
@@ -442,6 +446,7 @@ func TestProcessAttributes(t *testing.T) {
 			wantedAttributes: map[string]*string{
 				serviceName:           aws.String("my-service"),
 				deploymentEnvironment: aws.String("my-environment"),
+				awsAccountId:          aws.String("0123456789012"),
 				cluster:               aws.String("my-cluster"),
 				namespace:             aws.String("my-namespace"),
 				node:                  aws.String("my-node"),

--- a/internal/aws/cwlogs/cwlog_client_test.go
+++ b/internal/aws/cwlogs/cwlog_client_test.go
@@ -85,9 +85,10 @@ var logStreamName = "logStream"
 
 var entity = cloudwatchlogs.Entity{
 	KeyAttributes: map[string]*string{
-		"Type":        aws.String("Service"),
-		"Name":        aws.String("myService"),
-		"Environment": aws.String("myEnvironment"),
+		"Type":         aws.String("Service"),
+		"Name":         aws.String("myService"),
+		"Environment":  aws.String("myEnvironment"),
+		"AwsAccountId": aws.String("0123456789012"),
 	},
 	Attributes: map[string]*string{
 		"Instance": aws.String("i-1234567"),


### PR DESCRIPTION
**Description:** Attach AwsAccountId as a KeyAttribute for Compass Entity. The exporter assumes this is already set as a resource attribute earlier in the pipeline.

**Testing:** Updated unit tests