### PR TITLE
Add ability to automatically use all labels as dimensions for Prometheus

### DIFF
--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -36,12 +36,16 @@ type Config struct {
 	// The default behavior is that the first value occurrence of a metric is set as the baseline for the calculation of
 	// the delta to the next occurrence. With this flag set to true the exporter will instead use this first value as the
 	// initial delta value. This is especially useful when handling low frequency metrics.
+
 	RetainInitialValueOfDeltaMetric bool `mapstructure:"retain_initial_value_of_delta_metric"`
 	// DimensionRollupOption is the option for metrics dimension rollup. Three options are available, default option is "ZeroAndSingleDimensionRollup".
 	// "ZeroAndSingleDimensionRollup" - Enable both zero dimension rollup and single dimension rollup
 	// "SingleDimensionRollupOnly" - Enable single dimension rollup
 	// "NoDimensionRollup" - No dimension rollup (only keep original metrics which contain all dimensions)
 	DimensionRollupOption string `mapstructure:"dimension_rollup_option"`
+
+	// UseAllLabelsAsDimensions is the flag to indicate all labels should be used as dimensions if the dimensions MetricDeclaration is nil. Default is "false", is only set to "true" for Prometheus
+	UseAllLabelsAsDimensions bool `mapstructure:"use_all_labels_as_dimensions"`
 
 	// LogRetention is the option to set the log retention policy for the CloudWatch Log Group. Defaults to Never Expire if not specified or set to 0
 	// Possible values are 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 2192, 2557, 2922, 3288, or 3653

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -380,6 +380,14 @@ func groupedMetricToCWMeasurementsWithFilters(groupedMetric *groupedMetric, conf
 		// De-duplicate dimensions
 		dimensions = dedupDimensions(dimensions)
 
+		if config.UseAllLabelsAsDimensions && dimensions == nil {
+			var dims []string
+			for key := range labels {
+				dims = append(dims, key)
+			}
+			dimensions = [][]string{dims}
+		}
+
 		// Export metrics only with non-empty dimensions list
 		if len(dimensions) > 0 {
 			cwm := cWMeasurement{

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -1737,6 +1737,15 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			{
+				MetricNameSelectors: []string{"metric.*"},
+				LabelMatchers: []*LabelMatcher{
+					{
+						LabelNames: []string{"a", "b"},
+						Regex:      "A;C",
+					},
+				},
+			},
+			{
 				Dimensions:          [][]string{{"b"}, {"b", "d"}},
 				MetricNameSelectors: []string{"metric.*"},
 				LabelMatchers: []*LabelMatcher{
@@ -1856,11 +1865,12 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 	metricName := "metric1"
 	instrLibName := "cloudwatch-otel"
 	rollupTestCases := []struct {
-		testName              string
-		labels                map[string]string
-		metricDeclarations    []*MetricDeclaration
-		dimensionRollupOption string
-		expectedDims          [][]string
+		testName                 string
+		labels                   map[string]string
+		metricDeclarations       []*MetricDeclaration
+		dimensionRollupOption    string
+		UseAllLabelsAsDimensions bool
+		expectedDims             [][]string
 	}{
 		{
 			"Single label w/ no rollup",
@@ -1875,6 +1885,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			"",
+			false,
 			[][]string{{"a"}},
 		},
 		{
@@ -1890,6 +1901,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			"",
+			false,
 			[][]string{{"a", oTellibDimensionKey}},
 		},
 		{
@@ -1905,6 +1917,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			singleDimensionRollupOnly,
+			false,
 			[][]string{{"a"}, {"a", oTellibDimensionKey}},
 		},
 		{
@@ -1920,6 +1933,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			[][]string{{"a"}, {"a", oTellibDimensionKey}, {oTellibDimensionKey}},
 		},
 		{
@@ -1935,6 +1949,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			[][]string{{"a", oTellibDimensionKey}, {oTellibDimensionKey}},
 		},
 		{
@@ -1951,6 +1966,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			"",
+			false,
 			[][]string{{"a"}},
 		},
 		{
@@ -1967,6 +1983,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			[][]string{
 				{"a"},
 				{oTellibDimensionKey, "a"},
@@ -1988,6 +2005,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			"",
+			false,
 			[][]string{{"a", "b"}, {"b"}},
 		},
 		{
@@ -2004,6 +2022,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			"",
+			false,
 			[][]string{{"a", "b"}, {"b", oTellibDimensionKey}, {oTellibDimensionKey}},
 		},
 		{
@@ -2020,6 +2039,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			[][]string{
 				{"a", "b"},
 				{"b"},
@@ -2042,6 +2062,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			[][]string{
 				{"b"},
 				{oTellibDimensionKey, "a"},
@@ -2064,6 +2085,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			[][]string{
 				{"a", "b"},
 				{"b"},
@@ -2071,6 +2093,24 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				{oTellibDimensionKey, "b"},
 				{oTellibDimensionKey, "c"},
 				{oTellibDimensionKey},
+			},
+		},
+		{
+			"multiple labels, prometheus, no dimensions set",
+			map[string]string{
+				"a": "foo",
+				"b": "bar",
+				"c": "car",
+			},
+			[]*MetricDeclaration{
+				{
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			"",
+			true,
+			[][]string{
+				{"a", "b", "c"},
 			},
 		},
 		{
@@ -2096,6 +2136,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			"",
+			false,
 			[][]string{
 				{"a", "b"},
 				{"b"},
@@ -2127,6 +2168,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			[][]string{
 				{"a", "b"},
 				{"b"},
@@ -2158,6 +2200,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			"",
+			false,
 			[][]string{
 				{"a", "b"},
 				{"b"},
@@ -2182,6 +2225,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			"",
+			false,
 			nil,
 		},
 		{
@@ -2194,6 +2238,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			nil,
 		},
 		{
@@ -2206,6 +2251,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			[][]string{{}},
 		},
 	}
@@ -2232,9 +2278,10 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			config := &Config{
-				DimensionRollupOption: tc.dimensionRollupOption,
-				MetricDeclarations:    tc.metricDeclarations,
-				logger:                zap.NewNop(),
+				DimensionRollupOption:    tc.dimensionRollupOption,
+				MetricDeclarations:       tc.metricDeclarations,
+				logger:                   zap.NewNop(),
+				UseAllLabelsAsDimensions: tc.UseAllLabelsAsDimensions,
 			}
 
 			cWMeasurements := groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)


### PR DESCRIPTION
#### Description

Currently, in the event the application exposes a new label, the customer must explicitly include the new label in "dimensions" and update configuration to make that new label available in CloudWatch Metrics.

#### Details

For Prometheus metrics, customers can leave `dimensions` off of the  `metric_declaration` object, and receive all available dimensions.


Current
```
    {
      "logs": {
        "credentials": {
          "role_arn": "arn..."
        },
        "metrics_collected": {
          "prometheus": {
            "prometheus_config_path": "/etc/prometheusconfig/prometheus.yaml",
            "emf_processor": {
              "metric_declaration": [
                {
                  "source_labels": [
                    "job"
                  ],
                  "label_matcher": "(kubernetes-apiservers|rdi-metric-exporter|kube-state-metrics)",
                  "dimensions": [
                    [
                      "ClusterName",
                      "Service"
                    ]
                  ],
                  "metric_selectors": [
                    ".*"
                  ]
                }
              ]
            }
          }
        },
        "force_flush_interval": 5
      }
    }
```

New
```
    {
      "logs": {
        "credentials": {
          "role_arn": "arn:aws:iam::939706305709:role/AWSCloudWatchRoleToBeAssumed"
        },
        "metrics_collected": {
          "prometheus": {
            "prometheus_config_path": "/etc/prometheusconfig/prometheus.yaml",
            "emf_processor": {
              "metric_declaration": [
                {
                  "source_labels": [
                    "job"
                  ],
                  "label_matcher": "(kubernetes-apiservers|rdi-metric-exporter|kube-state-metrics)",
                  "metric_selectors": [
                    ".*"
                  ]
                }
              ]
            }
          }
        },
        "force_flush_interval": 5
      }
    }
```

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
