### PR TITLE
Update `Telemetry.Agent` to `aws-opentelemetry-collector` in ApplicationSignals Processor

### DIFF
--- a/processor/awsapplicationsignalsprocessor/internal/normalizer/attributesnormalizer.go
+++ b/processor/awsapplicationsignalsprocessor/internal/normalizer/attributesnormalizer.go
@@ -175,7 +175,7 @@ func (n *AttributesNormalizer) normalizeTelemetryAttributes(attributes, resource
 	}
 	attributes.PutStr(common.MetricAttributeTelemetrySDK, fmt.Sprintf("%s,%s,%s,%s", sdkName, sdkVersion, sdkLang, mode))
 	// NOTE: In CWAgent, `opentelemetry-collector` is replaced by `CWAgent`
-	attributes.PutStr(common.MetricAttributeTelemetryAgent, fmt.Sprintf("opentelemetry-collector/%s", GetCollectorVersion()))
+	attributes.PutStr(common.MetricAttributeTelemetryAgent, fmt.Sprintf("aws-opentelemetry-collector/%s", GetCollectorVersion()))
 
 	var telemetrySource string
 	if val, ok := attributes.Get(attr.AWSSpanKind); ok {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Update `Telemetry.Agent` to `aws-opentelemetry-collector` in ApplicationSignals Processor

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

Tested with ADOT JS SDK Sample App and OCB Collector running locally to generate EMF metric:

(The version `v0.103.0` is the version of `go.opentelemetry.io/collector` module)
>`"Telemetry.Agent": "aws-opentelemetry-collector/v0.103.0"`


```
{
    "Environment": "generic:default",
    "Host": "<(removed_host_name)>",
    "Operation": "GET /http",
    "PlatformType": "Generic",
    "Service": "example-application-service-name",
    "Telemetry.Agent": "aws-opentelemetry-collector/v0.103.0",
    "Telemetry.SDK": "opentelemetry,0.3.0-dev0-aws,nodejs,Auto",
    "Telemetry.Source": "LocalRootSpan",
    "Version": "1",
    "_aws": {
        "CloudWatchMetrics": [

    ...

```

**Documentation:** <Describe the documentation added.>