### PR TITLE
use endpoints discovery to find all available control plane nodes

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
@@ -11,10 +11,12 @@ import (
 	"strings"
 	"time"
 
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
 	configutil "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/kubernetes"
 	"github.com/prometheus/prometheus/model/relabel"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -70,6 +72,7 @@ type PrometheusScraperOpts struct {
 	Ctx                 context.Context
 	TelemetrySettings   component.TelemetrySettings
 	Endpoint            string
+	EndpointAddresses   []string
 	Consumer            consumer.Metrics
 	Host                component.Host
 	ClusterNameProvider clusterNameProvider
@@ -107,24 +110,24 @@ func NewPrometheusScraper(opts PrometheusScraperOpts) (*PrometheusScraper, error
 		ScrapeInterval:  model.Duration(collectionInterval),
 		ScrapeTimeout:   model.Duration(collectionInterval),
 		ScrapeProtocols: config.DefaultScrapeProtocols,
-		JobName:         fmt.Sprintf("%s/%s", jobName, opts.Endpoint),
+		JobName:         fmt.Sprintf("%s/%s", jobName, kubernetes.RoleEndpoint),
 		HonorTimestamps: true,
 		Scheme:          "https",
 		MetricsPath:     "/metrics",
 		ServiceDiscoveryConfigs: discovery.Configs{
-			&discovery.StaticConfig{
-				{
-					Targets: []model.LabelSet{
-						{
-							model.AddressLabel: model.LabelValue(opts.Endpoint),
-							"ClusterName":      model.LabelValue(opts.ClusterNameProvider.GetClusterName()),
-							"Version":          model.LabelValue("0"),
-							"Sources":          model.LabelValue("[\"apiserver\"]"),
-							"NodeName":         model.LabelValue(os.Getenv("HOST_NAME")),
-							"Type":             model.LabelValue("ControlPlane"),
-						},
-					},
+			&kubernetes.SDConfig{
+				Role: kubernetes.RoleEndpoint,
+				NamespaceDiscovery: kubernetes.NamespaceDiscovery{
+					Names: []string{"default"},
 				},
+			},
+		},
+		RelabelConfigs: []*relabel.Config{
+			{
+				SourceLabels: model.LabelNames{"__meta_kubernetes_endpoints_name", "__meta_kubernetes_endpoint_port_name"},
+				Regex:        relabel.MustNewRegexp("kubernetes;https"),
+				Separator:    ";",
+				Action:       relabel.Keep,
 			},
 		},
 		MetricRelabelConfigs: []*relabel.Config{
@@ -134,7 +137,7 @@ func NewPrometheusScraper(opts PrometheusScraperOpts) (*PrometheusScraper, error
 				Regex:        relabel.MustNewRegexp(controlPlaneMetricsAllowRegex),
 				Action:       relabel.Keep,
 			},
-			// type conflicts with the log Type in the container insights output format, it needs to be replaced and dropped
+			//type conflicts with the log Type in the container insights output format, it needs to be replaced and dropped
 			{
 				Regex:       relabel.MustNewRegexp("^type$"),
 				Replacement: "kubernetes_type",
@@ -143,6 +146,42 @@ func NewPrometheusScraper(opts PrometheusScraperOpts) (*PrometheusScraper, error
 			{
 				Regex:  relabel.MustNewRegexp("^type$"),
 				Action: relabel.LabelDrop,
+			},
+			// default labels set
+			{
+				SourceLabels: model.LabelNames{"__meta_kubernetes_namespace"},
+				TargetLabel:  ci.ClusterNameKey,
+				Regex:        relabel.MustNewRegexp(".*"),
+				Replacement:  opts.ClusterNameProvider.GetClusterName(),
+				Action:       relabel.Replace,
+			},
+			{
+				SourceLabels: model.LabelNames{"__meta_kubernetes_namespace"},
+				TargetLabel:  ci.Version,
+				Regex:        relabel.MustNewRegexp(".*"),
+				Replacement:  "0",
+				Action:       relabel.Replace,
+			},
+			{
+				SourceLabels: model.LabelNames{"__meta_kubernetes_namespace"},
+				TargetLabel:  ci.SourcesKey,
+				Regex:        relabel.MustNewRegexp(".*"),
+				Replacement:  "[\"apiserver\"]",
+				Action:       relabel.Replace,
+			},
+			{
+				SourceLabels: model.LabelNames{"__meta_kubernetes_namespace"},
+				TargetLabel:  ci.NodeNameKey,
+				Regex:        relabel.MustNewRegexp(".*"),
+				Replacement:  os.Getenv("HOST_NAME"),
+				Action:       relabel.Replace,
+			},
+			{
+				SourceLabels: model.LabelNames{"__meta_kubernetes_namespace"},
+				TargetLabel:  "Type",
+				Regex:        relabel.MustNewRegexp(".*"),
+				Replacement:  "ControlPlane",
+				Action:       relabel.Replace,
 			},
 		},
 	}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Currently, ContainerInsights uses a static target discovery mechanism when initializing Prometheus scraping configuration for the control plane. This approach leverages a cluster IP for the k8s service that points to the control plane nodes, causing traffic to be load balanced to only one available control plane node. As a result, the agent only fetches data from a single node, leading to incomplete metrics collection.

This PR addresses the issue by updating the Prometheus configuration for the control plane to use endpoint discovery instead. This native Prometheus mechanism queries endpoints (e.g., `kubernetes` endpoint in the `default` namespace for the control plane) and creates targets for each IP associated with the endpoint (per port). Consequently, the agent will scrape control plane metrics from all nodes. Additionally, in the event of a control plane scale-up, endpoint discovery will automatically detect newly added nodes and begin scraping metrics from them as new targets.

**Changes:**
- Change `staticConfig` to k8s endpoints discovery in scraping configuration for CP
- Add default labels including `ClusterName` `Sources` `NodeName`  `Type` and `Version`

**Testing:** <Describe what testing was performed and which tests were added.>
Attached screenshot demonstrating that the sum of the `apiserver_request_total` metrics scraped by the agent now matches the aggregated values reported by EKS vended metrics. This confirms that our new endpoint discovery mechanism is correctly capturing data from all control plane nodes. 

<img width="1253" alt="Screenshot 2025-02-03 at 10 07 12 AM" src="https://github.com/user-attachments/assets/0ea172f1-5a6f-4faf-b3ac-0c8c82fb10f0" />


**Documentation:** <Describe the documentation added.>