### PR TITLE
Add workflow for OCB components testing and tagging

### DIFF
--- a/.github/workflows/release-ocb-components.yml
+++ b/.github/workflows/release-ocb-components.yml
@@ -1,0 +1,137 @@
+name: Automation - Test and Create Release Tags for OCB components
+
+on:
+  workflow_dispatch:
+    inputs:
+      ocb-module-version:
+        required: true
+        description: Release Tag version (Follows OTel Collector Versioning, like 0.113.0)
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
+  E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
+  OCB_MODULE_VERSION: ${{ inputs.ocb-module-version }}
+
+jobs:
+  setup-ocb-test-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: aws-ocb-dev
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.E2E_TEST_ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
+          aws-region: us-east-1
+
+      - name: Retrieve account
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ACCOUNT_ID, otlp-region-account/gamma-us-east-1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ secrets.E2E_TEST_ROLE_NAME }}
+          aws-region: us-east-1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to private AWS ECR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
+        env:
+          AWS_REGION: us-east-1
+
+      - name: Update versions used in OCB testing
+        run: |
+          sed -i -e 's#${TEST_COMPONENT_GITHASH}#${{ github.sha }}#g' ./ocb-utils/builder-config-appsignals.yaml
+          sed -i -e 's#${OCB_VERSION}#${{ env.OCB_MODULE_VERSION }}#g' ./ocb-utils/builder-config-appsignals.yaml
+          sed -i -e 's#${OCB_VERSION}#${{ env.OCB_MODULE_VERSION }}#g' ./ocb-utils/Dockerfile
+
+      - name: Build and push image with latest git hash as tag
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          context: ./ocb-utils/
+          file: ./ocb-utils/Dockerfile
+          platforms: linux/amd64
+          tags: ${{ env.ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/ocb-release-test-collector:${{ github.sha }}
+          load: false
+          cache-from: type=gha,scope=build-${{ github.ref_name }}-ocb
+          cache-to: type=gha,scope=build-${{ github.ref_name }}-ocb
+
+  ocb-e2e-test:
+    secrets: inherit
+    needs: [ setup-ocb-test-image ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-eks-otlp-ocb-test.yml@main
+    with:
+      aws-region: us-east-1
+      test-cluster-name: 'e2e-otel-collector-contrib-release-test'
+      caller-workflow-name: 'appsignals-java-e2e-eks-otlp-ocb-release-test'
+      java-version: '11'
+      e2e-otel-collector-image-tag: ${{ github.sha }}
+
+  update-canary-image-and-tag-release:
+    runs-on: ubuntu-latest
+    needs: [ ocb-e2e-test ]
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: aws-ocb-dev
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.E2E_TEST_ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
+          aws-region: us-east-1
+
+      - name: Retrieve account
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ACCOUNT_ID, otlp-region-account/gamma-us-east-1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ secrets.E2E_TEST_ROLE_NAME }}
+          aws-region: us-east-1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to private AWS ECR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
+        env:
+          AWS_REGION: us-east-1
+
+      - name: Build and push image with latest tag
+        run: |
+          docker image pull ${{ env.ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/ocb-release-test-collector:${{ github.sha }}
+          docker tag ${{ env.ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/ocb-release-test-collector:${{ github.sha }} ${{ env.ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/ocb-release-test-collector:latest
+          docker push ${{ env.ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/ocb-release-test-collector:latest
+
+      # - name: Tag OCB modules
+      #   run: |
+      #     git tag internal/aws/cwlogs/v${{ env.OCB_MODULE_VERSION }}
+      #     git tag internal/aws/awsutil/v${{ env.OCB_MODULE_VERSION }}
+      #     git tag exporter/awsemfexporter/v${{ env.OCB_MODULE_VERSION }}
+      #     git tag processor/awsapplicationsignalsprocessor/v${{ env.OCB_MODULE_VERSION }}
+
+      # - name: Publish tags for OCB modules
+      #   run: git push --tags

--- a/ocb-utils/Dockerfile
+++ b/ocb-utils/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:latest AS prep
+RUN apk --update add ca-certificates
+
+FROM public.ecr.aws/docker/library/golang:1.23.2 AS build
+
+WORKDIR /tmp/build/
+RUN go env -w GOPROXY=direct
+RUN curl --proto '=https' --tlsv1.2 -fL -o ocb https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/cmd%2Fbuilder%2Fv${OCB_VERSION}/ocb_${OCB_VERSION}_linux_amd64
+
+RUN chmod +x ocb
+
+
+COPY builder-config-appsignals.yaml .
+
+RUN --mount=type=cache,target=/go/pkg/mod ./ocb --config builder-config-appsignals.yaml
+
+FROM public.ecr.aws/amazonlinux/amazonlinux:minimal
+
+ARG USER_UID=10001
+USER ${USER_UID}
+
+COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build /tmp/build/otelcol-appsignals/otelcol-appsignals /
+
+WORKDIR /
+
+EXPOSE 4317 4318 13133 2000 4316 4315 55680 55679
+ENTRYPOINT ["/otelcol-appsignals"]
+CMD ["--config", "/etc/otel/config.yaml"]

--- a/ocb-utils/builder-config-appsignals.yaml
+++ b/ocb-utils/builder-config-appsignals.yaml
@@ -1,0 +1,23 @@
+
+dist:
+  name: otelcol-appsignals
+  description: OTel Collector for Application Signals
+  output_path: ./otelcol-appsignals
+exporters:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v${OCB_VERSION}
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v${OCB_VERSION}
+processors:
+  - gomod: github.com/amazon-contributing/opentelemetry-collector-contrib/processor/awsapplicationsignalsprocessor ${TEST_COMPONENT_GITHASH}
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v${OCB_VERSION}
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v${OCB_VERSION}
+receivers:
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v${OCB_VERSION}
+extensions:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy v${OCB_VERSION}
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v${OCB_VERSION}
+replaces:
+  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v${OCB_VERSION} => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/awsutil ${TEST_COMPONENT_GITHASH}
+  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs v${OCB_VERSION} => github.com/amazon-contributing/opentelemetry-collector-contrib/internal/aws/cwlogs ${TEST_COMPONENT_GITHASH}
+  - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v${OCB_VERSION} => github.com/amazon-contributing/opentelemetry-collector-contrib/exporter/awsemfexporter ${TEST_COMPONENT_GITHASH}
+  - github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api v0.0.0-20180801171038-322a19404e37
+


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Add workflow with 3 jobs:
1. setup-ocb-test-image
    - Update Dockerfile with sed to use correct version of OCB
    - Update OCB Builder Config with sed to use correct version of OTel Collector and correct hash of OCB components
    - Build OTel Collector Image and Push image to private ECR tagged with current github.sha
2. ocb-e2e-test
    - Run `otlp-ocb` test from `aws-observability/aws-application-signals-test-framework`
3. update-canary-image-and-tag-release
    - Update previous pushed image to also be tagged with `latest`
    - Tag and push tags of latest release (currently commented out to test workflow without tagging)

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
https://github.com/jj22ee/opentelemetry-collector-contrib/actions/runs/12166249281/job/33932528121
(Pending `otlp-ocb` test workflow to be merged into `aws-observability/aws-application-signals-test-framework`)

**Documentation:** <Describe the documentation added.>