### PR TITLE
Add ability to refresh service account token to AWS Container Insights Kueue Receiver

### DIFF
--- a/receiver/awscontainerinsightskueuereceiver/factory.go
+++ b/receiver/awscontainerinsightskueuereceiver/factory.go
@@ -51,5 +51,5 @@ func createMetricsReceiver(
 	consumer consumer.Metrics,
 ) (receiver.Metrics, error) {
 	rCfg := baseCfg.(*Config)
-	return newAWSContainerInsightReceiver(params.TelemetrySettings, rCfg, consumer)
+	return newAWSContainerInsightsKueueReceiver(params.TelemetrySettings, rCfg, consumer)
 }

--- a/receiver/awscontainerinsightskueuereceiver/internal/kueuescraper/kueue_prometheus_scraper.go
+++ b/receiver/awscontainerinsightskueuereceiver/internal/kueuescraper/kueue_prometheus_scraper.go
@@ -60,6 +60,7 @@ type KueuePrometheusScraper struct {
 	host               component.Host
 	clusterName        string
 	prometheusReceiver receiver.Metrics
+	scrapeConfig       *config.ScrapeConfig
 	running            bool
 }
 
@@ -83,6 +84,31 @@ func NewKueuePrometheusScraper(opts KueuePrometheusScraperOpts) (*KueuePrometheu
 		return nil, errors.New("cluster name cannot be empty")
 	}
 
+	scrapeConfig := GetScrapeConfig(
+		opts.ClusterName,
+		opts.BearerToken,
+		opts.TelemetrySettings.Logger,
+	)
+
+	scraper := &KueuePrometheusScraper{
+		ctx:          opts.Ctx,
+		settings:     opts.TelemetrySettings,
+		host:         opts.Host,
+		clusterName:  opts.ClusterName,
+		scrapeConfig: scrapeConfig,
+	}
+
+	promReceiver, err := scraper.createPrometheusReceiver(opts.Consumer)
+	if err != nil {
+		return nil, err
+	}
+
+	scraper.prometheusReceiver = promReceiver
+
+	return scraper, nil
+}
+
+func GetScrapeConfig(clusterName string, bearerToken string, logger *zap.Logger) *config.ScrapeConfig {
 	scrapeConfig := &config.ScrapeConfig{
 		HTTPClientConfig: configutil.HTTPClientConfig{
 			TLSConfig: configutil.TLSConfig{
@@ -111,39 +137,16 @@ func NewKueuePrometheusScraper(opts KueuePrometheusScraperOpts) (*KueuePrometheu
 				},
 			},
 		},
-		MetricRelabelConfigs: GetKueueRelabelConfigs(opts.ClusterName),
+		MetricRelabelConfigs: GetKueueRelabelConfigs(clusterName),
 	}
 
-	if opts.BearerToken != "" {
-		scrapeConfig.HTTPClientConfig.BearerToken = configutil.Secret(opts.BearerToken)
+	if bearerToken != "" {
+		scrapeConfig.HTTPClientConfig.BearerToken = configutil.Secret(bearerToken)
 	} else {
-		opts.TelemetrySettings.Logger.Warn("bearer token is not set, kueue metrics will not be published")
+		logger.Warn("bearer token is not set, kueue metrics will not be published")
 	}
 
-	promConfig := prometheusreceiver.Config{
-		PrometheusConfig: &prometheusreceiver.PromConfig{
-			ScrapeConfigs: []*config.ScrapeConfig{scrapeConfig},
-		},
-	}
-
-	params := receiver.Settings{
-		ID:                component.MustNewID(kmJobName),
-		TelemetrySettings: opts.TelemetrySettings,
-	}
-
-	promFactory := prometheusreceiver.NewFactory()
-	promReceiver, err := promFactory.CreateMetrics(opts.Ctx, params, &promConfig, opts.Consumer)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create prometheus receiver for kueue metrics: %w", err)
-	}
-
-	return &KueuePrometheusScraper{
-		ctx:                opts.Ctx,
-		settings:           opts.TelemetrySettings,
-		host:               opts.Host,
-		clusterName:        opts.ClusterName,
-		prometheusReceiver: promReceiver,
-	}, nil
+	return scrapeConfig
 }
 
 func GetKueueRelabelConfigs(clusterName string) []*relabel.Config {
@@ -193,6 +196,27 @@ func GetKueueRelabelConfigs(clusterName string) []*relabel.Config {
 	return relabelConfigs
 }
 
+func (kps *KueuePrometheusScraper) createPrometheusReceiver(consumer consumer.Metrics) (receiver.Metrics, error) {
+	promConfig := prometheusreceiver.Config{
+		PrometheusConfig: &prometheusreceiver.PromConfig{
+			ScrapeConfigs: []*config.ScrapeConfig{kps.scrapeConfig},
+		},
+	}
+
+	params := receiver.Settings{
+		ID:                component.MustNewID(kmJobName),
+		TelemetrySettings: kps.settings,
+	}
+
+	promFactory := prometheusreceiver.NewFactory()
+	promReceiver, err := promFactory.CreateMetrics(kps.ctx, params, &promConfig, consumer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create prometheus receiver for kueue metrics: %w", err)
+	}
+
+	return promReceiver, nil
+}
+
 func (kps *KueuePrometheusScraper) GetMetrics() []pmetric.Metrics {
 	// This method will never return metrics because the metrics are collected by the scraper.
 
@@ -209,6 +233,7 @@ func (kps *KueuePrometheusScraper) GetMetrics() []pmetric.Metrics {
 
 func (kps *KueuePrometheusScraper) Shutdown() {
 	if kps.running {
+		kps.settings.Logger.Info("Shutting down the Kueue metrics scraper")
 		err := kps.prometheusReceiver.Shutdown(kps.ctx)
 		if err != nil {
 			kps.settings.Logger.Error("Unable to shutdown Kueue PrometheusReceiver", zap.Error(err))

--- a/receiver/awscontainerinsightskueuereceiver/internal/kueuescraper/kueue_prometheus_scraper_test.go
+++ b/receiver/awscontainerinsightskueuereceiver/internal/kueuescraper/kueue_prometheus_scraper_test.go
@@ -123,7 +123,6 @@ func TestNewKueuePrometheusScraperEndToEnd(t *testing.T) {
 			Consumer:          mConsumer,
 			Host:              componenttest.NewNopHost(),
 			ClusterName:       "DummyCluster",
-			BearerToken:       "",
 		},
 	)
 	assert.NoError(t, err)

--- a/receiver/awscontainerinsightskueuereceiver/internal/tokenprovider/token_provider.go
+++ b/receiver/awscontainerinsightskueuereceiver/internal/tokenprovider/token_provider.go
@@ -1,0 +1,55 @@
+package tokenprovider // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightskueuereceiver/internal/tokenprovider"
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	serviceAccountTokenDefaultPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+)
+
+type BearerTokenProvider struct {
+	tokenGeneration int
+	loadedToken     string
+	RetrieveToken   func() (string, error)
+}
+
+func NewBearerTokenProvider() *BearerTokenProvider {
+	var provider *BearerTokenProvider = &BearerTokenProvider{
+		tokenGeneration: 0,
+		loadedToken:     "",
+		RetrieveToken:   defaultRetrieveToken,
+	}
+
+	return provider
+}
+
+func (provider *BearerTokenProvider) GetToken() (string, error) {
+	newToken, err := provider.RetrieveToken()
+	if err != nil {
+		return "", err
+	}
+	if newToken != provider.loadedToken {
+		provider.tokenGeneration += 1
+		provider.loadedToken = newToken
+	}
+	return provider.loadedToken, nil
+}
+
+func (provider *BearerTokenProvider) TokenGeneration() int {
+	return provider.tokenGeneration
+}
+
+func defaultRetrieveToken() (string, error) {
+	return retrieveTokenFromFileSystem(serviceAccountTokenDefaultPath)
+}
+
+func retrieveTokenFromFileSystem(tokenPath string) (string, error) {
+	tokenBytes, err := os.ReadFile(tokenPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read bearer token: %w", err)
+	}
+	return strings.TrimSpace(string(tokenBytes)), nil
+}

--- a/receiver/awscontainerinsightskueuereceiver/internal/tokenprovider/token_provider_test.go
+++ b/receiver/awscontainerinsightskueuereceiver/internal/tokenprovider/token_provider_test.go
@@ -1,0 +1,153 @@
+package tokenprovider // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightskueuereceiver/internal/tokenprovider"
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewBearerTokenProvider(t *testing.T) {
+	testCases := []struct {
+		caseName string
+	}{
+		{
+			caseName: "Success Case",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.caseName, func(t *testing.T) {
+			var testProvider *BearerTokenProvider = NewBearerTokenProvider()
+
+			assert.NotNil(t, testProvider)
+			assert.Equal(t, 0, testProvider.tokenGeneration)
+			assert.Empty(t, testProvider.loadedToken)
+
+			expectedPtr := reflect.ValueOf(defaultRetrieveToken).Pointer()
+			actualPtr := reflect.ValueOf(testProvider.RetrieveToken).Pointer()
+			assert.Equal(t, expectedPtr, actualPtr)
+		})
+	}
+}
+
+func TestRetrieveToken(t *testing.T) {
+	var mockToken string = "dummy-token"
+	var mockError error = fmt.Errorf("dummy error")
+
+	testCases := []struct {
+		caseName           string
+		initialToken       string
+		mockProvider       func() (string, error)
+		expectedError      error
+		expectedToken      string
+		expectedGeneration int
+	}{
+		{
+			caseName:     "New Token Case",
+			initialToken: "",
+			mockProvider: func() (string, error) {
+				return mockToken, nil
+			},
+			expectedError:      nil,
+			expectedToken:      mockToken,
+			expectedGeneration: 1,
+		},
+		{
+			caseName:     "Same Token Case",
+			initialToken: mockToken,
+			mockProvider: func() (string, error) {
+				return mockToken, nil
+			},
+			expectedError:      nil,
+			expectedToken:      mockToken,
+			expectedGeneration: 0,
+		},
+		{
+			caseName:     "Error Case",
+			initialToken: "",
+			mockProvider: func() (string, error) {
+				return "", mockError
+			},
+			expectedError:      mockError,
+			expectedToken:      "",
+			expectedGeneration: 0,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.caseName, func(t *testing.T) {
+			var testProvider *BearerTokenProvider = &BearerTokenProvider{
+				tokenGeneration: 0,
+				loadedToken:     testCase.initialToken,
+				RetrieveToken:   testCase.mockProvider,
+			}
+
+			assert.Equal(t, 0, testProvider.tokenGeneration)
+			assert.Equal(t, testCase.initialToken, testProvider.loadedToken)
+
+			yieldedToken, err := testProvider.GetToken()
+
+			assert.Equal(t, testCase.expectedGeneration, testProvider.tokenGeneration)
+			assert.Equal(t, testCase.expectedToken, yieldedToken)
+			assert.Equal(t, testCase.expectedToken, testProvider.loadedToken)
+			assert.Equal(t, testCase.expectedGeneration, testProvider.tokenGeneration)
+			assert.Equal(t, testCase.expectedError, err)
+		})
+	}
+}
+
+func TestTokenGeneration(t *testing.T) {
+	provider := &BearerTokenProvider{
+		tokenGeneration: 42,
+	}
+
+	if gen := provider.TokenGeneration(); gen != 42 {
+		t.Errorf("Expected token generation 42, got %d", gen)
+	}
+}
+
+func TestRetrieveTokenFromFileSystem2(t *testing.T) {
+	var tmpDir string = t.TempDir()
+	var dummyToken string = "dummy-token-content"
+	var dummyTokenPath string = filepath.Join(tmpDir, "test-token")
+
+	err := os.WriteFile(dummyTokenPath, []byte(dummyToken+"\n"), 0600)
+	if err != nil {
+		t.Fatalf("Failed to create test token file: %v", err)
+	}
+
+	testCases := []struct {
+		caseName      string
+		tokenPath     string
+		expectedToken string
+		errorExpected bool
+	}{
+		{
+			caseName:      "Success Case",
+			tokenPath:     dummyTokenPath,
+			expectedToken: dummyToken,
+			errorExpected: false,
+		},
+		{
+			caseName:      "Nonexistent File Case",
+			tokenPath:     filepath.Join(tmpDir, "nonexistent-token"),
+			expectedToken: "",
+			errorExpected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.caseName, func(t *testing.T) {
+			token, err := retrieveTokenFromFileSystem(testCase.tokenPath)
+			assert.Equal(t, testCase.expectedToken, token)
+			if testCase.errorExpected {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}

--- a/receiver/awscontainerinsightskueuereceiver/receiver.go
+++ b/receiver/awscontainerinsightskueuereceiver/receiver.go
@@ -5,7 +5,6 @@ package awscontainerinsightskueuereceiver // import "github.com/open-telemetry/o
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"runtime"
 	"time"
@@ -14,38 +13,41 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
-	"k8s.io/client-go/rest"
 
 	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightskueuereceiver/internal/kueuescraper"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightskueuereceiver/internal/tokenprovider"
 )
 
 var _ receiver.Metrics = (*awsContainerInsightKueueReceiver)(nil)
 
 // awsContainerInsightKueueReceiver implements the receiver.Metrics
 type awsContainerInsightKueueReceiver struct {
-	settings     component.TelemetrySettings
-	nextConsumer consumer.Metrics
-	config       *Config
-	cancel       context.CancelFunc
-	kueueScraper *kueuescraper.KueuePrometheusScraper
+	settings        component.TelemetrySettings
+	nextConsumer    consumer.Metrics
+	config          *Config
+	cancel          context.CancelFunc
+	tokenProvider   *tokenprovider.BearerTokenProvider
+	tokenGeneration int
+	kueueScraper    *kueuescraper.KueuePrometheusScraper
 }
 
-// newAWSContainerInsightReceiver creates the aws container insight receiver with the given parameters.
-func newAWSContainerInsightReceiver(
+// newAWSContainerInsightsKueueReceiver creates the AWS Container Insights Kueue receiver with the given parameters.
+func newAWSContainerInsightsKueueReceiver(
 	settings component.TelemetrySettings,
 	config *Config,
 	nextConsumer consumer.Metrics,
 ) (receiver.Metrics, error) {
 	r := &awsContainerInsightKueueReceiver{
-		settings:     settings,
-		nextConsumer: nextConsumer,
-		config:       config,
+		settings:      settings,
+		nextConsumer:  nextConsumer,
+		config:        config,
+		tokenProvider: tokenprovider.NewBearerTokenProvider(),
 	}
 	return r, nil
 }
 
-// Start collecting metrics from cadvisor and k8s api server (if it is an elected leader)
+// Start collecting metrics from Kueue metrics prometheusendpoint
 func (akr *awsContainerInsightKueueReceiver) Start(ctx context.Context, host component.Host) error {
 	ctx, akr.cancel = context.WithCancel(ctx)
 
@@ -55,7 +57,7 @@ func (akr *awsContainerInsightKueueReceiver) Start(ctx context.Context, host com
 			akr.settings.Logger.Error("Unable to initialize receiver for Kueue metrics", zap.Error(err))
 			return
 		}
-		akr.start(ctx)
+		akr.start(ctx, host)
 	}()
 
 	return nil
@@ -66,7 +68,16 @@ func (akr *awsContainerInsightKueueReceiver) init(ctx context.Context, host comp
 		return fmt.Errorf("unsupported operating system: %s", ci.OperatingSystemWindows)
 	}
 
-	err := akr.initKueuePrometheusScraper(ctx, host)
+	bearerToken, tokenErr := akr.tokenProvider.GetToken()
+
+	if tokenErr != nil {
+		akr.settings.Logger.Warn("Unable to retrieve bearer token", zap.Error(tokenErr))
+		return tokenErr
+	}
+
+	akr.tokenGeneration = akr.tokenProvider.TokenGeneration()
+
+	err := akr.initKueuePrometheusScraper(ctx, host, bearerToken)
 	if err != nil {
 		akr.settings.Logger.Warn("Unable to start kueue prometheus scraper", zap.Error(err))
 		return err
@@ -74,7 +85,7 @@ func (akr *awsContainerInsightKueueReceiver) init(ctx context.Context, host comp
 	return nil
 }
 
-func (akr *awsContainerInsightKueueReceiver) start(ctx context.Context) {
+func (akr *awsContainerInsightKueueReceiver) start(ctx context.Context, host component.Host) {
 	ticker := time.NewTicker(akr.config.CollectionInterval)
 	defer ticker.Stop()
 
@@ -82,6 +93,17 @@ func (akr *awsContainerInsightKueueReceiver) start(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			akr.collectData()
+			// perform a token load to check if generation has changed
+			_, err := akr.tokenProvider.GetToken()
+			if err != nil {
+				akr.settings.Logger.Warn("Unable to retrieve bearer token, receiver will continue without refreshing", zap.Error(err))
+			} else {
+				if akr.tokenGeneration != akr.tokenProvider.TokenGeneration() {
+					akr.settings.Logger.Info("Token generation has changed, restarting receiver")
+					akr.shutdownScraper()
+					akr.init(ctx, host)
+				}
+			}
 		case <-ctx.Done():
 			return
 		}
@@ -91,16 +113,9 @@ func (akr *awsContainerInsightKueueReceiver) start(ctx context.Context) {
 func (akr *awsContainerInsightKueueReceiver) initKueuePrometheusScraper(
 	ctx context.Context,
 	host component.Host,
+	bearerToken string,
 ) error {
-	restConfig, err := rest.InClusterConfig()
-	if err != nil {
-		return err
-	}
-	bearerToken := restConfig.BearerToken
-	if bearerToken == "" {
-		return errors.New("bearer token was empty")
-	}
-
+	var err error
 	akr.kueueScraper, err = kueuescraper.NewKueuePrometheusScraper(kueuescraper.KueuePrometheusScraperOpts{
 		Ctx:               ctx,
 		TelemetrySettings: akr.settings,
@@ -119,11 +134,15 @@ func (akr *awsContainerInsightKueueReceiver) Shutdown(context.Context) error {
 	}
 	akr.cancel()
 
+	akr.shutdownScraper()
+
+	return nil
+}
+
+func (akr *awsContainerInsightKueueReceiver) shutdownScraper() {
 	if akr.kueueScraper != nil {
 		akr.kueueScraper.Shutdown()
 	}
-
-	return nil
 }
 
 func (akr *awsContainerInsightKueueReceiver) collectData() {


### PR DESCRIPTION
#### Description

This PR:
1. Adds a new component `BearerTokenProvider` with a default behaviour of loading the service account token from the cluster.
2. Updates the `awsContainerInsightKueueReceiver` to use a `BearerTokenProvider` for both initially retrieving the bearer token and refreshing it as necessary.
3. Separates scrape configuration and prometheus receiver setup into helper functions from the `KueuePrometheusScraper` constructor.
4. Other minor documentation and renaming changes.

#### Link to tracking issue

Tracking issues are internal.

#### Testing

Unit testing was added for the `BearerTokenProvider`.

**Manual end-to-end validation is pending. This should not be merged before that is complete.**


<!--Describe the documentation added.-->
#### Documentation

No documentation was added.