### PR TITLE
reduce noisy logs with prometheus receiver

### DIFF
--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -126,11 +126,11 @@ func (t *transaction) Append(_ storage.SeriesRef, ls labels.Labels, atMs int64, 
 	// But it can also be a staleNaN, which is inserted when the target goes away.
 	if metricName == scrapeUpMetricName && val != 1.0 && !value.IsStaleNaN(val) {
 		if val == 0.0 {
-			t.logger.Warn("Failed to scrape Prometheus endpoint",
+			t.logger.Debug("Failed to scrape Prometheus endpoint",
 				zap.Int64("scrape_timestamp", atMs),
 				zap.Stringer("target_labels", ls))
 		} else {
-			t.logger.Warn("The 'up' metric contains invalid value",
+			t.logger.Debug("The 'up' metric contains invalid value",
 				zap.Float64("value", val),
 				zap.Int64("scrape_timestamp", atMs),
 				zap.Stringer("target_labels", ls))


### PR DESCRIPTION
#### Description
Prometheus receiver generates warning logs at every polling interval when it fails to scrape a target. In container environments, this can clutter agent logs, especially with EnhancedContainerInsights enabled, as it initiates both Neuron and DCGM scrapers. 

This change suppresses those warning logs to reduce log noise and also helps reduce costs associated with excessive and unnecessary logging. However, for troubleshooting Prometheus metrics, enabling the agent's debug mode will restore these error logs, allowing for investigation when needed.

Example logs:
```
2025-03-28T13:58:15Z W! {"caller":"internal/transaction.go:125","msg":"Failed to scrape Prometheus endpoint","kind":"receiver","name":"awscontainerinsightreceiver","data_type":"metrics","scrape_timestamp":1743170295987,"target_labels":"{__name__=\"up\", instance=\"neuron-monitor-service.amazon-cloudwatch.svc:8000\", job=\"containerInsightsNeuronMonitorScraper\"}"}
2025-03-28T13:59:10Z W! {"caller":"internal/transaction.go:125","msg":"Failed to scrape Prometheus endpoint","kind":"receiver","name":"awscontainerinsightreceiver","data_type":"metrics","scrape_timestamp":1743170290086,"target_labels":"{__name__=\"up\", instance=\"dcgm-exporter-service.amazon-cloudwatch.svc:9400\", job=\"containerInsightsDCGMExporterScraper\"}"}
2025-03-28T13:59:15Z W! {"caller":"internal/transaction.go:125","msg":"Failed to scrape Prometheus endpoint","kind":"receiver","name":"awscontainerinsightreceiver","data_type":"metrics","scrape_timestamp":1743170355987,"target_labels":"{__name__=\"up\", instance=\"neuron-monitor-service.amazon-cloudwatch.svc:8000\", job=\"containerInsightsNeuronMonitorScraper\"}"}
2025-03-28T14:00:10Z W! {"caller":"internal/transaction.go:125","msg":"Failed to scrape Prometheus endpoint","kind":"receiver","name":"awscontainerinsightreceiver","data_type":"metrics","scrape_timestamp":1743170350088,"target_labels":"{__name__=\"up\", instance=\"dcgm-exporter-service.amazon-cloudwatch.svc:9400\", job=\"containerInsightsDCGMExporterScraper\"}"}
```

#### Testing
deployed to a test cluster
