### PR TITLE
[Backport] Generate url section in xray segment when net.peer.name is available

### DIFF
--- a/exporter/awsxrayexporter/internal/translator/http.go
+++ b/exporter/awsxrayexporter/internal/translator/http.go
@@ -92,6 +92,7 @@ func makeHTTP(span ptrace.Span) (map[string]pcommon.Value, *awsxray.HTTPData) {
 			hasHTTPRequestURLAttributes = true
 		case conventions.AttributeNetPeerName:
 			urlParts[key] = value.Str()
+			hasHTTPRequestURLAttributes = true
 		case conventions.AttributeNetPeerPort:
 			urlParts[key] = value.Str()
 			if len(urlParts[key]) == 0 {

--- a/exporter/awsxrayexporter/internal/translator/http_test.go
+++ b/exporter/awsxrayexporter/internal/translator/http_test.go
@@ -88,6 +88,7 @@ func TestClientSpanWithPeerAttributes(t *testing.T) {
 
 	assert.NotNil(t, httpData)
 	assert.NotNil(t, filtered)
+	assert.NotNil(t, httpData.Request.URL)
 
 	assert.Equal(t, "10.8.17.36", *httpData.Request.ClientIP)
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Backport https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36530.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35375

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>