### PR TITLE
fix url in tracing

### DIFF
--- a/exporter/awsxrayexporter/internal/translator/http.go
+++ b/exporter/awsxrayexporter/internal/translator/http.go
@@ -72,7 +72,7 @@ func makeHTTP(span ptrace.Span) (map[string]pcommon.Value, *awsxray.HTTPData) {
 			urlParts[key] = value.Str()
 			hasHTTP = true
 			hasHTTPRequestURLAttributes = true
-		case conventions.AttributeHTTPTarget, AttributeURLQuery:
+		case conventions.AttributeHTTPTarget:
 			urlParts[conventions.AttributeHTTPTarget] = value.Str()
 			hasHTTP = true
 		case conventions.AttributeHTTPServerName:

--- a/exporter/awsxrayexporter/internal/translator/http_test.go
+++ b/exporter/awsxrayexporter/internal/translator/http_test.go
@@ -78,7 +78,6 @@ func TestClientSpanWithSchemeHostTargetAttributesStable(t *testing.T) {
 	attributes[AttributeHTTPRequestMethod] = "GET"
 	attributes[AttributeURLScheme] = "https"
 	attributes[conventions.AttributeHTTPHost] = "api.example.com"
-	attributes[AttributeURLQuery] = "/users/junit"
 	attributes[AttributeHTTPResponseStatusCode] = 200
 	attributes["user.id"] = "junit"
 	span := constructHTTPClientSpan(attributes)
@@ -91,7 +90,7 @@ func TestClientSpanWithSchemeHostTargetAttributesStable(t *testing.T) {
 	require.NoError(t, w.Encode(httpData))
 	jsonStr := w.String()
 	testWriters.release(w)
-	assert.Contains(t, jsonStr, "https://api.example.com/users/junit")
+	assert.Contains(t, jsonStr, "https://api.example.com/")
 }
 
 func TestClientSpanWithPeerAttributes(t *testing.T) {
@@ -127,7 +126,6 @@ func TestClientSpanWithPeerAttributesStable(t *testing.T) {
 	attributes[conventions.AttributeNetPeerName] = "kb234.example.com"
 	attributes[conventions.AttributeNetPeerPort] = 8080
 	attributes[conventions.AttributeNetPeerIP] = "10.8.17.36"
-	attributes[AttributeURLQuery] = "/users/junit"
 	attributes[AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPClientSpan(attributes)
 
@@ -142,7 +140,7 @@ func TestClientSpanWithPeerAttributesStable(t *testing.T) {
 	require.NoError(t, w.Encode(httpData))
 	jsonStr := w.String()
 	testWriters.release(w)
-	assert.Contains(t, jsonStr, "http://kb234.example.com:8080/users/junit")
+	assert.Contains(t, jsonStr, "http://kb234.example.com:8080/")
 }
 
 func TestClientSpanWithHttpPeerAttributes(t *testing.T) {
@@ -278,7 +276,7 @@ func TestServerSpanWithSchemeHostTargetAttributesStable(t *testing.T) {
 	attributes[AttributeHTTPRequestMethod] = http.MethodGet
 	attributes[AttributeURLScheme] = "https"
 	attributes[AttributeServerAddress] = "api.example.com"
-	attributes[AttributeURLQuery] = "/users/junit"
+	attributes[AttributeURLPath] = "/users/junit"
 	attributes[AttributeClientAddress] = "192.168.15.32"
 	attributes[AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
@@ -322,7 +320,7 @@ func TestServerSpanWithSchemeServernamePortTargetAttributesStable(t *testing.T) 
 	attributes[AttributeURLScheme] = "https"
 	attributes[AttributeServerAddress] = "api.example.com"
 	attributes[AttributeServerPort] = 443
-	attributes[AttributeURLQuery] = "/users/junit"
+	attributes[AttributeURLPath] = "/users/junit"
 	attributes[AttributeClientAddress] = "192.168.15.32"
 	attributes[AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The previous [PR](https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/267) introduced a regression for the `url` attribute inside `http.request` in the traces. 

Before the change, we have this:
```
"http": {
  "request": {
     "url": "http://main-app-service.sample-app-namespace.svc.cluster.local:8080/test",
     "method": "GET",
     "user_agent": "curl/8.3.0"
}
```
The url is the host+port+url_path

After the change, we have
```
"http": {
  "request": {
     "url": "http://main-app-service.sample-app-namespace.svc.cluster.local:8080?testingId=xxxx",
     "method": "GET",
     "user_agent": "curl/8.3.0"
}
```
The url is the host+port+url_query


In this commit, we want to recover the old behavior and use the url_path (rather than url_query) at the end. 



<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit tests.

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
