### PR TITLE
Add service entity support for EMF exporter

### DIFF
--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -81,6 +81,10 @@ type Config struct {
 	// retaining all the fields / labels in the EMF log except for the section responsible for extraction of metrics.
 	DisableMetricExtraction bool `mapstructure:"disable_metric_extraction"`
 
+	// AddEntity is an option to add entity to the EMF log to correlate related telemetry.
+	// Setting this to true adds fields such as Service, Environment, etc.
+	AddEntity bool `mapstructure:"add_entity"`
+
 	// ResourceToTelemetrySettings is an option for converting resource attrihutes to telemetry attributes.
 	// "Enabled" - A boolean field to enable/disable this option. Default is `false`.
 	// If enabled, all the resource attributes will be converted to metric labels by default.

--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math"
 	"strconv"
-	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -19,8 +18,6 @@ import (
 )
 
 const (
-	AWSEntityPrefix = "com.amazonaws.cloudwatch.entity.internal."
-
 	summaryCountSuffix = "_count"
 	summarySumSuffix   = "_sum"
 )
@@ -533,11 +530,6 @@ func (dps summaryDataPointSlice) IsStaleNaNInf(i int) (bool, pcommon.Map) {
 func createLabels(attributes pcommon.Map) map[string]string {
 	labels := make(map[string]string, attributes.Len()+1)
 	attributes.Range(func(k string, v pcommon.Value) bool {
-		// we don't want to export entity related attributes as dimensions, so we skip these
-		if strings.HasPrefix(k, AWSEntityPrefix) {
-			return true
-		}
-
 		labels[k] = v.AsString()
 		return true
 	})

--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -1976,7 +1976,6 @@ func TestCreateLabels(t *testing.T) {
 		"a": "A",
 		"b": "B",
 		"c": "C",
-		"com.amazonaws.cloudwatch.entity.internal.A": "A",
 	}))
 
 	labels := createLabels(labelsMap)

--- a/exporter/awsemfexporter/internal/entity/entityattributes.go
+++ b/exporter/awsemfexporter/internal/entity/entityattributes.go
@@ -1,0 +1,64 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package entity // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter/internal/entity"
+
+const (
+	// Entity resource attributes in OTLP payload
+	AWSEntityPrefix                      = "com.amazonaws.cloudwatch.entity.internal."
+	AttributeEntityServiceName           = AWSEntityPrefix + "service.name"
+	AttributeEntityDeploymentEnvironment = AWSEntityPrefix + "deployment.environment"
+	AttributeEntityK8sClusterName        = AWSEntityPrefix + "k8s.cluster.name"
+	AttributeEntityK8sNamespaceName      = AWSEntityPrefix + "k8s.namespace.name"
+	AttributeEntityK8sWorkloadName       = AWSEntityPrefix + "k8s.workload.name"
+	AttributeEntityK8sNodeName           = AWSEntityPrefix + "k8s.node.name"
+	AttributeEntityServiceNameSource     = AWSEntityPrefix + "service.name.source"
+	AttributeEntityPlatformType          = AWSEntityPrefix + "platform.type"
+	AttributeEntityInstanceID            = AWSEntityPrefix + "instance.id"
+
+	// Entity fields in EMF log
+	Service              = "Service"
+	Environment          = "Environment"
+	EksCluster           = "EKS.Cluster"
+	K8sCluster           = "K8s.Cluster"
+	K8sNamespace         = "K8s.Namespace"
+	K8sWorkload          = "K8s.Workload"
+	K8sNode              = "K8s.Node"
+	AWSServiceNameSource = "AWS.ServiceNameSource"
+	PlatformType         = "PlatformType"
+	InstanceID           = "EC2.InstanceId"
+
+	// Possible values for PlatformType
+	AttributeEntityEKSPlatform = "AWS::EKS"
+	AttributeEntityK8sPlatform = "K8s"
+)
+
+// attributeEntityToFieldMap maps attribute entity resource attributes to entity fields
+var attributeEntityToFieldMap = map[string]string{
+	AttributeEntityServiceName:           Service,
+	AttributeEntityDeploymentEnvironment: Environment,
+	AttributeEntityK8sNamespaceName:      K8sNamespace,
+	AttributeEntityK8sWorkloadName:       K8sWorkload,
+	AttributeEntityK8sNodeName:           K8sNode,
+	AttributeEntityPlatformType:          PlatformType,
+	AttributeEntityInstanceID:            InstanceID,
+	AttributeEntityServiceNameSource:     AWSServiceNameSource,
+}
+
+// GetEntityField returns entity field for provided attribute
+func GetEntityField(attribute string, platform string) string {
+	if attribute == AttributeEntityK8sClusterName {
+		switch platform {
+		case AttributeEntityEKSPlatform:
+			return EksCluster
+		case AttributeEntityK8sPlatform:
+			return K8sCluster
+		}
+	}
+
+	if field, ok := attributeEntityToFieldMap[attribute]; ok {
+		return field
+	}
+
+	return ""
+}

--- a/exporter/awsemfexporter/internal/entity/entityattributes_test.go
+++ b/exporter/awsemfexporter/internal/entity/entityattributes_test.go
@@ -1,0 +1,107 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package entity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetEntityField(t *testing.T) {
+	tests := []struct {
+		name      string
+		attribute string
+		value     string
+		want      string
+	}{
+		{
+			name:      "AttributeEntityServiceName from map",
+			attribute: AttributeEntityServiceName,
+			value:     "",
+			want:      Service,
+		},
+		{
+			name:      "AttributeEntityDeploymentEnvironment from map",
+			attribute: AttributeEntityDeploymentEnvironment,
+			value:     "",
+			want:      Environment,
+		},
+		{
+			name:      "AttributeEntityK8sNamespaceName from map",
+			attribute: AttributeEntityK8sNamespaceName,
+			value:     "",
+			want:      K8sNamespace,
+		},
+		{
+			name:      "AttributeEntityK8sWorkloadName from map",
+			attribute: AttributeEntityK8sWorkloadName,
+			value:     "",
+			want:      K8sWorkload,
+		},
+		{
+			name:      "AttributeEntityK8sNodeName from map",
+			attribute: AttributeEntityK8sNodeName,
+			value:     "",
+			want:      K8sNode,
+		},
+		{
+			name:      "AttributeEntityPlatformType from map",
+			attribute: AttributeEntityPlatformType,
+			value:     "",
+			want:      PlatformType,
+		},
+		{
+			name:      "AttributeEntityInstanceID from map",
+			attribute: AttributeEntityInstanceID,
+			value:     "",
+			want:      InstanceID,
+		},
+		{
+			name:      "AttributeEntityServiceNameSource from map",
+			attribute: AttributeEntityServiceNameSource,
+			value:     "",
+			want:      AWSServiceNameSource,
+		},
+		{
+			name:      "K8sClusterName with EKSPlatform",
+			attribute: AttributeEntityK8sClusterName,
+			value:     AttributeEntityEKSPlatform,
+			want:      EksCluster,
+		},
+		{
+			name:      "K8sClusterName with K8sPlatform",
+			attribute: AttributeEntityK8sClusterName,
+			value:     AttributeEntityK8sPlatform,
+			want:      K8sCluster,
+		},
+		{
+			name:      "K8sClusterName with unknown platform",
+			attribute: AttributeEntityK8sClusterName,
+			value:     "unknown",
+			want:      "",
+		},
+		{
+			name:      "Unknown attribute",
+			attribute: "unknown",
+			value:     "",
+			want:      "",
+		},
+		{
+			name:      "K8sClusterName with no values provided",
+			attribute: AttributeEntityK8sClusterName,
+			value:     "",
+			want:      "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetEntityField(tc.attribute, tc.value)
+			assert.Equalf(t, tc.want, got,
+				"GetEntityField(%q, %v) = %q; want %q",
+				tc.attribute, tc.value, got, tc.want)
+		})
+	}
+}

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter/internal/entity"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs"
 	aws "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics"
 )
@@ -184,7 +185,7 @@ func (mt metricTranslator) translateOTelToGroupedMetric(rm pmetric.ResourceMetri
 
 // translateGroupedMetricToCWMetric converts Grouped Metric format to CloudWatch Metric format.
 func translateGroupedMetricToCWMetric(groupedMetric *groupedMetric, config *Config) *cWMetrics {
-	labels := filterAWSEMFAttributes(groupedMetric.labels)
+	labels := filterAWSEMFAttributes(groupedMetric.labels, false)
 	fieldsLength := len(labels) + len(groupedMetric.metrics)
 
 	isPrometheusMetric := groupedMetric.metadata.receiver == prometheusReceiver
@@ -195,7 +196,24 @@ func translateGroupedMetricToCWMetric(groupedMetric *groupedMetric, config *Conf
 
 	// Add labels to fields
 	for k, v := range labels {
-		fields[k] = v
+		if !strings.HasPrefix(k, entity.AWSEntityPrefix) {
+			fields[k] = v
+			continue
+		}
+
+		if config.AddEntity {
+			// This check is needed to determine whether to use EKS.Cluster or K8s.Cluster
+			if k == entity.AttributeEntityK8sClusterName {
+				if entityField := entity.GetEntityField(k, labels[entity.AttributeEntityPlatformType]); entityField != "" {
+					fields[entityField] = v
+				}
+				continue
+			}
+
+			if entityField := entity.GetEntityField(k, ""); entityField != "" {
+				fields[entityField] = v
+			}
+		}
 	}
 	// Add metrics to fields
 	for metricName, metricInfo := range groupedMetric.metrics {
@@ -228,7 +246,8 @@ func translateGroupedMetricToCWMetric(groupedMetric *groupedMetric, config *Conf
 
 // groupedMetricToCWMeasurement creates a single CW Measurement from a grouped metric.
 func groupedMetricToCWMeasurement(groupedMetric *groupedMetric, config *Config) cWMeasurement {
-	labels := filterAWSEMFAttributes(groupedMetric.labels)
+	labels := filterAWSEMFAttributes(groupedMetric.labels, true)
+
 	dimensionRollupOption := config.DimensionRollupOption
 
 	// Create a dimension set containing list of label names
@@ -287,7 +306,7 @@ func groupedMetricToCWMeasurement(groupedMetric *groupedMetric, config *Config) 
 // groupedMetricToCWMeasurementsWithFilters filters the grouped metric using the given list of metric
 // declarations and returns the corresponding list of CW Measurements.
 func groupedMetricToCWMeasurementsWithFilters(groupedMetric *groupedMetric, config *Config) (cWMeasurements []cWMeasurement) {
-	labels := filterAWSEMFAttributes(groupedMetric.labels)
+	labels := filterAWSEMFAttributes(groupedMetric.labels, true)
 
 	// Filter metric declarations by labels
 	metricDeclarations := make([]*MetricDeclaration, 0, len(config.MetricDeclarations))
@@ -544,11 +563,12 @@ func translateGroupedMetricToEmf(groupedMetric *groupedMetric, config *Config, d
 	return event, nil
 }
 
-func filterAWSEMFAttributes(labels map[string]string) map[string]string {
+func filterAWSEMFAttributes(labels map[string]string, removeEntity bool) map[string]string {
 	// remove any labels that are attributes specific to AWS EMF Exporter
 	filteredLabels := make(map[string]string)
 	for labelName := range labels {
-		if labelName != emfStorageResolutionAttribute {
+		if labelName != emfStorageResolutionAttribute &&
+			(!removeEntity || !strings.HasPrefix(labelName, entity.AWSEntityPrefix)) {
 			filteredLabels[labelName] = labels[labelName]
 		}
 	}

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -21,6 +21,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter/internal/entity"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/occonventions"
 )
@@ -2619,6 +2620,198 @@ func TestTranslateOtToGroupedMetricForInitialDeltaValue(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEntityAttributesToFields(t *testing.T) {
+	timestamp := int64(1596151098037)
+	namespace := "TestNamespace"
+
+	labels := map[string]string{
+		"normal_label":                              "normal_value",
+		entity.AttributeEntityServiceName:           "sampleApp",
+		entity.AttributeEntityDeploymentEnvironment: "eks:myEksCluster/myNamespace",
+		entity.AttributeEntityPlatformType:          entity.AttributeEntityEKSPlatform,
+		entity.AttributeEntityK8sWorkloadName:       "sampleApp",
+		entity.AttributeEntityK8sClusterName:        "myEksCluster",
+		entity.AttributeEntityK8sNamespaceName:      "myNamespace",
+		entity.AttributeEntityK8sNodeName:           "ip-012-345-67-890.ec2.internal",
+		entity.AttributeEntityInstanceID:            "i-0123456789",
+		entity.AttributeEntityServiceNameSource:     "K8sWorkload",
+		entity.AWSEntityPrefix + "unknown_field":    "should_not_appear",
+	}
+	metrics := map[string]*metricInfo{
+		"metric1": {value: 1, unit: "Count"},
+	}
+	groupedMetric := &groupedMetric{
+		labels:  labels,
+		metrics: metrics,
+		metadata: cWMetricMetadata{
+			groupedMetricMetadata: groupedMetricMetadata{
+				namespace:   namespace,
+				timestampMs: timestamp,
+			},
+		},
+	}
+
+	t.Run("AddEntity true", func(t *testing.T) {
+		config := &Config{
+			DimensionRollupOption: "",
+			logger:                zap.NewNop(),
+			AddEntity:             true,
+		}
+		cw := translateGroupedMetricToCWMetric(groupedMetric, config)
+
+		require.Len(t, cw.measurements, 1)
+		dims := cw.measurements[0].Dimensions
+		assert.Equal(t, [][]string{{"normal_label"}}, dims)
+
+		assert.Equal(t, timestamp, cw.timestampMs)
+		assert.Equal(t, namespace, cw.measurements[0].Namespace)
+
+		expectedFields := map[string]any{
+			"normal_label":          "normal_value",
+			"metric1":               1,
+			"AWS.ServiceNameSource": "K8sWorkload",
+			"EKS.Cluster":           "myEksCluster",
+			"Environment":           "eks:myEksCluster/myNamespace",
+			"K8s.Namespace":         "myNamespace",
+			"K8s.Node":              "ip-012-345-67-890.ec2.internal",
+			"K8s.Workload":          "sampleApp",
+			"PlatformType":          entity.AttributeEntityEKSPlatform,
+			"Service":               "sampleApp",
+			"EC2.InstanceId":        "i-0123456789",
+		}
+		assert.Equal(t, expectedFields, cw.fields)
+
+		expectedMeasurement := []cWMeasurement{{
+			Namespace:  namespace,
+			Dimensions: [][]string{{"normal_label"}},
+			Metrics: []cWMetricInfo{{
+				Name:              "metric1",
+				Unit:              "Count",
+				StorageResolution: 60,
+			}},
+		}}
+		assertCWMeasurementSliceEqual(t, expectedMeasurement, cw.measurements)
+	})
+
+	t.Run("AddEntity false", func(t *testing.T) {
+		config := &Config{
+			DimensionRollupOption: "",
+			logger:                zap.NewNop(),
+			AddEntity:             false,
+		}
+		cw := translateGroupedMetricToCWMetric(groupedMetric, config)
+
+		require.Len(t, cw.measurements, 1)
+		dims := cw.measurements[0].Dimensions
+		assert.Equal(t, [][]string{{"normal_label"}}, dims)
+
+		assert.Equal(t, timestamp, cw.timestampMs)
+		assert.Equal(t, namespace, cw.measurements[0].Namespace)
+
+		expectedFields := map[string]any{
+			"normal_label": "normal_value",
+			"metric1":      1,
+		}
+		assert.Equal(t, expectedFields, cw.fields)
+	})
+}
+
+func TestEntityK8sClusterWithMissingPlatformType(t *testing.T) {
+	labels := map[string]string{
+		entity.AttributeEntityK8sClusterName: "myEksCluster",
+	}
+	groupedMetric := &groupedMetric{
+		labels: labels,
+		metrics: map[string]*metricInfo{
+			"metric1": {value: 1, unit: "Count"},
+		},
+		metadata: cWMetricMetadata{
+			groupedMetricMetadata: groupedMetricMetadata{
+				namespace:   "NoPlatformType",
+				timestampMs: 10000,
+			},
+		},
+	}
+
+	t.Run("AddEntity true", func(t *testing.T) {
+		config := &Config{
+			logger:    zap.NewNop(),
+			AddEntity: true,
+		}
+		cw := translateGroupedMetricToCWMetric(groupedMetric, config)
+
+		require.Len(t, cw.measurements, 1)
+		assert.Empty(t, cw.measurements[0].Dimensions[0], "should have no dimension since no normal labels")
+
+		assert.Empty(t, cw.fields["K8s.Cluster"])
+		assert.Empty(t, cw.fields["EKS.Cluster"])
+
+		expectedFields := map[string]any{
+			"metric1": 1,
+		}
+		assert.Equal(t, expectedFields, cw.fields)
+	})
+
+	t.Run("AddEntity false", func(t *testing.T) {
+		config := &Config{
+			logger:    zap.NewNop(),
+			AddEntity: false,
+		}
+		cw := translateGroupedMetricToCWMetric(groupedMetric, config)
+
+		require.Len(t, cw.measurements, 1)
+		assert.Empty(t, cw.measurements[0].Dimensions[0], "should have no dimension since no normal labels")
+
+		assert.Empty(t, cw.fields["K8s.Cluster"])
+		assert.Empty(t, cw.fields["EKS.Cluster"])
+
+		expectedFields := map[string]any{
+			"metric1": 1,
+		}
+		assert.Equal(t, expectedFields, cw.fields)
+	})
+}
+
+func TestUnknownEntityAttributeIsDropped(t *testing.T) {
+	labels := map[string]string{
+		entity.AWSEntityPrefix + "unknown_field": "some_value",
+	}
+	groupedMetric := &groupedMetric{
+		labels: labels,
+		metrics: map[string]*metricInfo{
+			"metric1": {value: 1, unit: "Count"},
+		},
+		metadata: cWMetricMetadata{
+			groupedMetricMetadata: groupedMetricMetadata{
+				namespace:   "UnknownEntityAttribute",
+				timestampMs: 12345,
+			},
+		},
+	}
+
+	t.Run("AddEntity true", func(t *testing.T) {
+		config := &Config{
+			AddEntity: true,
+			logger:    zap.NewNop(),
+		}
+		cw := translateGroupedMetricToCWMetric(groupedMetric, config)
+
+		assert.NotContains(t, cw.fields, "unknown_field")
+		assert.Equal(t, 1, cw.fields["metric1"])
+	})
+
+	t.Run("AddEntity false", func(t *testing.T) {
+		config := &Config{
+			AddEntity: false,
+			logger:    zap.NewNop(),
+		}
+		cw := translateGroupedMetricToCWMetric(groupedMetric, config)
+
+		assert.NotContains(t, cw.fields, "unknown_field")
+		assert.Equal(t, 1, cw.fields["metric1"])
+	})
 }
 
 func generateTestMetrics(tm testMetric) pmetric.Metrics {


### PR DESCRIPTION
# Description of the issue
To support the [**Explore related**](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ExploreRelated.html) feature in CloudWatch, the CloudWatch Agent sends an "Entity", which includes relevant metadata to correlate metrics or logs between resources (e.g., an EKS cluster) and services (e.g., a Java application). In the case of exporting custom metrics received by OTLP or from scraping Prometheus targets, we need to export a service "Entity" for EMF, which includes the following attributes: `Service`, `Environment`, `EKS.Cluster`/`K8s.Cluster`, `K8s.Namespace`, `K8s.Workload`, `K8s.Node`, `AWS.ServiceNameSource`, `PlatformType`, and `EC2.InstanceId`.

Right now, in the CloudWatch Agent's entity processor, we generate these "Entity" fields, but they're in the following format: `com.amazonaws.cloudwatch.entity.internal.<field>`. We then filter them out when creating labels in the EMF exporter.

We need to convert them into their expected format when exporting for EMF logs.

# Description of changes
> [!IMPORTANT]
> **Co-PRs:** https://github.com/aws/amazon-cloudwatch-agent/pull/1529; https://github.com/aws-observability/helm-charts/pull/171
- Migrate current entity label filtering logic to filtering out dimensions as we don't want "Entity" fields to show up as dimensions.
- Convert entity attributes into expected entity fields when generating field map for EMF logs.
- Create `entityattributes.go` to hold entity constants and field retrieval logic.
- Add flag to enable entity.
- Add unit tests.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
## CloudWatch Agent Logs
`2025-02-06T17:27:40Z D! {"caller":"awsemfexporter@v0.103.0/emf_exporter.go:160","msg":"Finish processing resource metrics","kind":"exporter","data_type":"metrics","name":"awsemf","labels":{"com.amazonaws.cloudwatch.entity.internal.aws.account.id":"637423426239","com.amazonaws.cloudwatch.entity.internal.deployment.environment":"eks:entity-cluster-2/default","com.amazonaws.cloudwatch.entity.internal.instance.id":"i-0da7f196c5fa59a25","com.amazonaws.cloudwatch.entity.internal.k8s.cluster.name":"entity-cluster-2","com.amazonaws.cloudwatch.entity.internal.k8s.namespace.name":"default","com.amazonaws.cloudwatch.entity.internal.k8s.node.name":"ip-XXX-XX-XX-XX.us-west-2.compute.internal","com.amazonaws.cloudwatch.entity.internal.k8s.workload.name":"sample-app","com.amazonaws.cloudwatch.entity.internal.platform.type":"AWS::EKS","com.amazonaws.cloudwatch.entity.internal.service.name":"unknown_service:java","com.amazonaws.cloudwatch.entity.internal.service.name.source":"Instrumentation","com.amazonaws.cloudwatch.entity.internal.type":"Service","host.arch":"amd64","host.name":"sample-app-54d797bb9b-nkb77", "k8s.deployment.name":"sample-app","k8s.namespace.name":"default","k8s.node.name":"ip-XXX-XX-XX-XX.us-west-2.compute.internal","k8s.pod.ip":"XXX.XX.XX.XX","k8s.pod.name":"sample-app-54d797bb9b-nkb77","k8s.replicaset.name":"sample-app-54d797bb9b","os.description":"Linux 6.1.119-129.201.amzn2023.x86_64","os.type":"linux","process.command_line":"/usr/lib/jvm/java-17-openjdk-amd64:bin:java -javaagent:/aws-observability/classpath/aws-opentelemetry-agent-1.17.0.jar","process.executable.path":"/usr/lib/jvm/java-17-openjdk-amd64:bin:java","process.pid":"","process.runtime.description":"Debian OpenJDK 64-Bit Server VM 17.0.4+8-Debian-1deb11u1","process.runtime.name":"OpenJDK Runtime Environment","process.runtime.version":"17.0.4+8-Debian-1deb11u1","service.name":"unknown_service:java","telemetry.auto.version":"1.17.0-aws","telemetry.sdk.language":"java","telemetry.sdk.name":"opentelemetry","telemetry.sdk.version":"1.17.0"}}`

## EMF Log
```
{
    "AWS.ServiceNameSource": "Instrumentation",
    "CloudWatchMetrics": [
        {
            "Namespace": "CWAgent",
            "Dimensions": [
                [
                    "process.runtime.description",
                    "telemetry.sdk.language",
                    "telemetry.sdk.name",
                    "service.name",
                    "process.executable.path",
                    "telemetry.auto.version",
                    "k8s.pod.ip",
                    "k8s.node.name",
                    "k8s.pod.name",
                    "process.pid",
                    "os.description",
                    "telemetry.sdk.version",
                    "k8s.namespace.name",
                    "host.arch",
                    "process.runtime.version",
                    "host.name",
                    "process.runtime.name",
                    "os.type",
                    "k8s.deployment.name",
                    "process.command_line",
                    "k8s.replicaset.name"
                ]
            ],
            "Metrics": [
                {
                    "Name": "process.runtime.jvm.classes.unloaded"
                },
                {
                    "Name": "process.runtime.jvm.classes.loaded"
                },
                {
                    "Name": "process.runtime.jvm.classes.current_loaded"
                },
                {
                    "Name": "process.runtime.jvm.threads.count"
                }
            ]
        }
    ],
    "EC2.InstanceId": "i-0da7f196c5fa59a25",
    "Environment": "eks:entity-cluster-2/default",
    "EKS.Cluster": "entity-cluster-2",
    "K8s.Namespace": "default",
    "K8s.Node": "ip-XXX-XX-XX-XX.us-west-2.compute.internal",
    "K8s.Workload": "sample-app",
    "Service": "unknown_service:java",
    "PlatformType": "AWS::EKS",
    "Timestamp": "1738862978053",
    "Version": "0",
    "host.arch": "amd64",
    "host.name": "sample-app-54d797bb9b-nkb77",
    "k8s.deployment.name": "sample-app",
    "k8s.namespace.name": "default",
    "k8s.node.name": "ip-XXX-XX-XX-XX.us-west-2.compute.internal",
    "k8s.pod.ip": "XXX.XX.XX.XX",
    "k8s.pod.name": "sample-app-54d797bb9b-nkb77",
    "k8s.replicaset.name": "sample-app-54d797bb9b",
    "os.description": "Linux 6.1.119-129.201.amzn2023.x86_64",
    "os.type": "linux",
    "process.command_line": "/usr/lib/jvm/java-17-openjdk-amd64:bin:java -javaagent:/aws-observability/classpath/aws-opentelemetry-agent-1.17.0.jar",
    "process.executable.path": "/usr/lib/jvm/java-17-openjdk-amd64:bin:java",
    "process.pid": "1",
    "process.runtime.description": "Debian OpenJDK 64-Bit Server VM 17.0.4+8-Debian-1deb11u1",
    "process.runtime.name": "OpenJDK Runtime Environment",
    "process.runtime.version": "17.0.4+8-Debian-1deb11u1",
    "service.name": "unknown_service:java",
    "telemetry.auto.version": "1.17.0-aws",
    "telemetry.sdk.language": "java",
    "telemetry.sdk.name": "opentelemetry",
    "telemetry.sdk.version": "1.17.0",
    "process.runtime.jvm.classes.current_loaded": 0,
    "process.runtime.jvm.classes.loaded": 0,
    "process.runtime.jvm.classes.unloaded": 0,
    "process.runtime.jvm.threads.count": 0
}
```