### PR TITLE
[Fix] Target Allocator Manager quits if the initial sync fails

### DIFF
--- a/receiver/prometheusreceiver/targetallocator/manager.go
+++ b/receiver/prometheusreceiver/targetallocator/manager.go
@@ -68,7 +68,7 @@ func (m *Manager) Start(ctx context.Context, host component.Host, sm *scrape.Man
 	// immediately sync jobs, not waiting for the first tick
 	savedHash, err := m.sync(uint64(0), httpClient)
 	if err != nil {
-		return err
+		m.settings.Logger.Error("Failed to sync target allocator", zap.Error(err))
 	}
 	go func() {
 		targetAllocatorIntervalTicker := time.NewTicker(m.cfg.Interval)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
If the CloudWatch Agent Collector pod starts before the Target Allocator pod, it will fail to ping the Target Allocator.  This failure causes the Agent's target allocator thread to end, resulting in prometheus metrics being lost. Currently, the only solution is to restart the pods if this happens.

To overcome this , I removed the `return failure` on Start of the TA Manager thread; thus, TA Manager can keep on trying. 

This ensures no loss in metrics. This also has no extra cost since if the `scrape_config`(savedHash) is the same as the previous one, sync function will immediately return. In the case if the ping keeps failing the `savedHash` will be the same the as the hash--which is 0,   requiring  no extra computing power.  

**Testing:** <Describe what testing was performed and which tests were added.>
Manually tested, here you can see when the first one is failing it keeps on trying again. 
![TA Logs](https://github.com/user-attachments/assets/047e1b91-cf2d-464f-9221-f22d9cd55137)
