### PR TITLE
Update workflows to only test ocb collector modules

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -70,23 +70,7 @@ jobs:
           - windows
           - linux
         group:
-          - receiver-0
-          - receiver-1
-          - receiver-2
-          - receiver-3
-          - processor-0
-          - processor-1
-          - exporter-0
-          - exporter-1
-          - exporter-2
-          - exporter-3
-          - extension
-          - connector
-          - internal
-          - pkg
-          - cmd-0
-          - cmd-1
-          - other
+          - ocb-collector
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
@@ -138,22 +122,7 @@ jobs:
       fail-fast: false
       matrix:
         group:
-          - receiver-0
-          - receiver-1
-          - receiver-2
-          - receiver-3
-          - processor-0
-          - processor-1
-          - exporter-0
-          - exporter-1
-          - exporter-2
-          - exporter-3
-          - extension
-          - connector
-          - internal
-          - pkg
-          - cmd-0
-          - cmd-1
+          - ocb-collector
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -258,23 +227,7 @@ jobs:
         go-version: ["1.22.5", "1.21.11"] # 1.20 is interpreted as 1.2 without quotes
         runner: [ubuntu-latest]
         group:
-          - receiver-0
-          - receiver-1
-          - receiver-2
-          - receiver-3
-          - processor-0
-          - processor-1
-          - exporter-0
-          - exporter-1
-          - exporter-2
-          - exporter-3
-          - extension
-          - connector
-          - internal
-          - pkg
-          - cmd-0
-          - cmd-1
-          - other
+          - ocb-collector
     runs-on: ${{ matrix.runner }}
     needs: [setup-environment]
     steps:
@@ -349,22 +302,7 @@ jobs:
       fail-fast: false
       matrix:
         group:
-          - receiver-0
-          - receiver-1
-          - receiver-2
-          - receiver-3
-          - processor-0
-          - processor-1
-          - exporter-0
-          - exporter-1
-          - exporter-2
-          - exporter-3
-          - extension
-          - connector
-          - internal
-          - pkg
-          - cmd-0
-          - cmd-1
+          - ocb-collector
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ CMD_MODS_1 := $(shell find ./cmd/[n-z]* $(FIND_MOD_ARGS) -not -path "./cmd/otelc
 CMD_MODS := $(CMD_MODS_0) $(CMD_MODS_1)
 OVERRIDE_MODS := $(shell find ./override/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
 OTHER_MODS := $(shell find . $(EX_COMPONENTS) $(EX_INTERNAL) $(EX_PKG) $(EX_CMD) $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) ) $(PWD)
+OCB_COLLECTOR_MODS := $(shell find ./processor/awsapplicationsignalsprocessor ./exporter/awsemfexporter ./internal/aws/cwlogs ./internal/aws/awsutil $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
 ALL_MODS := $(RECEIVER_MODS) $(PROCESSOR_MODS) $(EXPORTER_MODS) $(EXTENSION_MODS) $(CONNECTOR_MODS) $(INTERNAL_MODS) $(PKG_MODS) $(CMD_MODS) $(OTHER_MODS)
 
 FIND_INTEGRATION_TEST_MODS={ find . -type f -name "*integration_test.go" & find . -type f -name "*e2e_test.go" -not -path "./testbed/*"; }
@@ -88,6 +89,7 @@ all-groups:
 	@echo "\ncmd: $(CMD_MODS)"
 	@echo "\noverride: $(OVERRIDE_MODS)"
 	@echo "\nother: $(OTHER_MODS)"
+	@echo "\nocb-collector: $(OCB_COLLECTOR_MODS)"
 
 .PHONY: all
 all: install-tools all-common goporto multimod-verify gotest otelcontribcol
@@ -251,6 +253,9 @@ for-override-target: $(OVERRIDE_MODS)
 
 .PHONY: for-other-target
 for-other-target: $(OTHER_MODS)
+
+.PHONY: for-ocb-collector-target
+for-ocb-collector-target: $(OCB_COLLECTOR_MODS)
 
 .PHONY: for-integration-target
 for-integration-target: $(INTEGRATION_MODS)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Since the OCB Collector is decoupled from the rest of the repository and only utilizes certain modules, there is no need for us to test non-ocb modules. This change will update the github workflows to only test the relavant workflows for the aws-ocb-dev branch. 

<!--Describe what testing was performed and which tests were added.-->
Tested on personal account to verify that the ocb collector test cases pass and that the correct workflow is triggered when a PR is merged to the aws-ocb-dev branch.

<!--Please delete paragraphs that you did not use before submitting.-->
