### PR TITLE
[exporter/awsemfexporter] Allowlist auto scaling group entity mapping for EMF exporter

### DIFF
--- a/exporter/awsemfexporter/internal/entity/entityattributes.go
+++ b/exporter/awsemfexporter/internal/entity/entityattributes.go
@@ -15,6 +15,7 @@ const (
 	AttributeEntityServiceNameSource     = AWSEntityPrefix + "service.name.source"
 	AttributeEntityPlatformType          = AWSEntityPrefix + "platform.type"
 	AttributeEntityInstanceID            = AWSEntityPrefix + "instance.id"
+	AttributeEntityAutoScalingGroup      = AWSEntityPrefix + "auto.scaling.group"
 
 	// Entity fields in EMF log
 	Service              = "Service"
@@ -27,6 +28,7 @@ const (
 	AWSServiceNameSource = "AWS.ServiceNameSource"
 	PlatformType         = "PlatformType"
 	InstanceID           = "EC2.InstanceId"
+	AutoscalingGroup     = "EC2.AutoScalingGroup"
 
 	// Possible values for PlatformType
 	AttributeEntityEKSPlatform = "AWS::EKS"
@@ -42,6 +44,7 @@ var attributeEntityToFieldMap = map[string]string{
 	AttributeEntityK8sNodeName:           K8sNode,
 	AttributeEntityPlatformType:          PlatformType,
 	AttributeEntityInstanceID:            InstanceID,
+	AttributeEntityAutoScalingGroup:      AutoscalingGroup,
 	AttributeEntityServiceNameSource:     AWSServiceNameSource,
 }
 

--- a/exporter/awsemfexporter/internal/entity/entityattributes_test.go
+++ b/exporter/awsemfexporter/internal/entity/entityattributes_test.go
@@ -59,6 +59,12 @@ func TestGetEntityField(t *testing.T) {
 			want:      InstanceID,
 		},
 		{
+			name:      "AttributeEntityAutoScalingGroup from map",
+			attribute: AttributeEntityAutoScalingGroup,
+			value:     "",
+			want:      AutoscalingGroup,
+		},
+		{
 			name:      "AttributeEntityServiceNameSource from map",
 			attribute: AttributeEntityServiceNameSource,
 			value:     "",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Add auto scaling group to part of entity mapping for EMF exporter. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
N/A

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit Test

## Sample EMF output after this change
```
{
    "AWS.ServiceNameSource": "ClientIamRole",
    "CloudWatchMetrics": [
        {
            "Namespace": "CWAgent",
            "Dimensions": [
                [
                    "http.route",
                    "http.method"
                ]
            ],
            "Metrics": [
                {
                    "Name": "asg.http.server.duration",
                    "Unit": "Milliseconds",
                    "StorageResolution": 60
                }
            ]
        }
    ],
    "EC2.AutoScalingGroup": "zhiholin-entity-test-asg",
    "EC2.InstanceId": "i-x",
    "Environment": "ec2:zhiholin-entity-test-asg",
    "PlatformType": "AWS::EC2",
    "Service": "cwa-e2e-iam-role",
    "Timestamp": "1746028270254",
    "Version": "0",
    "http.method": "GET",
    "http.route": "/api/items",
    "asg.http.server.duration": {
        "Max": 70,
        "Min": 5,
        "Count": 5,
        "Sum": 120.5
    }
}
```

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
