### PR TITLE
Remove internal entity fields for awsemfexporter

### DIFF
--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -18,6 +19,8 @@ import (
 )
 
 const (
+	AWSEntityPrefix = "com.amazonaws.cloudwatch.entity.internal."
+
 	summaryCountSuffix = "_count"
 	summarySumSuffix   = "_sum"
 )
@@ -531,6 +534,11 @@ func (dps summaryDataPointSlice) IsStaleNaNInf(i int) (bool, pcommon.Map) {
 func createLabels(attributes pcommon.Map) map[string]string {
 	labels := make(map[string]string, attributes.Len()+1)
 	attributes.Range(func(k string, v pcommon.Value) bool {
+		// we don't want to export entity related attributes as dimensions, so we skip these
+		if strings.HasPrefix(k, AWSEntityPrefix) {
+			return true
+		}
+
 		labels[k] = v.AsString()
 		return true
 	})

--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -1940,6 +1940,7 @@ func TestCreateLabels(t *testing.T) {
 		"a": "A",
 		"b": "B",
 		"c": "C",
+		"com.amazonaws.cloudwatch.entity.internal.A": "A",
 	}))
 
 	labels := createLabels(labelsMap)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

As a part of adding the entity processor to our OTLP pipeline, we were suddenly emitting metrics that had our internal entity fields as additional dimensions. 

The change is to stop creating labels if the the attribute is prefixed with `com.amazonaws.cloudwatch.entity.internal.`. This change is extremely similar to that found in https://github.com/aws/amazon-cloudwatch-agent/blob/main/plugins/outputs/cloudwatch/convert_otel.go#L27-L29

**Testing:**
1. Unit testing
2. Manual E2E testing

## Manual Testing

**Before the change**
<img width="810" alt="image" src="https://github.com/user-attachments/assets/485e9470-0a83-4e51-be9f-d951e14e01bd" />


**After the change**
<img width="645" alt="image" src="https://github.com/user-attachments/assets/d47a07cd-c785-4ddf-92b9-3ec6c13b65cf" />
