### PR TITLE
Drops all attributes with entity prefix in awsemfexporter

### DIFF
--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -48,9 +48,9 @@ const (
 	keyAttributeEntityResourceType          = AWSEntityPrefix + "resource.type"
 	resourceType                            = "ResourceType"
 	keyAttributeEntityIdentifier            = AWSEntityPrefix + "resource.identifier"
-	keyAttributeEntityAwsAccountId          = AWSEntityPrefix + "aws.account.id"
+	keyAttributeEntityAwsAccountID          = AWSEntityPrefix + "aws.account.id"
 	identifier                              = "Identifier"
-	awsAccountId                            = "AwsAccountId"
+	awsAccountID                            = "AwsAccountId"
 	attributeEntityCluster                  = AWSEntityPrefix + "k8s.cluster.name"
 	cluster                                 = "Cluster"
 	attributeEntityNamespace                = AWSEntityPrefix + "k8s.namespace.name"
@@ -73,7 +73,7 @@ var keyAttributeEntityToShortNameMap = map[string]string{
 	keyAttributeEntityType:                  entityType,
 	keyAttributeEntityResourceType:          resourceType,
 	keyAttributeEntityIdentifier:            identifier,
-	keyAttributeEntityAwsAccountId:          awsAccountId,
+	keyAttributeEntityAwsAccountID:          awsAccountID,
 	keyAttributeEntityServiceName:           serviceName,
 	keyAttributeEntityDeploymentEnvironment: deploymentEnvironment,
 	keyAttributeEntityServiceNameSource:     source,
@@ -236,8 +236,9 @@ func fetchEntityFields(resourceAttributes pcommon.Map) cloudwatchlogs.Entity {
 	keyAttributesMap := map[string]*string{}
 	attributeMap := map[string]*string{}
 
-	processAttributes(keyAttributeEntityToShortNameMap, keyAttributesMap, resourceAttributes)
-	processAttributes(attributeEntityToShortNameMap, attributeMap, resourceAttributes)
+	processEntityAttributes(keyAttributeEntityToShortNameMap, keyAttributesMap, resourceAttributes)
+	processEntityAttributes(attributeEntityToShortNameMap, attributeMap, resourceAttributes)
+	removeEntityAttributes(resourceAttributes)
 
 	return cloudwatchlogs.Entity{
 		KeyAttributes: keyAttributesMap,

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -2582,16 +2582,17 @@ func TestFetchEntityFields(t *testing.T) {
 	resourceMetrics.Resource().Attributes().PutStr(keyAttributeEntityType, "Service")
 	resourceMetrics.Resource().Attributes().PutStr(keyAttributeEntityDeploymentEnvironment, "my-environment")
 	resourceMetrics.Resource().Attributes().PutStr(keyAttributeEntityServiceName, "my-service")
-	resourceMetrics.Resource().Attributes().PutStr(keyAttributeEntityAwsAccountId, "0123456789012")
+	resourceMetrics.Resource().Attributes().PutStr(keyAttributeEntityAwsAccountID, "0123456789012")
 	resourceMetrics.Resource().Attributes().PutStr(attributeEntityNode, "my-node")
 	resourceMetrics.Resource().Attributes().PutStr(attributeEntityCluster, "my-cluster")
 	resourceMetrics.Resource().Attributes().PutStr(attributeEntityNamespace, "my-namespace")
 	resourceMetrics.Resource().Attributes().PutStr(attributeEntityWorkload, "my-workload")
+	resourceMetrics.Resource().Attributes().PutStr(AWSEntityPrefix+"fake_value", "go_terps")
 
 	expectedEntity := cloudwatchlogs.Entity{KeyAttributes: map[string]*string{
 		entityType:            aws.String(service),
 		serviceName:           aws.String("my-service"),
-		awsAccountId:          aws.String("0123456789012"),
+		awsAccountID:          aws.String("0123456789012"),
 		deploymentEnvironment: aws.String("my-environment"),
 	},
 		Attributes: map[string]*string{
@@ -2603,6 +2604,7 @@ func TestFetchEntityFields(t *testing.T) {
 	}
 	entity := fetchEntityFields(resourceMetrics.Resource().Attributes())
 	assert.Equal(t, expectedEntity, entity)
+	assert.Equal(t, 0, resourceMetrics.Resource().Attributes().Len())
 }
 
 func generateTestMetrics(tm testMetric) pmetric.Metrics {

--- a/exporter/awsemfexporter/util.go
+++ b/exporter/awsemfexporter/util.go
@@ -188,9 +188,6 @@ func processEntityAttributes(entityMap map[string]string, targetMap map[string]*
 // removeEntityAttributes so that it is not tagged as a dimension, and reduces the size of the PLE payload.
 func removeEntityAttributes(mutableResourceAttributes pcommon.Map) {
 	mutableResourceAttributes.RemoveIf(func(s string, _ pcommon.Value) bool {
-		if strings.HasPrefix(s, AWSEntityPrefix) {
-			return true
-		}
-		return false
+		return strings.HasPrefix(s, AWSEntityPrefix)
 	})
 }

--- a/exporter/awsemfexporter/util.go
+++ b/exporter/awsemfexporter/util.go
@@ -174,15 +174,23 @@ func attrMaptoStringMap(attrMap pcommon.Map) map[string]string {
 	return strMap
 }
 
-// processAttributes fetches the aws.entity fields and creates an entity to be sent at the PutLogEvent call. It also
-// removes the entity attributes so that it is not tagged as a dimension, and reduces the size of the PLE payload.
-func processAttributes(entityMap map[string]string, targetMap map[string]*string, mutableResourceAttributes pcommon.Map) {
+// processEntityAttributes fetches the aws.entity fields and creates an entity to be sent at the PutLogEvent call.
+func processEntityAttributes(entityMap map[string]string, targetMap map[string]*string, mutableResourceAttributes pcommon.Map) {
 	for entityField, shortName := range entityMap {
 		if val, ok := mutableResourceAttributes.Get(entityField); ok {
 			if strVal := val.Str(); strVal != "" {
 				targetMap[shortName] = aws.String(strVal)
 			}
-			mutableResourceAttributes.Remove(entityField)
 		}
 	}
+}
+
+// removeEntityAttributes so that it is not tagged as a dimension, and reduces the size of the PLE payload.
+func removeEntityAttributes(mutableResourceAttributes pcommon.Map) {
+	mutableResourceAttributes.RemoveIf(func(s string, _ pcommon.Value) bool {
+		if strings.HasPrefix(s, AWSEntityPrefix) {
+			return true
+		}
+		return false
+	})
 }


### PR DESCRIPTION
**Description:** Prior to this change, a customer could theoriically export a dimension with an unsupported entity field, such as `com.amazonaws.cloudwatch.entity.internal.foo.bar`. This PR will now drop all fields that begin with `com.amazonaws.cloudwatch.entity.internal`, regardless of validity.
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Testing:** Unit tests