### PR TITLE
Add scraper for NVME Container Insights prometheus metrics in EKS (#296)

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -197,6 +197,7 @@ const (
 	TypePodEFA          = "PodEFA"
 	TypeNodeEFA         = "NodeEFA"
 	TypeHyperPodNode    = "HyperPodNode"
+	TypeNodeNVME        = "NodeNVME"
 
 	// unit
 	UnitBytes       = "Bytes"

--- a/internal/aws/containerinsight/k8sconst.go
+++ b/internal/aws/containerinsight/k8sconst.go
@@ -20,6 +20,7 @@ const (
 	GpuDevice        = "GpuDevice"
 	EfaDevice        = "EfaDevice"
 	EniID            = "NetworkInterfaceId"
+	VolumeID         = "VolumeId"
 
 	PodStatus       = "pod_status"
 	ContainerStatus = "container_status"

--- a/receiver/awscontainerinsightreceiver/internal/nvme/metric_unit.go
+++ b/receiver/awscontainerinsightreceiver/internal/nvme/metric_unit.go
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nvme // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/gpu"
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+)
+
+const (
+	// Original Metric Names
+	ebsReadOpsTotal        = "aws_ebs_csi_read_ops_total"
+	ebsWriteOpsTotal       = "aws_ebs_csi_write_ops_total"
+	ebsReadBytesTotal      = "aws_ebs_csi_read_bytes_total"
+	ebsWriteBytesTotal     = "aws_ebs_csi_write_bytes_total"
+	ebsReadTime            = "aws_ebs_csi_read_seconds_total"
+	ebsWriteTime           = "aws_ebs_csi_write_seconds_total"
+	ebsExceededIOPSTime    = "aws_ebs_csi_exceeded_iops_seconds_total"
+	ebsExceededTPTime      = "aws_ebs_csi_exceeded_tp_seconds_total"
+	ebsExceededEC2IOPSTime = "aws_ebs_csi_ec2_exceeded_iops_seconds_total"
+	ebsExceededEC2TPTime   = "aws_ebs_csi_ec2_exceeded_tp_seconds_total"
+	ebsVolumeQueueLength   = "aws_ebs_csi_volume_queue_length"
+)
+
+var MetricToUnit = map[string]string{
+	ebsReadOpsTotal:        containerinsight.UnitCount,
+	ebsWriteOpsTotal:       containerinsight.UnitCount,
+	ebsReadBytesTotal:      containerinsight.UnitBytes,
+	ebsWriteBytesTotal:     containerinsight.UnitBytes,
+	ebsReadTime:            containerinsight.UnitSecond,
+	ebsWriteTime:           containerinsight.UnitSecond,
+	ebsExceededIOPSTime:    containerinsight.UnitSecond,
+	ebsExceededTPTime:      containerinsight.UnitSecond,
+	ebsExceededEC2IOPSTime: containerinsight.UnitSecond,
+	ebsExceededEC2TPTime:   containerinsight.UnitSecond,
+	ebsVolumeQueueLength:   containerinsight.UnitCount,
+}

--- a/receiver/awscontainerinsightreceiver/internal/nvme/nvmescraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/nvme/nvmescraper_config.go
@@ -1,0 +1,102 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nvme // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/gpu"
+
+import (
+	"os"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/kubernetes"
+	"github.com/prometheus/prometheus/model/relabel"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+)
+
+const (
+	collectionInterval        = 60 * time.Second
+	jobName                   = "containerInsightsNVMeExporterScraper"
+	scraperMetricsPath        = "/metrics"
+	scraperK8sServiceSelector = "app=ebs-csi-node"
+)
+
+type hostInfoProvider interface {
+	GetClusterName() string
+	GetInstanceID() string
+	GetInstanceType() string
+}
+
+func GetScraperConfig(hostInfoProvider hostInfoProvider) *config.ScrapeConfig {
+	return &config.ScrapeConfig{
+		ScrapeInterval:  model.Duration(collectionInterval),
+		ScrapeTimeout:   model.Duration(collectionInterval),
+		ScrapeProtocols: config.DefaultScrapeProtocols,
+		JobName:         jobName,
+		Scheme:          "http",
+		MetricsPath:     scraperMetricsPath,
+		ServiceDiscoveryConfigs: discovery.Configs{
+			&kubernetes.SDConfig{
+				Role: kubernetes.RoleService,
+				NamespaceDiscovery: kubernetes.NamespaceDiscovery{
+					Names: []string{"kube-system"},
+				},
+				Selectors: []kubernetes.SelectorConfig{
+					{
+						Role:  kubernetes.RoleService,
+						Label: scraperK8sServiceSelector,
+					},
+				},
+			},
+		},
+		MetricRelabelConfigs: getMetricRelabelConfig(hostInfoProvider),
+	}
+}
+
+func getMetricRelabelConfig(hostInfoProvider hostInfoProvider) []*relabel.Config {
+	return []*relabel.Config{
+		{
+			SourceLabels: model.LabelNames{"__name__"},
+			Regex:        relabel.MustNewRegexp("aws_ebs_csi_.*"),
+			Action:       relabel.Keep,
+		},
+
+		// Below metrics are histogram type which are not supported for container insights yet
+		{
+			SourceLabels: model.LabelNames{"__name__"},
+			Regex:        relabel.MustNewRegexp(".*_bucket|.*_sum|.*_count.*"),
+			Action:       relabel.Drop,
+		},
+		// Hacky way to inject static values (clusterName/instanceId/nodeName/volumeID)
+		{
+			SourceLabels: model.LabelNames{"instance_id"},
+			TargetLabel:  ci.NodeNameKey,
+			Regex:        relabel.MustNewRegexp(".*"),
+			Replacement:  os.Getenv("HOST_NAME"),
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"instance_id"},
+			TargetLabel:  ci.ClusterNameKey,
+			Regex:        relabel.MustNewRegexp(".*"),
+			Replacement:  hostInfoProvider.GetClusterName(),
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"instance_id"},
+			TargetLabel:  ci.InstanceID,
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  "${1}",
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"volume_id"},
+			TargetLabel:  ci.VolumeID,
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  "${1}",
+			Action:       relabel.Replace,
+		},
+	}
+}

--- a/receiver/awscontainerinsightreceiver/internal/nvme/nvmescraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/nvme/nvmescraper_test.go
@@ -1,0 +1,220 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nvme
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	configutil "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/receiver"
+	"go.uber.org/zap"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/mocks"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/prometheusscraper"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+)
+
+const renameMetric = `
+# HELP aws_ebs_csi_read_ops_total The total number of completed read operations.
+# TYPE aws_ebs_csi_read_ops_total counter
+aws_ebs_csi_read_ops_total{instance_id="i-0131bee5395cc4317",volume_id="vol-0281cf921f3dbb69b"} 55592
+# HELP aws_ebs_csi_read_seconds_total The total time spent, in seconds, by all completed read operations.
+# TYPE aws_ebs_csi_read_seconds_total counter
+aws_ebs_csi_read_seconds_total{instance_id="i-0131bee5395cc4317",volume_id="vol-0281cf921f3dbb69b"} 34.52
+`
+
+const (
+	dummyInstanceID   = "i-0000000000"
+	dummyClusterName  = "cluster-name"
+	dummyInstanceType = "instance-type"
+	dummyNodeName     = "hostname"
+)
+
+type mockHostInfoProvider struct{}
+
+func (m mockHostInfoProvider) GetClusterName() string {
+	return dummyClusterName
+}
+
+func (m mockHostInfoProvider) GetInstanceID() string {
+	return dummyInstanceID
+}
+
+func (m mockHostInfoProvider) GetInstanceType() string {
+	return dummyInstanceType
+}
+
+type mockConsumer struct {
+	t        *testing.T
+	called   *bool
+	expected map[string]struct {
+		value  float64
+		labels map[string]string
+	}
+}
+
+func (m mockConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{
+		MutatesData: false,
+	}
+}
+
+func (m mockConsumer) ConsumeMetrics(_ context.Context, md pmetric.Metrics) error {
+	assert.Equal(m.t, 1, md.ResourceMetrics().Len())
+
+	scrapedMetricCnt := 0
+	scopeMetrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	for i := 0; i < scopeMetrics.Len(); i++ {
+		metric := scopeMetrics.At(i)
+		// skip prometheus metadata metrics including "up"
+		if !strings.HasPrefix(metric.Name(), "node_") {
+			continue
+		}
+		metadata, ok := m.expected[metric.Name()]
+		assert.True(m.t, ok)
+		assert.Equal(m.t, metadata.value, metric.Gauge().DataPoints().At(0).DoubleValue())
+		for k, v := range metadata.labels {
+			gauge := metric.Gauge().DataPoints().At(0)
+			m.t.Logf("%v", gauge)
+			lv, found := metric.Gauge().DataPoints().At(0).Attributes().Get(k)
+			assert.True(m.t, found)
+			assert.Equal(m.t, v, lv.AsString())
+		}
+		scrapedMetricCnt++
+	}
+	assert.Equal(m.t, len(m.expected), scrapedMetricCnt)
+	*m.called = true
+	return nil
+}
+
+func TestNewNVMEScraperEndToEnd(t *testing.T) {
+	t.Setenv("HOST_NAME", dummyNodeName)
+	expected := map[string]struct {
+		value  float64
+		labels map[string]string
+	}{
+		"node_diskio_ebs_total_read_time": {
+			value: 34.52,
+			labels: map[string]string{
+				ci.NodeNameKey:    "hostname",
+				ci.ClusterNameKey: dummyClusterName,
+				ci.InstanceID:     "i-0131bee5395cc4317",
+				ci.VolumeID:       "vol-0281cf921f3dbb69b",
+			},
+		},
+		"node_diskio_ebs_total_read_ops": {
+			value: 55592,
+			labels: map[string]string{
+				ci.NodeNameKey:    "hostname",
+				ci.ClusterNameKey: dummyClusterName,
+				ci.InstanceID:     "i-0131bee5395cc4317",
+				ci.VolumeID:       "vol-0281cf921f3dbb69b",
+			},
+		},
+	}
+
+	consumerCalled := false
+	mConsumer := mockConsumer{
+		t:        t,
+		called:   &consumerCalled,
+		expected: expected,
+	}
+
+	settings := componenttest.NewNopTelemetrySettings()
+	settings.Logger, _ = zap.NewDevelopment()
+
+	scraper, err := prometheusscraper.NewSimplePrometheusScraper(prometheusscraper.SimplePrometheusScraperOpts{
+		Ctx:               context.TODO(),
+		TelemetrySettings: settings,
+		Consumer:          mConsumer,
+		Host:              componenttest.NewNopHost(),
+		HostInfoProvider:  mockHostInfoProvider{},
+		ScraperConfigs:    GetScraperConfig(mockHostInfoProvider{}),
+		Logger:            settings.Logger,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, mockHostInfoProvider{}, scraper.HostInfoProvider)
+
+	// build up a new PR
+	promFactory := prometheusreceiver.NewFactory()
+
+	targets := []*mocks.TestData{
+		{
+			Name: "nvme",
+			Pages: []mocks.MockPrometheusResponse{
+				{Code: 200, Data: renameMetric},
+			},
+		},
+	}
+	mp, cfg, err := mocks.SetupMockPrometheus(targets...)
+	assert.NoError(t, err)
+
+	scrapeConfig := scraper.ScraperConfigs
+	scrapeConfig.ScrapeProtocols = cfg.ScrapeConfigs[0].ScrapeProtocols
+	scrapeConfig.ScrapeInterval = cfg.ScrapeConfigs[0].ScrapeInterval
+	scrapeConfig.ScrapeTimeout = cfg.ScrapeConfigs[0].ScrapeInterval
+	scrapeConfig.Scheme = "http"
+	scrapeConfig.MetricsPath = cfg.ScrapeConfigs[0].MetricsPath
+	scrapeConfig.HTTPClientConfig = configutil.HTTPClientConfig{
+		TLSConfig: configutil.TLSConfig{
+			InsecureSkipVerify: true,
+		},
+	}
+	scrapeConfig.ServiceDiscoveryConfigs = discovery.Configs{
+		// using dummy static config to avoid service discovery initialization
+		&discovery.StaticConfig{
+			{
+				Targets: []model.LabelSet{
+					{
+						model.AddressLabel: model.LabelValue(strings.Split(mp.Srv.URL, "http://")[1]),
+					},
+				},
+			},
+		},
+	}
+
+	promConfig := prometheusreceiver.Config{
+		PrometheusConfig: &prometheusreceiver.PromConfig{
+			ScrapeConfigs: []*config.ScrapeConfig{scrapeConfig},
+		},
+	}
+
+	// replace the prom receiver
+	params := receiver.Settings{
+		TelemetrySettings: scraper.Settings,
+	}
+	scraper.PrometheusReceiver, err = promFactory.CreateMetrics(scraper.Ctx, params, &promConfig, mConsumer)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, mp)
+	defer mp.Close()
+
+	// perform a single scrape, this will kick off the scraper process for additional scrapes
+	scraper.GetMetrics()
+
+	t.Cleanup(func() {
+		scraper.Shutdown()
+	})
+
+	// wait for 2 scrapes, one initiated by us, another by the new scraper process
+	mp.Wg.Wait()
+	mp.Wg.Wait()
+	// make sure the consumer is called at scraping interval
+	assert.True(t, consumerCalled)
+}
+
+func TestDcgmScraperJobName(t *testing.T) {
+	// needs to start with containerInsights
+	assert.True(t, strings.HasPrefix(jobName, "containerInsightsNVMeExporterScraper"))
+}

--- a/receiver/awscontainerinsightreceiver/internal/nvme/nvmescraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/nvme/nvmescraper_test.go
@@ -78,16 +78,16 @@ func (m mockConsumer) ConsumeMetrics(_ context.Context, md pmetric.Metrics) erro
 	for i := 0; i < scopeMetrics.Len(); i++ {
 		metric := scopeMetrics.At(i)
 		// skip prometheus metadata metrics including "up"
-		if !strings.HasPrefix(metric.Name(), "node_") {
+		if !strings.HasPrefix(metric.Name(), "aws_ebs") {
 			continue
 		}
 		metadata, ok := m.expected[metric.Name()]
 		assert.True(m.t, ok)
-		assert.Equal(m.t, metadata.value, metric.Gauge().DataPoints().At(0).DoubleValue())
+		assert.Equal(m.t, metadata.value, metric.Sum().DataPoints().At(0).DoubleValue())
 		for k, v := range metadata.labels {
-			gauge := metric.Gauge().DataPoints().At(0)
+			gauge := metric.Sum().DataPoints().At(0)
 			m.t.Logf("%v", gauge)
-			lv, found := metric.Gauge().DataPoints().At(0).Attributes().Get(k)
+			lv, found := metric.Sum().DataPoints().At(0).Attributes().Get(k)
 			assert.True(m.t, found)
 			assert.Equal(m.t, v, lv.AsString())
 		}
@@ -104,7 +104,7 @@ func TestNewNVMEScraperEndToEnd(t *testing.T) {
 		value  float64
 		labels map[string]string
 	}{
-		"node_diskio_ebs_total_read_time": {
+		"aws_ebs_csi_read_seconds_total": {
 			value: 34.52,
 			labels: map[string]string{
 				ci.NodeNameKey:    "hostname",
@@ -113,7 +113,7 @@ func TestNewNVMEScraperEndToEnd(t *testing.T) {
 				ci.VolumeID:       "vol-0281cf921f3dbb69b",
 			},
 		},
-		"node_diskio_ebs_total_read_ops": {
+		"aws_ebs_csi_read_ops_total": {
 			value: 55592,
 			labels: map[string]string{
 				ci.NodeNameKey:    "hostname",
@@ -214,7 +214,7 @@ func TestNewNVMEScraperEndToEnd(t *testing.T) {
 	assert.True(t, consumerCalled)
 }
 
-func TestDcgmScraperJobName(t *testing.T) {
+func TestNvmeScraperJobName(t *testing.T) {
 	// needs to start with containerInsights
 	assert.True(t, strings.HasPrefix(jobName, "containerInsightsNVMeExporterScraper"))
 }

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -28,6 +28,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8sapiserver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/neuron"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/nvme"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/prometheusscraper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/prometheusscraper/decoratorconsumer"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores"
@@ -57,6 +58,7 @@ type awsContainerInsightReceiver struct {
 	prometheusScraper        *k8sapiserver.PrometheusScraper
 	podResourcesStore        *stores.PodResourcesStore
 	dcgmScraper              *prometheusscraper.SimplePrometheusScraper
+	nvmeScraper              *prometheusscraper.SimplePrometheusScraper
 	neuronMonitorScraper     *prometheusscraper.SimplePrometheusScraper
 	efaSysfsScraper          *efa.Scraper
 }
@@ -200,6 +202,10 @@ func (acir *awsContainerInsightReceiver) initEKS(ctx context.Context, host compo
 		if err != nil {
 			acir.settings.Logger.Debug("Unable to start dcgm scraper", zap.Error(err))
 		}
+		err = acir.initNVMEScraper(ctx, host, hostInfo, localNodeDecorator)
+		if err != nil {
+			acir.settings.Logger.Debug("Unable to start NVME scraper", zap.Error(err))
+		}
 		err = acir.initPodResourcesStore()
 		if err != nil {
 			acir.settings.Logger.Debug("Unable to start pod resources store", zap.Error(err))
@@ -311,6 +317,31 @@ func (acir *awsContainerInsightReceiver) initDcgmScraper(ctx context.Context, ho
 	return err
 }
 
+func (acir *awsContainerInsightReceiver) initNVMEScraper(ctx context.Context, host component.Host, hostInfo *hostinfo.Info, localNodeDecorator stores.Decorator) error {
+	decoConsumer := decoratorconsumer.DecorateConsumer{
+		ContainerOrchestrator: ci.EKS,
+		NextConsumer:          acir.nextConsumer,
+		MetricType:            ci.TypeNodeNVME,
+		MetricToUnitMap:       nvme.MetricToUnit,
+		K8sDecorator:          localNodeDecorator,
+		Logger:                acir.settings.Logger,
+	}
+
+	scraperOpts := prometheusscraper.SimplePrometheusScraperOpts{
+		Ctx:               ctx,
+		TelemetrySettings: acir.settings,
+		Consumer:          &decoConsumer,
+		Host:              host,
+		ScraperConfigs:    nvme.GetScraperConfig(hostInfo),
+		HostInfoProvider:  hostInfo,
+		Logger:            acir.settings.Logger,
+	}
+
+	var err error
+	acir.nvmeScraper, err = prometheusscraper.NewSimplePrometheusScraper(scraperOpts)
+	return err
+}
+
 func (acir *awsContainerInsightReceiver) initPodResourcesStore() error {
 	var err error
 	acir.podResourcesStore, err = stores.NewPodResourcesStore(acir.settings.Logger)
@@ -401,6 +432,9 @@ func (acir *awsContainerInsightReceiver) Shutdown(context.Context) error {
 	if acir.neuronMonitorScraper != nil {
 		acir.neuronMonitorScraper.Shutdown()
 	}
+	if acir.nvmeScraper != nil {
+		acir.nvmeScraper.Shutdown()
+	}
 	if acir.efaSysfsScraper != nil {
 		acir.efaSysfsScraper.Shutdown()
 	}
@@ -446,6 +480,10 @@ func (acir *awsContainerInsightReceiver) collectData(ctx context.Context) error 
 
 	if acir.neuronMonitorScraper != nil {
 		acir.neuronMonitorScraper.GetMetrics() //nolint:errcheck
+	}
+
+	if acir.nvmeScraper != nil {
+		acir.nvmeScraper.GetMetrics() //nolint:errcheck
 	}
 
 	if acir.efaSysfsScraper != nil {


### PR DESCRIPTION
> [!IMPORTANT]  
> This PR assumes CSI driver will modify their Kubernetes service policy to be local. Otherwise the metrics routed from the service IP will be random.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
## Description
Customers who have ebs csi driver addon installed should see new ebs volume metrics when enabling container insights. This is not the current behavior since container insights receiver does not have any functionality to support this use case. 

This PR adds prometheus scraper to scrape at port 3302 which is the default port exposed by CSI driver for disk metrics: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/metrics.md#ebs-node-metrics

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
## Link to tracking issue
- https://github.com/aws/containers-roadmap/issues/2377

<!--Describe what testing was performed and which tests were added.-->
## Testing
Unit test. 

### Manual Testing
#### EMF Output
```
{
    "AutoScalingGroupName": "eks-ng-27c93684-7ec8b6de-01de-1dd8-638d-256a326dd637",
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName"
                ],
                [
                    "ClusterName",
                    "InstanceId",
                    "NodeName"
                ],
                [
                    "ClusterName",
                    "InstanceId",
                    "NodeName",
                    "VolumeID"
                ]
            ],
            "Metrics": [
                {
                    "Name": "node_diskio_ebs_ec2_instance_performance_exceeded_iops",
                    "Unit": "Seconds",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_diskio_ebs_total_read_bytes",
                    "Unit": "Bytes",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_diskio_ebs_total_write_time",
                    "Unit": "Seconds",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_diskio_ebs_total_read_ops",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_diskio_ebs_total_read_time",
                    "Unit": "Seconds",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_diskio_ebs_volume_performance_exceeded_tp",
                    "Unit": "Seconds",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_diskio_ebs_volume_queue_length",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_diskio_ebs_volume_performance_exceeded_iops",
                    "Unit": "Seconds",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_diskio_ebs_ec2_instance_performance_exceeded_tp",
                    "Unit": "Seconds",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_diskio_ebs_total_write_bytes",
                    "Unit": "Bytes",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_diskio_ebs_total_write_ops",
                    "Unit": "Count",
                    "StorageResolution": 60
                }
            ]
        }
    ],
    "ClusterName": "compass-cluster-iad",
    "InstanceId": "i-123456789",
    "InstanceType": "m5.large",
    "NodeName": "ip-123-456-7-890.ec2.internal",
    "Timestamp": "1743094298457",
    "Version": "0",
    "VolumeID": "vol-123456789",
    "http.scheme": "http",
    "instance_id": "i-123456789",
    "k8s.namespace.name": "kube-system",
    "kubernetes": {
        "host": "ip-123-456-7-890.ec2.internal"
    },
    "net.host.name": "ebs-csi-node.kube-system.svc",
    "net.host.port": "3302",
    "server.address": "ebs-csi-node.kube-system.svc",
    "server.port": "3302",
    "service.instance.id": "ebs-csi-node.kube-system.svc:3302",
    "service.name": "containerInsightsNVMeExporterScraper",
    "url.scheme": "http",
    "volume_id": "vol-123456789",
    "node_diskio_ebs_ec2_instance_performance_exceeded_iops": 0,
    "node_diskio_ebs_ec2_instance_performance_exceeded_tp": 0,
    "node_diskio_ebs_total_read_bytes": 4437120000,
    "node_diskio_ebs_total_read_ops": 160206,
    "node_diskio_ebs_total_read_time": 100.642948,
    "node_diskio_ebs_total_write_bytes": 51040256,
    "node_diskio_ebs_total_write_ops": 213,
    "node_diskio_ebs_total_write_time": 0.611623,
    "node_diskio_ebs_volume_performance_exceeded_iops": 0,
    "node_diskio_ebs_volume_performance_exceeded_tp": 0,
    "node_diskio_ebs_volume_queue_length": 0
}
```
<img width="1405" alt="Screenshot 2025-03-27 at 12 54 55 PM" src="https://github.com/user-attachments/assets/e743ae39-3386-4d73-8f77-071fba70cc17" />

<!--Please delete paragraphs that you did not use before submitting.-->
