### PR TITLE
Use k8s secret file for bearer token to handle key rotations 

### DIFF
--- a/internal/kubelet/client.go
+++ b/internal/kubelet/client.go
@@ -130,7 +130,6 @@ func (p *kubeConfigClientProvider) BuildClient() (Client, error) {
 	}
 
 	joinPath, err := url.JoinPath(authConf.Host, "/api/v1/nodes/", p.endpoint, "/proxy/")
-
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper_test.go
@@ -101,7 +101,6 @@ func TestNewPrometheusScraperBadInputs(t *testing.T) {
 			Host:                componenttest.NewNopHost(),
 			ClusterNameProvider: mockClusterNameProvider{},
 			LeaderElection:      nil,
-			BearerToken:         "",
 		},
 		{
 			Ctx:                 context.TODO(),
@@ -111,7 +110,6 @@ func TestNewPrometheusScraperBadInputs(t *testing.T) {
 			Host:                componenttest.NewNopHost(),
 			ClusterNameProvider: mockClusterNameProvider{},
 			LeaderElection:      &leaderElection,
-			BearerToken:         "",
 		},
 		{
 			Ctx:                 context.TODO(),
@@ -121,7 +119,6 @@ func TestNewPrometheusScraperBadInputs(t *testing.T) {
 			Host:                nil,
 			ClusterNameProvider: mockClusterNameProvider{},
 			LeaderElection:      &leaderElection,
-			BearerToken:         "",
 		},
 		{
 			Ctx:                 context.TODO(),
@@ -131,7 +128,6 @@ func TestNewPrometheusScraperBadInputs(t *testing.T) {
 			Host:                componenttest.NewNopHost(),
 			ClusterNameProvider: nil,
 			LeaderElection:      &leaderElection,
-			BearerToken:         "",
 		},
 	}
 
@@ -172,7 +168,6 @@ func TestNewPrometheusScraperEndToEnd(t *testing.T) {
 		Host:                componenttest.NewNopHost(),
 		ClusterNameProvider: mockClusterNameProvider{},
 		LeaderElection:      &leaderElection,
-		BearerToken:         "",
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, mockClusterNameProvider{}, scraper.clusterNameProvider)

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -12,13 +12,6 @@ import (
 	"time"
 
 	"github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware"
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/pdata/pmetric"
-	"go.opentelemetry.io/collector/receiver"
-	"go.uber.org/zap"
-	"k8s.io/client-go/rest"
-
 	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor"
@@ -33,6 +26,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/prometheusscraper/decoratorconsumer"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/receiver"
+	"go.uber.org/zap"
 )
 
 const (
@@ -270,16 +268,6 @@ func (acir *awsContainerInsightReceiver) initPrometheusScraper(ctx context.Conte
 	}
 
 	acir.settings.Logger.Debug("kube apiserver endpoint found", zap.String("endpoint", endpoint))
-	// use the same leader
-
-	restConfig, err := rest.InClusterConfig()
-	if err != nil {
-		return err
-	}
-	bearerToken := restConfig.BearerToken
-	if bearerToken == "" {
-		return errors.New("bearer token was empty")
-	}
 
 	acir.prometheusScraper, err = k8sapiserver.NewPrometheusScraper(k8sapiserver.PrometheusScraperOpts{
 		Ctx:                 ctx,
@@ -289,7 +277,6 @@ func (acir *awsContainerInsightReceiver) initPrometheusScraper(ctx context.Conte
 		Host:                host,
 		ClusterNameProvider: hostInfo,
 		LeaderElection:      leaderElection,
-		BearerToken:         bearerToken,
 	})
 	return err
 }

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -12,6 +12,12 @@ import (
 	"time"
 
 	"github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/receiver"
+	"go.uber.org/zap"
+
 	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor"
@@ -26,11 +32,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/prometheusscraper/decoratorconsumer"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil"
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/pdata/pmetric"
-	"go.opentelemetry.io/collector/receiver"
-	"go.uber.org/zap"
 )
 
 const (


### PR DESCRIPTION
#### Description
Use a Kubernetes secret file for the bearer token when accessing the apiserver prometheus endpoint to properly handle key rotations. This aligns with the recent update made to the Kueue receiver, ensuring consistency in authentication management. https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/285

#### Testing
Deployed the changes to a testing cluster to verify for apiserver metric `apiserver_request_total` 
<img width="1194" alt="Screenshot 2025-03-18 at 3 00 52 PM" src="https://github.com/user-attachments/assets/602fdce0-316c-4716-a609-0e7da6aed788" />

This is a copy of https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/292