### PR TITLE
Add service account token refresh to AWS Container Insights Kueue Receiver

### DIFF
--- a/receiver/awscontainerinsightskueuereceiver/factory.go
+++ b/receiver/awscontainerinsightskueuereceiver/factory.go
@@ -51,5 +51,5 @@ func createMetricsReceiver(
 	consumer consumer.Metrics,
 ) (receiver.Metrics, error) {
 	rCfg := baseCfg.(*Config)
-	return newAWSContainerInsightReceiver(params.TelemetrySettings, rCfg, consumer)
+	return newAWSContainerInsightsKueueReceiver(params.TelemetrySettings, rCfg, consumer)
 }

--- a/receiver/awscontainerinsightskueuereceiver/go.mod
+++ b/receiver/awscontainerinsightskueuereceiver/go.mod
@@ -20,7 +20,6 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	gopkg.in/yaml.v2 v2.4.0
-	k8s.io/client-go v0.30.0
 )
 
 require (
@@ -187,6 +186,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.30.0 // indirect
 	k8s.io/apimachinery v0.30.0 // indirect
+	k8s.io/client-go v0.30.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect

--- a/receiver/awscontainerinsightskueuereceiver/internal/kueuescraper/kueue_prometheus_scraper.go
+++ b/receiver/awscontainerinsightskueuereceiver/internal/kueuescraper/kueue_prometheus_scraper.go
@@ -35,7 +35,7 @@ const (
 	kueueServiceFieldSelector   = "metadata.name=kueue-controller-manager-metrics-service"
 	kueueMetricsLogStream       = "kubernetes-kueue"
 
-	serviceAccountTokenDefaultPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	serviceAccountTokenDefaultPath = "/var/run/secrets/kubernetes.io/serviceaccount/token" // #nosec
 )
 
 var ( // list of regular expressions for the kueue metrics this scraper is intended to capture

--- a/receiver/awscontainerinsightskueuereceiver/internal/kueuescraper/kueue_prometheus_scraper.go
+++ b/receiver/awscontainerinsightskueuereceiver/internal/kueuescraper/kueue_prometheus_scraper.go
@@ -34,6 +34,8 @@ const (
 	kueueComponentLabelSelector = "app.kubernetes.io/component=controller"
 	kueueServiceFieldSelector   = "metadata.name=kueue-controller-manager-metrics-service"
 	kueueMetricsLogStream       = "kubernetes-kueue"
+
+	serviceAccountTokenDefaultPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )
 
 var ( // list of regular expressions for the kueue metrics this scraper is intended to capture
@@ -69,7 +71,6 @@ type KueuePrometheusScraperOpts struct {
 	Consumer          consumer.Metrics
 	Host              component.Host
 	ClusterName       string
-	BearerToken       string
 }
 
 func NewKueuePrometheusScraper(opts KueuePrometheusScraperOpts) (*KueuePrometheusScraper, error) {
@@ -87,6 +88,10 @@ func NewKueuePrometheusScraper(opts KueuePrometheusScraperOpts) (*KueuePrometheu
 		HTTPClientConfig: configutil.HTTPClientConfig{
 			TLSConfig: configutil.TLSConfig{
 				InsecureSkipVerify: true,
+			},
+			Authorization: &configutil.Authorization{
+				Type:            "Bearer",
+				CredentialsFile: serviceAccountTokenDefaultPath,
 			},
 		},
 		ScrapeInterval:  model.Duration(kmCollectionInterval),
@@ -112,12 +117,6 @@ func NewKueuePrometheusScraper(opts KueuePrometheusScraperOpts) (*KueuePrometheu
 			},
 		},
 		MetricRelabelConfigs: GetKueueRelabelConfigs(opts.ClusterName),
-	}
-
-	if opts.BearerToken != "" {
-		scrapeConfig.HTTPClientConfig.BearerToken = configutil.Secret(opts.BearerToken)
-	} else {
-		opts.TelemetrySettings.Logger.Warn("bearer token is not set, kueue metrics will not be published")
 	}
 
 	promConfig := prometheusreceiver.Config{

--- a/receiver/awscontainerinsightskueuereceiver/internal/kueuescraper/kueue_prometheus_scraper_test.go
+++ b/receiver/awscontainerinsightskueuereceiver/internal/kueuescraper/kueue_prometheus_scraper_test.go
@@ -74,7 +74,6 @@ func TestNewKueuePrometheusScraperBadInputs(t *testing.T) {
 			Consumer:          nil,
 			Host:              componenttest.NewNopHost(),
 			ClusterName:       "DummyCluster",
-			BearerToken:       "/path/to/dummy/token",
 		},
 		{ // case: no host
 			Ctx:               context.TODO(),
@@ -82,14 +81,12 @@ func TestNewKueuePrometheusScraperBadInputs(t *testing.T) {
 			Consumer:          mockKueueConsumer{},
 			Host:              nil,
 			ClusterName:       "DummyCluster",
-			BearerToken:       "/path/to/dummy/token",
 		},
 		{ // case: no cluster name
 			Ctx:               context.TODO(),
 			TelemetrySettings: settings,
 			Consumer:          mockKueueConsumer{},
 			Host:              componenttest.NewNopHost(),
-			BearerToken:       "/path/to/dummy/token",
 		},
 	}
 
@@ -123,7 +120,6 @@ func TestNewKueuePrometheusScraperEndToEnd(t *testing.T) {
 			Consumer:          mConsumer,
 			Host:              componenttest.NewNopHost(),
 			ClusterName:       "DummyCluster",
-			BearerToken:       "",
 		},
 	)
 	assert.NoError(t, err)


### PR DESCRIPTION
#### Description

This PR:

1. Updates the `KueuePrometheusScraper` to specify service account token file path via `HTTPConfig` for refreshing the token as necessary.
2. Other minor documentation and renaming changes.

#### Link to tracking issue

Tracking issues are internal.

#### Testing

Through manual testing, I have verified:

1. Metrics cannot be collected without a token present at the specified file path.
2. When a valid token is added, the scrape succeeds.
3. If/when the token becomes invalid, scrapes no longer succeeds.
4. When the token is rotated, there is no gap in metrics collection.

#### Documentation

No documentation was added.