### PR TITLE
Allow EKS Resolver without configured Name and Fallback Name, use Detected ClusterName when possible

### DIFF
--- a/processor/awsapplicationsignalsprocessor/config/config.go
+++ b/processor/awsapplicationsignalsprocessor/config/config.go
@@ -55,9 +55,6 @@ func (cfg *Config) Validate() error {
 	for _, resolver := range cfg.Resolvers {
 		switch resolver.Platform {
 		case PlatformEKS:
-			if resolver.Name == "" {
-				return errors.New("name must not be empty for eks resolver")
-			}
 		case PlatformK8s:
 			if resolver.Name == "" {
 				return errors.New("name must not be empty for k8s resolver")

--- a/processor/awsapplicationsignalsprocessor/config/config_test.go
+++ b/processor/awsapplicationsignalsprocessor/config/config_test.go
@@ -20,7 +20,7 @@ func TestValidatePassed(t *testing.T) {
 		},
 		{
 			"testEKSWithoutName",
-			NewEKSResolverWithoutName(),
+			NewEKSResolver(""),
 		},
 		{
 			"testK8S",

--- a/processor/awsapplicationsignalsprocessor/config/config_test.go
+++ b/processor/awsapplicationsignalsprocessor/config/config_test.go
@@ -19,6 +19,10 @@ func TestValidatePassed(t *testing.T) {
 			NewEKSResolver("test"),
 		},
 		{
+			"testEKSWithoutName",
+			NewEKSResolverWithoutName(),
+		},
+		{
 			"testK8S",
 			NewK8sResolver("test"),
 		},
@@ -60,10 +64,6 @@ func TestValidateFailedOnEmptyResolverName(t *testing.T) {
 		name     string
 		resolver Resolver
 	}{
-		{
-			"testEKS",
-			NewEKSResolver(""),
-		},
 		{
 			"testK8S",
 			NewK8sResolver(""),

--- a/processor/awsapplicationsignalsprocessor/config/resolvers.go
+++ b/processor/awsapplicationsignalsprocessor/config/resolvers.go
@@ -28,6 +28,12 @@ func NewEKSResolver(name string) Resolver {
 	}
 }
 
+func NewEKSResolverWithoutName() Resolver {
+	return Resolver{
+		Platform: PlatformEKS,
+	}
+}
+
 func NewK8sResolver(name string) Resolver {
 	return Resolver{
 		Name:     name,

--- a/processor/awsapplicationsignalsprocessor/config/resolvers.go
+++ b/processor/awsapplicationsignalsprocessor/config/resolvers.go
@@ -28,12 +28,6 @@ func NewEKSResolver(name string) Resolver {
 	}
 }
 
-func NewEKSResolverWithoutName() Resolver {
-	return Resolver{
-		Platform: PlatformEKS,
-	}
-}
-
 func NewK8sResolver(name string) Resolver {
 	return Resolver{
 		Name:     name,

--- a/processor/awsapplicationsignalsprocessor/internal/attributes/attributes.go
+++ b/processor/awsapplicationsignalsprocessor/internal/attributes/attributes.go
@@ -23,7 +23,8 @@ const (
 	AWSECSTaskID      = "aws.ecs.task.id"
 
 	// resource detection processor attributes
-	ResourceDetectionHostID   = "host.id"
-	ResourceDetectionHostName = "host.name"
-	ResourceDetectionASG      = "ec2.tag.aws:autoscaling:groupName"
+	ResourceDetectionHostID      = "host.id"
+	ResourceDetectionHostName    = "host.name"
+	ResourceDetectionASG         = "ec2.tag.aws:autoscaling:groupName"
+	ResourceDetectionClusterName = "k8s.cluster.name"
 )

--- a/processor/awsapplicationsignalsprocessor/internal/resolver/attributesresolver.go
+++ b/processor/awsapplicationsignalsprocessor/internal/resolver/attributesresolver.go
@@ -54,6 +54,9 @@ func NewAttributesResolver(resolvers []appsignalsconfig.Resolver, logger *zap.Lo
 	for _, resolver := range resolvers {
 		switch resolver.Platform {
 		case appsignalsconfig.PlatformEKS, appsignalsconfig.PlatformK8s:
+			if resolver.Name == "" {
+				resolver.Name = "UNKNOWN"
+			}
 			subResolvers = append(subResolvers, getKubernetesResolver(resolver.Platform, resolver.Name, logger), newKubernetesResourceAttributesResolver(resolver.Platform, resolver.Name))
 		case appsignalsconfig.PlatformEC2:
 			subResolvers = append(subResolvers, newResourceAttributesResolver(resolver.Platform, AttributePlatformEC2, DefaultInheritedAttributes))

--- a/processor/awsapplicationsignalsprocessor/internal/resolver/kubernetes.go
+++ b/processor/awsapplicationsignalsprocessor/internal/resolver/kubernetes.go
@@ -592,6 +592,20 @@ func newKubernetesResourceAttributesResolver(platformCode, clusterName string) *
 		attributeMap: DefaultInheritedAttributes,
 	}
 }
+
+// Attempt to get the `k8s.cluster.name“ attribute that should be populated from resourcedetectionprocessor.
+// If that attribute doesn't exist (e.g. resourcedetectionprocessor is not used or fails to get the k8s attributes),
+// fallback to the processor's configured clusterName (which is "UNKNOWN" if not specified).
+func (h *kubernetesResourceAttributesResolver) getResourceDetectorClusterName(resourceAttributes pcommon.Map) string {
+	clusterName := h.clusterName
+
+	if val, ok := resourceAttributes.Get(attr.ResourceDetectionClusterName); ok {
+		clusterName = val.Str()
+	}
+
+	return clusterName
+}
+
 func (h *kubernetesResourceAttributesResolver) Process(attributes, resourceAttributes pcommon.Map) error {
 	for attrKey, mappingKey := range h.attributeMap {
 		if val, ok := resourceAttributes.Get(attrKey); ok {
@@ -600,10 +614,10 @@ func (h *kubernetesResourceAttributesResolver) Process(attributes, resourceAttri
 	}
 	if h.platformCode == config.PlatformEKS {
 		attributes.PutStr(common.AttributePlatformType, AttributePlatformEKS)
-		attributes.PutStr(common.AttributeEKSClusterName, h.clusterName)
+		attributes.PutStr(common.AttributeEKSClusterName, h.getResourceDetectorClusterName(resourceAttributes))
 	} else {
 		attributes.PutStr(common.AttributePlatformType, AttributePlatformK8S)
-		attributes.PutStr(common.AttributeK8SClusterName, h.clusterName)
+		attributes.PutStr(common.AttributeK8SClusterName, h.getResourceDetectorClusterName(resourceAttributes))
 	}
 	var namespace string
 	if nsAttr, ok := resourceAttributes.Get(semconv.AttributeK8SNamespaceName); ok {
@@ -613,7 +627,7 @@ func (h *kubernetesResourceAttributesResolver) Process(attributes, resourceAttri
 	}
 
 	if val, ok := attributes.Get(attr.AWSLocalEnvironment); !ok {
-		env := generateLocalEnvironment(h.platformCode, h.clusterName+"/"+namespace)
+		env := generateLocalEnvironment(h.platformCode, h.getResourceDetectorClusterName(resourceAttributes)+"/"+namespace)
 		attributes.PutStr(attr.AWSLocalEnvironment, env)
 	} else {
 		attributes.PutStr(attr.AWSLocalEnvironment, val.Str())
@@ -623,7 +637,7 @@ func (h *kubernetesResourceAttributesResolver) Process(attributes, resourceAttri
 	// The application log group in Container Insights is a fixed pattern:
 	// "/aws/containerinsights/{Cluster_Name}/application"
 	// See https://github.com/aws/amazon-cloudwatch-agent-operator/blob/fe144bb02d7b1930715aa3ea32e57a5ff13406aa/helm/templates/fluent-bit-configmap.yaml#L82
-	logGroupName := "/aws/containerinsights/" + h.clusterName + "/application"
+	logGroupName := "/aws/containerinsights/" + h.getResourceDetectorClusterName(resourceAttributes) + "/application"
 	resourceAttributes.PutStr(semconv.AttributeAWSLogGroupNames, logGroupName)
 
 	return nil


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

1. In AppSignals Processor, CWAgent can configure the EKS Resolver's cluster `name`, but in OCB Collector + OTel Operator, user has to configure the EKS Resolver themselves. To minimize user configuration, we want to ensure that the configuration for the EKS Resolver's cluster `name` is optional, so we need an alternative to obtaining the cluster name.
    - To get the cluster name, the alternative method is to obtain it from the Resource Detection Processor. The detected cluster name takes precedence over a configured cluster `name`.
    - If customer doesn't use EKS Resolver and doesn't configure EKS Resolver's cluster `name`, fallback to `UNKNOWN` cluster name for EKS Resolver.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
Add unit tests to use Resource Detected Cluster Names when appropriate.

Manually tested 3 cases:
![image](https://github.com/user-attachments/assets/e2376d7f-5ddd-4435-b2d4-0a5c30ab0304)

1. Use EKS detector, which will populate the EKS Cluster Name
2. fallback to `fallback_cluster_name` when there is no EKS Resource Detector and when `Name` is configured in the configured EKS resolver
3. fallback to `UNKNOWN` when not using EKS Resource Detector and without a configured `Name` in the EKS Resolver.

Sample configuration for processors
```
    processors:
      awsapplicationsignals:
        resolvers:
          - platform: eks
            name: fallback_cluster_name

      resourcedetection:
        detectors:
          - eks
...
        eks:
          resource_attributes:
...
            k8s.cluster.name:
              enabled: true
````

**Documentation:** <Describe the documentation added.>