### PR TITLE
Add ability to automatically use all labels as dimensions for Prometheus

### DIFF
--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -37,11 +37,16 @@ type Config struct {
 	// the delta to the next occurrence. With this flag set to true the exporter will instead use this first value as the
 	// initial delta value. This is especially useful when handling low frequency metrics.
 	RetainInitialValueOfDeltaMetric bool `mapstructure:"retain_initial_value_of_delta_metric"`
+
 	// DimensionRollupOption is the option for metrics dimension rollup. Three options are available, default option is "ZeroAndSingleDimensionRollup".
 	// "ZeroAndSingleDimensionRollup" - Enable both zero dimension rollup and single dimension rollup
 	// "SingleDimensionRollupOnly" - Enable single dimension rollup
 	// "NoDimensionRollup" - No dimension rollup (only keep original metrics which contain all dimensions)
 	DimensionRollupOption string `mapstructure:"dimension_rollup_option"`
+
+	// UseAllLabelsAsDimensions is a boolean flag indicating all labels should be used as dimensions.  This option is only used if the dimensions array is empty.
+	// This flag defaults to "false".  Only set to true for Prometheus
+	UseAllLabelsAsDimensions bool `mapstructure:"use_all_labels_as_dimensions"`
 
 	// LogRetention is the option to set the log retention policy for the CloudWatch Log Group. Defaults to Never Expire if not specified or set to 0
 	// Possible values are 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 2192, 2557, 2922, 3288, or 3653

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -399,6 +399,14 @@ func groupedMetricToCWMeasurementsWithFilters(groupedMetric *groupedMetric, conf
 		// De-duplicate dimensions
 		dimensions = dedupDimensions(dimensions)
 
+		if config.UseAllLabelsAsDimensions && dimensions == nil && len(labels) > 0 {
+			var dims []string
+			for key := range labels {
+				dims = append(dims, key)
+			}
+			dimensions = [][]string{dims}
+		}
+
 		// Export metrics only with non-empty dimensions list
 		if len(dimensions) > 0 {
 			cwm := cWMeasurement{

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -1857,11 +1857,12 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 	metricName := "metric1"
 	instrLibName := "cloudwatch-otel"
 	rollupTestCases := []struct {
-		testName              string
-		labels                map[string]string
-		metricDeclarations    []*MetricDeclaration
-		dimensionRollupOption string
-		expectedDims          [][]string
+		testName                 string
+		labels                   map[string]string
+		metricDeclarations       []*MetricDeclaration
+		dimensionRollupOption    string
+		UseAllLabelsAsDimensions bool
+		expectedDims             [][]string
 	}{
 		{
 			"Single label w/ no rollup",
@@ -1876,6 +1877,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			"",
+			false,
 			[][]string{{"a"}},
 		},
 		{
@@ -1891,6 +1893,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			"",
+			false,
 			[][]string{{"a", oTellibDimensionKey}},
 		},
 		{
@@ -1906,6 +1909,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			singleDimensionRollupOnly,
+			false,
 			[][]string{{"a"}, {"a", oTellibDimensionKey}},
 		},
 		{
@@ -1921,6 +1925,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			[][]string{{"a"}, {"a", oTellibDimensionKey}, {oTellibDimensionKey}},
 		},
 		{
@@ -1936,6 +1941,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			[][]string{{"a", oTellibDimensionKey}, {oTellibDimensionKey}},
 		},
 		{
@@ -1952,6 +1958,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			"",
+			false,
 			[][]string{{"a"}},
 		},
 		{
@@ -1968,6 +1975,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			[][]string{
 				{"a"},
 				{oTellibDimensionKey, "a"},
@@ -1989,6 +1997,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			"",
+			false,
 			[][]string{{"a", "b"}, {"b"}},
 		},
 		{
@@ -2005,6 +2014,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			"",
+			false,
 			[][]string{{"a", "b"}, {"b", oTellibDimensionKey}, {oTellibDimensionKey}},
 		},
 		{
@@ -2021,6 +2031,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			[][]string{
 				{"a", "b"},
 				{"b"},
@@ -2043,6 +2054,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			[][]string{
 				{"b"},
 				{oTellibDimensionKey, "a"},
@@ -2065,6 +2077,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			[][]string{
 				{"a", "b"},
 				{"b"},
@@ -2097,6 +2110,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			"",
+			false,
 			[][]string{
 				{"a", "b"},
 				{"b"},
@@ -2128,6 +2142,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			[][]string{
 				{"a", "b"},
 				{"b"},
@@ -2159,6 +2174,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			"",
+			false,
 			[][]string{
 				{"a", "b"},
 				{"b"},
@@ -2183,6 +2199,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			"",
+			false,
 			nil,
 		},
 		{
@@ -2195,6 +2212,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			nil,
 		},
 		{
@@ -2207,7 +2225,71 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				},
 			},
 			zeroAndSingleDimensionRollup,
+			false,
 			[][]string{{}},
+		},
+		{
+			"no labels, UseAllLabelsAsDimensions true",
+			map[string]string{},
+			[]*MetricDeclaration{
+				{
+					Dimensions:          [][]string{{"a", "b", "c"}, {"b"}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			"",
+			true,
+			nil,
+		},
+		{
+			"no labels, empty dimension, UseAllLabelsAsDimensions true",
+			map[string]string{},
+			[]*MetricDeclaration{
+				{
+					Dimensions:          [][]string{{}, {"a"}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			"",
+			true,
+			[][]string{{}},
+		},
+		{
+			"multiple labels, empty dimension, UseAllLabelsAsDimensions true",
+			map[string]string{
+				"a": "foo",
+				"b": "bar",
+				"c": "car",
+			},
+			[]*MetricDeclaration{
+				{
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			"",
+			true,
+			[][]string{
+				{"a", "b", "c"},
+			},
+		},
+		{
+			"multiple labels, empty dimension, UseAllLabelsAsDimensions true",
+			map[string]string{
+				"a":                   "foo",
+				"b":                   "bar",
+				"c":                   "car",
+				(oTellibDimensionKey): instrLibName,
+			},
+			[]*MetricDeclaration{
+				{
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			"",
+			true,
+			[][]string{
+				{"a", "b", "c", oTellibDimensionKey},
+			},
 		},
 	}
 
@@ -2233,9 +2315,10 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			config := &Config{
-				DimensionRollupOption: tc.dimensionRollupOption,
-				MetricDeclarations:    tc.metricDeclarations,
-				logger:                zap.NewNop(),
+				DimensionRollupOption:    tc.dimensionRollupOption,
+				MetricDeclarations:       tc.metricDeclarations,
+				logger:                   zap.NewNop(),
+				UseAllLabelsAsDimensions: tc.UseAllLabelsAsDimensions,
 			}
 
 			cWMeasurements := groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)


### PR DESCRIPTION
#### Description

Currently, in the event the application exposes a new label, the customer must explicitly include the new label in "dimensions" and update configuration to make that new label available in CloudWatch Metrics.

This change allows customers using Prometheus to leave `dimensions` off of `metric_declaration` and receive all available dimensions.


Current
```
    {
      "logs": {
        "credentials": {
          "role_arn": "arn..."
        },
        "metrics_collected": {
          "prometheus": {
            "prometheus_config_path": "/etc/prometheusconfig/prometheus.yaml",
            "emf_processor": {
              "metric_declaration": [
                {
                  "source_labels": [
                    "job"
                  ],
                  "label_matcher": "(kubernetes-apiservers|rdi-metric-exporter|kube-state-metrics)",
                  "dimensions": [
                    [
                      "ClusterName",
                      "Service"
                    ]
                  ],
                  "metric_selectors": [
                    ".*"
                  ]
                }
              ]
            }
          }
        },
        "force_flush_interval": 5
      }
    }
```

New
```
    {
      "logs": {
        "credentials": {
          "role_arn": "arn:aws:iam::939706305709:role/AWSCloudWatchRoleToBeAssumed"
        },
        "metrics_collected": {
          "prometheus": {
            "prometheus_config_path": "/etc/prometheusconfig/prometheus.yaml",
            "emf_processor": {
              "metric_declaration": [
                {
                  "source_labels": [
                    "job"
                  ],
                  "label_matcher": "(kubernetes-apiservers|rdi-metric-exporter|kube-state-metrics)",
                  "metric_selectors": [
                    ".*"
                  ]
                }
              ]
            }
          }
        },
        "force_flush_interval": 5
      }
    }
```

<!--Describe what testing was performed and which tests were added.-->
#### Testing
