### PR TITLE
use localNode decorator for DCGM and Neuron metrics for host metadata

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_config.go
@@ -83,7 +83,7 @@ func getMetricRelabelConfig(hostInfoProvider hostInfoProvider) []*relabel.Config
 			Replacement:  "${1}",
 			Action:       relabel.Replace,
 		},
-		// hacky way to inject static values (clusterName/instanceId/instancType)
+		// hacky way to inject static values (clusterName/instanceId/instanceType)
 		// could be removed since these labels are now set by localNode decorator
 		{
 			SourceLabels: model.LabelNames{"namespace"},

--- a/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_config.go
@@ -83,8 +83,8 @@ func getMetricRelabelConfig(hostInfoProvider hostInfoProvider) []*relabel.Config
 			Replacement:  "${1}",
 			Action:       relabel.Replace,
 		},
-		// hacky way to inject static values (clusterName & instanceId) to label set without additional processor
-		// relabel looks up an existing label then creates another label with given key (TargetLabel) and value (static)
+		// hacky way to inject static values (clusterName/instanceId/instancType)
+		// could be removed since these labels are now set by localNode decorator
 		{
 			SourceLabels: model.LabelNames{"namespace"},
 			TargetLabel:  ci.ClusterNameKey,

--- a/receiver/awscontainerinsightreceiver/internal/neuron/neuron_monitor_scraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/neuron/neuron_monitor_scraper_config.go
@@ -68,6 +68,36 @@ func GetNeuronMetricRelabelConfigs(hostinfo prometheusscraper.HostInfoProvider) 
 			Action:       relabel.Keep,
 		},
 		{
+			SourceLabels: model.LabelNames{"neuroncore"},
+			TargetLabel:  "NeuronCore",
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  "${1}",
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"instance_id"},
+			TargetLabel:  ci.NodeNameKey,
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  os.Getenv("HOST_NAME"),
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"neuron_device_index"},
+			TargetLabel:  "NeuronDevice",
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  "${1}",
+			Action:       relabel.Replace,
+		},
+		// hacky way to inject static values (clusterName) to label set without additional processor
+		// could be removed since these labels are now set by localNode decorator
+		{
+			SourceLabels: model.LabelNames{"instance_id"},
+			TargetLabel:  ci.ClusterNameKey,
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  hostinfo.GetClusterName(),
+			Action:       relabel.Replace,
+		},
+		{
 			SourceLabels: model.LabelNames{"instance_id"},
 			TargetLabel:  ci.InstanceID,
 			Regex:        relabel.MustNewRegexp("(.*)"),
@@ -79,36 +109,6 @@ func GetNeuronMetricRelabelConfigs(hostinfo prometheusscraper.HostInfoProvider) 
 			TargetLabel:  ci.InstanceType,
 			Regex:        relabel.MustNewRegexp("(.*)"),
 			Replacement:  hostinfo.GetInstanceType(),
-			Action:       relabel.Replace,
-		},
-		{
-			SourceLabels: model.LabelNames{"neuroncore"},
-			TargetLabel:  "NeuronCore",
-			Regex:        relabel.MustNewRegexp("(.*)"),
-			Replacement:  "${1}",
-			Action:       relabel.Replace,
-		},
-		{
-			SourceLabels: model.LabelNames{"neuron_device_index"},
-			TargetLabel:  "NeuronDevice",
-			Regex:        relabel.MustNewRegexp("(.*)"),
-			Replacement:  "${1}",
-			Action:       relabel.Replace,
-		},
-		// hacky way to inject static values (clusterName) to label set without additional processor
-		// relabel looks up an existing label then creates another label with given key (TargetLabel) and value (static)
-		{
-			SourceLabels: model.LabelNames{"instance_id"},
-			TargetLabel:  ci.ClusterNameKey,
-			Regex:        relabel.MustNewRegexp("(.*)"),
-			Replacement:  hostinfo.GetClusterName(),
-			Action:       relabel.Replace,
-		},
-		{
-			SourceLabels: model.LabelNames{"instance_id"},
-			TargetLabel:  ci.NodeNameKey,
-			Regex:        relabel.MustNewRegexp("(.*)"),
-			Replacement:  os.Getenv("HOST_NAME"),
 			Action:       relabel.Replace,
 		},
 	}

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -190,7 +190,7 @@ func (acir *awsContainerInsightReceiver) initEKS(ctx context.Context, host compo
 			}
 		}
 
-		err = acir.initDcgmScraper(ctx, host, hostInfo, k8sDecorator)
+		err = acir.initDcgmScraper(ctx, host, hostInfo, localNodeDecorator)
 		if err != nil {
 			acir.settings.Logger.Debug("Unable to start dcgm scraper", zap.Error(err))
 		}
@@ -198,7 +198,7 @@ func (acir *awsContainerInsightReceiver) initEKS(ctx context.Context, host compo
 		if err != nil {
 			acir.settings.Logger.Debug("Unable to start pod resources store", zap.Error(err))
 		}
-		err = acir.initNeuronScraper(ctx, host, hostInfo, k8sDecorator)
+		err = acir.initNeuronScraper(ctx, host, hostInfo, localNodeDecorator)
 		if err != nil {
 			acir.settings.Logger.Debug("Unable to start neuron scraper", zap.Error(err))
 		}
@@ -286,7 +286,7 @@ func (acir *awsContainerInsightReceiver) initPrometheusScraper(ctx context.Conte
 	})
 	return err
 }
-func (acir *awsContainerInsightReceiver) initDcgmScraper(ctx context.Context, host component.Host, hostInfo *hostinfo.Info, decorator *stores.K8sDecorator) error {
+func (acir *awsContainerInsightReceiver) initDcgmScraper(ctx context.Context, host component.Host, hostInfo *hostinfo.Info, localNodeDecorator stores.Decorator) error {
 	if !acir.config.EnableAcceleratedComputeMetrics {
 		return nil
 	}
@@ -296,7 +296,7 @@ func (acir *awsContainerInsightReceiver) initDcgmScraper(ctx context.Context, ho
 		NextConsumer:          acir.nextConsumer,
 		MetricType:            ci.TypeContainerGPU,
 		MetricToUnitMap:       gpu.MetricToUnit,
-		K8sDecorator:          decorator,
+		K8sDecorator:          localNodeDecorator,
 		Logger:                acir.settings.Logger,
 	}
 
@@ -321,7 +321,7 @@ func (acir *awsContainerInsightReceiver) initPodResourcesStore() error {
 	return err
 }
 
-func (acir *awsContainerInsightReceiver) initNeuronScraper(ctx context.Context, host component.Host, hostInfo *hostinfo.Info, decorator *stores.K8sDecorator) error {
+func (acir *awsContainerInsightReceiver) initNeuronScraper(ctx context.Context, host component.Host, hostInfo *hostinfo.Info, localNodeDecorator stores.Decorator) error {
 	if !acir.config.EnableAcceleratedComputeMetrics {
 		return nil
 	}
@@ -331,7 +331,7 @@ func (acir *awsContainerInsightReceiver) initNeuronScraper(ctx context.Context, 
 		ContainerOrchestrator: ci.EKS,
 		NextConsumer:          acir.nextConsumer,
 		MetricType:            ci.TypeContainerNeuron,
-		K8sDecorator:          decorator,
+		K8sDecorator:          localNodeDecorator,
 		Logger:                acir.settings.Logger,
 	}
 
@@ -368,7 +368,7 @@ func (acir *awsContainerInsightReceiver) initNeuronScraper(ctx context.Context, 
 	return err
 }
 
-func (acir *awsContainerInsightReceiver) initEfaSysfsScraper(localnodeDecorator stores.Decorator) error {
+func (acir *awsContainerInsightReceiver) initEfaSysfsScraper(localNodeDecorator stores.Decorator) error {
 	if !acir.config.EnableAcceleratedComputeMetrics {
 		return nil
 	}
@@ -376,7 +376,7 @@ func (acir *awsContainerInsightReceiver) initEfaSysfsScraper(localnodeDecorator 
 	if acir.podResourcesStore == nil {
 		return errors.New("pod resources store was not initialized")
 	}
-	acir.efaSysfsScraper = efa.NewEfaSyfsScraper(acir.settings.Logger, localnodeDecorator, acir.podResourcesStore)
+	acir.efaSysfsScraper = efa.NewEfaSyfsScraper(acir.settings.Logger, localNodeDecorator, acir.podResourcesStore)
 	return nil
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
For some edge cases, DCGM or Neuron metrics for ContainerInsights are missing host metadata labels including `InstanceId` and/or `InstanceType`. This PR is to use localNode decorator instead `k8sDecorator` to inject those host metadata while processing metrics. 

**Testing:** 
Tested on a test cluster to verify those metadata are still coming as part of DCGM/Neuron EMF logs (some sections have been redacted)
```
{
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName"
                ],
                [
                    "ClusterName",
                    "Namespace"
                ],
                [
                    "ClusterName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName",
                    "FullPodName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName",
                    "FullPodName",
                    "GpuDevice",
                    "Namespace",
                    "PodName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "pod_gpu_power_draw",
                    "Unit": "None"
                },
                {
                    "Name": "pod_gpu_utilization",
                    "Unit": "Percent"
                },
                {
                    "Name": "pod_gpu_memory_utilization",
                    "Unit": "Percent"
                },
                {
                    "Name": "pod_gpu_memory_used",
                    "Unit": "Bytes"
                },
                {
                    "Name": "pod_gpu_memory_total",
                    "Unit": "Bytes"
                },
                {
                    "Name": "pod_gpu_temperature",
                    "Unit": "None"
                }
            ]
        }
    ],
    "ClusterName": "mixed-cluster",
    "FullPodName": "gpu-burn-6dcbd994fb-r6mxr",
    "GpuDevice": "nvidia0",
    "InstanceId": "i-0cc88415ec370ecf1",
    "InstanceType": "g4dn.12xlarge",
    "Namespace": "amazon-cloudwatch",
    "NodeName": "node",
    "PodName": "gpu-burn",
    "Sources": [
        "dcgm",
        "pod",
        "calculated"
    ],
    "Timestamp": "1729777653591",
    "Type": "PodGPU",
    "UUID": "uuid",
    "Version": "0",
    "kubernetes": {
        ...
    },
    "pod_gpu_memory_total": 16106127360,
    "pod_gpu_memory_used": 14272167936,
    "pod_gpu_memory_utilization": 90.1268,
    "pod_gpu_power_draw": 69.415,
    "pod_gpu_temperature": 34,
    "pod_gpu_utilization": 100
}
```

**Documentation:** <Describe the documentation added.>