### PR TITLE
Fix bad merge that changes our logic to discard non metric log events…

### DIFF
--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -455,12 +455,8 @@ func translateCWMetricToEMF(cWMetric *cWMetrics, config *Config) (*cwlogs.Event,
 				"CloudWatchMetrics": cWMetric.measurements,
 				"Timestamp":         cWMetric.timestampMs,
 			}
-		}
-	}
 
-	if config.Version == "0" {
-		fieldMap["Timestamp"] = fmt.Sprint(cWMetric.timestampMs)
-		if len(cWMetric.measurements) > 0 {
+		} else {
 			/* 	EMF V0
 				{
 					"Version": "0",

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -455,7 +455,6 @@ func translateCWMetricToEMF(cWMetric *cWMetrics, config *Config) (*cwlogs.Event,
 				"CloudWatchMetrics": cWMetric.measurements,
 				"Timestamp":         cWMetric.timestampMs,
 			}
-
 		} else {
 			/* 	EMF V0
 				{


### PR DESCRIPTION
… for Enhanced CI

#### Description
As part https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/268, we accidentally modified the logic such that we no longer discard log events without any metrics for Enhanced CI. Hence we started to emit new log events that previously were not being emitted.
Example log event:
```
{
  "ClusterName": "cwagent-eks-integ-ddd16a5ab68e7d10",
  "ContainerName": "main",
  "DCGM_FI_DEV_FB_FREE": 1,
  "DCGM_FI_DEV_FB_TOTAL": 1,
  "DCGM_FI_DEV_FB_USED": 1,
  "DCGM_FI_DEV_FB_USED_PERCENT": 1,
  "DCGM_FI_DEV_GPU_TEMP": 1,
  "DCGM_FI_DEV_GPU_UTIL": 1,
  "DCGM_FI_DEV_POWER_USAGE": 1,
  "FullPodName": "pod1-hash",
  "GpuDevice": "nvidia0",
  "Hostname": "ip-172-31-10-40.us-west-2.compute.internal",
  "InstanceId": "i-024a202d50a871fd9",
  "InstanceType": "t3.medium",
  "K8sPodName": "pod1-hash",
  "Namespace": "amazon-cloudwatch",
  "NodeName": "ip-172-31-10-40.us-west-2.compute.internal",
  "PodName": "pod1",
  "Timestamp": "1740433809643",
  "UUID": "uuid0",
  "Version": "0",
  "container": "main",
  "device": "nvidia0",
  "gpu": "0",
  "modelName": "Tesla T4",
  "namespace": "amazon-cloudwatch",
  "pod": "pod1-hash"
}
```
<!--Describe what testing was performed and which tests were added.-->
#### Testing
* Updated unit tests
* Tested on a cluster locally to ensure the additional log events are no longer being published.