### PR TITLE
Fix prometheus-compliance-tests

### DIFF
--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Copy binary to compliance directory
         # The required name of the downloaded artifact is `otelcol_0.42.0_linux_amd64`, so we place the collector contrib artifact under the same name in the bin folder to run.
         # Source: https://github.com/prometheus/compliance/blob/12cbdf92abf7737531871ab7620a2de965fc5382/remote_write_sender/targets/otel.go#L8
-        run: mkdir compliance/remote_write_sender/bin && cp opentelemetry-collector-contrib/bin/otelcontribcol_linux_amd64 compliance/remote_write_sender/bin/otelcol_0.42.0_linux_amd64
+        run: mkdir -p compliance/remote_write_sender/bin && cp opentelemetry-collector-contrib/bin/otelcontribcol_linux_amd64 compliance/remote_write_sender/bin/otelcol_0.42.0_linux_amd64
       - name: Run compliance tests
         run: go test -v --tags=compliance -run "TestRemoteWrite/otel/.+" ./ |& tee ./test-report.txt
         working-directory: compliance/remote_write_sender


### PR DESCRIPTION
**Description:** 
Test was failing due to the following

```
 mkdir compliance/remote_write_sender/bin && cp opentelemetry-collector-contrib/bin/otelcontribcol_linux_amd64 compliance/remote_write_sender/bin/otelcol_0.42.0_linux_amd64
  shell: /usr/bin/bash -e {0}
  env:
    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
mkdir: cannot create directory ‘compliance/remote_write_sender/bin’: No such file or directory
Error: Process completed with exit code 1.
```

**Link to tracking Issue:** N/A

**Testing:**
Passes as part of this PR build