### PR TITLE
Modify govulncheck to only check cwagent components and fix lint issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,9 @@ Fixes
 <!--Describe the documentation added.-->
 #### Documentation
 
+<!--Ensure checks are successful -->
+#### Checks
+- Did you run `make fmt`? Y/N
+- Did you verify that all checks pass? Y/N
+
 <!--Please delete paragraphs that you did not use before submitting.-->

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -141,25 +141,14 @@ jobs:
       fail-fast: false
       matrix:
         group:
-          - receiver-0
-          - receiver-1
-          - receiver-2
-          - receiver-3
-          - processor-0
-          - processor-1
-          - exporter-0
-          - exporter-1
-          - exporter-2
-          - exporter-3
-          - extension
-          - connector
-          - internal
-          - pkg
-          - cmd-0
-          - cmd-1
+          - cwagent
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Checkout CloudWatch Agent Repo
+        uses: actions/checkout@v4
+        with:
+          repository: aws/amazon-cloudwatch-agent
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Setup Go

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -151,11 +151,9 @@ jobs:
       - name: Get Components
         id: get-components
         run: |
-          CWAGENT_COMPONENTS=$(grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]]*' amazon-cloudwatch-agent/go.mod | sed -n 's|.*/\([^/]*\)$|\1|p')
-          echo "cwagent components<<EOF" >> $GITHUB_OUTPUT
-          echo "$CWAGENT_COMPONENTS" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          
+          CWAGENT_COMPONENTS=$(grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]]*' amazon-cloudwatch-agent/go.mod | \
+                      sed -n 's|.*/\([^/]*\)$|\1|p' | \
+                      sort -u | tr '\n' ' ' | sed 's/ $//')
           echo "CWAGENT_COMPONENTS=$CWAGENT_COMPONENTS" >> $GITHUB_ENV
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -151,9 +151,7 @@ jobs:
       - name: Get Components
         id: get-components
         run: |
-          CWAGENT_COMPONENTS=$(grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]]*' amazon-cloudwatch-agent/go.mod | \
-                      sed -n 's|.*/\([^/]*\)$|\1|p' | \
-                      sort -u)
+          CWAGENT_COMPONENTS=$(grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]]*' amazon-cloudwatch-agent/go.mod | sed -n 's|.*/\([^/]*\)$|\1|p')
           echo "cwagent components<<EOF" >> $GITHUB_OUTPUT
           echo "$CWAGENT_COMPONENTS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -155,6 +155,7 @@ jobs:
         id: get-components
         run: |
           CWAGENT_COMPONENTS=$(grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]]*' amazon-cloudwatch-agent/go.mod | \
+                      grep -v 'pull' | \
                       sed -n 's|.*/\([^/]*\)$|\1|p' | \
                       sort -u | tr '\n' ' ' | sed 's/ $//')
           echo "CWAGENT_COMPONENTS=$CWAGENT_COMPONENTS" >> $GITHUB_ENV

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -139,6 +139,9 @@ jobs:
   govulncheck:
     strategy:
       fail-fast: false
+      matrix:
+        group:
+          - cwagent
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -176,7 +179,7 @@ jobs:
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make install-tools
       - name: Run `govulncheck`
-        run: make -j2 gogovulncheck GROUP=$CWAGENT_COMPONENTS
+        run: make -j2 gogovulncheck GROUP=cwagent
         env:
           CWAGENT_COMPONENTS: ${{ env.CWAGENT_COMPONENTS }}
   checks:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -149,6 +149,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: aws/amazon-cloudwatch-agent
+          path: '/amazon-cloudwatch-agent'
+          sparse-checkout: go.mod
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Setup Go

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -139,9 +139,6 @@ jobs:
   govulncheck:
     strategy:
       fail-fast: false
-      matrix:
-        group:
-          - cwagent
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -151,6 +148,17 @@ jobs:
           repository: aws/amazon-cloudwatch-agent
           path: 'amazon-cloudwatch-agent'
           sparse-checkout: go.mod
+      - name: Get Components
+        id: get-components
+        run: |
+          CWAGENT_COMPONENTS=$(grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]]*' amazon-cloudwatch-agent/go.mod | \
+                      sed -n 's|.*/\([^/]*\)$|\1|p' | \
+                      sort -u)
+          echo "cwagent components<<EOF" >> $GITHUB_OUTPUT
+          echo "$CWAGENT_COMPONENTS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          
+          echo "CWAGENT_COMPONENTS=$CWAGENT_COMPONENTS" >> $GITHUB_ENV
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Setup Go
@@ -172,7 +180,9 @@ jobs:
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make install-tools
       - name: Run `govulncheck`
-        run: make -j2 gogovulncheck GROUP=${{ matrix.group }}
+        run: make -j2 gogovulncheck GROUP=$CWAGENT_COMPONENTS
+        env:
+          CWAGENT_COMPONENTS: ${{ env.CWAGENT_COMPONENTS }}
   checks:
     runs-on: ubuntu-latest
     needs: [setup-environment]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.2"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -149,7 +149,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: aws/amazon-cloudwatch-agent
-          path: '/amazon-cloudwatch-agent'
+          path: 'amazon-cloudwatch-agent'
           sparse-checkout: go.mod
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -154,9 +154,9 @@ jobs:
       - name: Get Components
         id: get-components
         run: |
-          CWAGENT_COMPONENTS=$(grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]]*' amazon-cloudwatch-agent/go.mod | \
+          CWAGENT_COMPONENTS=$(grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]/]*/[^[:space:]]*' amazon-cloudwatch-agent/go.mod | \
                       grep -v 'pull' | \
-                      sed -n 's|.*/\([^/]*\)$|\1|p' | \
+                      sed -n 's|amazon-contributing/opentelemetry-collector-contrib/\([^/]*/[^/]*\)$|./\1|p' | \
                       sort -u | tr '\n' ' ' | sed 's/ $//')
           echo "CWAGENT_COMPONENTS=$CWAGENT_COMPONENTS" >> $GITHUB_ENV
       - name: Checkout Repo

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.12"
+          go-version: "1.24.2"
           cache: false
       - name: Cache Go
         id: go-cache

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,6 @@ OVERRIDE_MODS := $(shell find ./override/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) 
 OTHER_MODS := $(shell find . $(EX_COMPONENTS) $(EX_INTERNAL) $(EX_PKG) $(EX_CMD) $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) ) $(PWD)
 ALL_MODS := $(RECEIVER_MODS) $(PROCESSOR_MODS) $(EXPORTER_MODS) $(EXTENSION_MODS) $(CONNECTOR_MODS) $(INTERNAL_MODS) $(PKG_MODS) $(CMD_MODS) $(OTHER_MODS)
 CGO_MODS := ./receiver/hostmetricsreceiver
-CWAGENT_MODS := $(shell grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]]*' /home/runner/work/opentelemetry-collector-contrib/opentelemetry-collector-contrib/amazon-cloudwatch-agent/go.mod | sed -n 's|.*/\([^/]*\)$|\1|p' | sort -u)
 
 FIND_INTEGRATION_TEST_MODS={ find . -type f -name "*integration_test.go" & find . -type f -name "*e2e_test.go" -not -path "./testbed/*"; }
 INTEGRATION_MODS := $(shell $(FIND_INTEGRATION_TEST_MODS) | xargs $(TO_MOD_DIR) | uniq)
@@ -279,9 +278,6 @@ for-integration-target: $(INTEGRATION_MODS)
 
 .PHONY: for-cgo-target
 for-cgo-target: $(CGO_MODS)
-
-.PHONY: for-cwagent-target
-for-cwagent-target: $(CWAGENT_MODS)
 
 # Debugging target, which helps to quickly determine whether for-all-target is working or not.
 .PHONY: all-pwd

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ OVERRIDE_MODS := $(shell find ./override/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) 
 OTHER_MODS := $(shell find . $(EX_COMPONENTS) $(EX_INTERNAL) $(EX_PKG) $(EX_CMD) $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) ) $(PWD)
 ALL_MODS := $(RECEIVER_MODS) $(PROCESSOR_MODS) $(EXPORTER_MODS) $(EXTENSION_MODS) $(CONNECTOR_MODS) $(INTERNAL_MODS) $(PKG_MODS) $(CMD_MODS) $(OTHER_MODS)
 CGO_MODS := ./receiver/hostmetricsreceiver
-CWAGENT_MODS := $(shell ls | grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]]*' amazon-cloudwatch-agent/go.mod | sed -n 's|.*/\([^/]*\)$|\1|p' | sort -u)
+CWAGENT_MODS := $(shell grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]]*' /home/runner/work/opentelemetry-collector-contrib/opentelemetry-collector-contrib/amazon-cloudwatch-agent/go.mod | sed -n 's|.*/\([^/]*\)$|\1|p' | sort -u)
 
 FIND_INTEGRATION_TEST_MODS={ find . -type f -name "*integration_test.go" & find . -type f -name "*e2e_test.go" -not -path "./testbed/*"; }
 INTEGRATION_MODS := $(shell $(FIND_INTEGRATION_TEST_MODS) | xargs $(TO_MOD_DIR) | uniq)

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ OVERRIDE_MODS := $(shell find ./override/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) 
 OTHER_MODS := $(shell find . $(EX_COMPONENTS) $(EX_INTERNAL) $(EX_PKG) $(EX_CMD) $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) ) $(PWD)
 ALL_MODS := $(RECEIVER_MODS) $(PROCESSOR_MODS) $(EXPORTER_MODS) $(EXTENSION_MODS) $(CONNECTOR_MODS) $(INTERNAL_MODS) $(PKG_MODS) $(CMD_MODS) $(OTHER_MODS)
 CGO_MODS := ./receiver/hostmetricsreceiver
-CWAGENT_MODS := $(shell grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]]*' /amazon-cloudwatch-agent/go.mod | sed -n 's|.*/\([^/]*\)$|\1|p' | sort -u)
+CWAGENT_MODS := $(shell ls | grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]]*' amazon-cloudwatch-agent/go.mod | sed -n 's|.*/\([^/]*\)$|\1|p' | sort -u)
 
 FIND_INTEGRATION_TEST_MODS={ find . -type f -name "*integration_test.go" & find . -type f -name "*e2e_test.go" -not -path "./testbed/*"; }
 INTEGRATION_MODS := $(shell $(FIND_INTEGRATION_TEST_MODS) | xargs $(TO_MOD_DIR) | uniq)

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ OVERRIDE_MODS := $(shell find ./override/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) 
 OTHER_MODS := $(shell find . $(EX_COMPONENTS) $(EX_INTERNAL) $(EX_PKG) $(EX_CMD) $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) ) $(PWD)
 ALL_MODS := $(RECEIVER_MODS) $(PROCESSOR_MODS) $(EXPORTER_MODS) $(EXTENSION_MODS) $(CONNECTOR_MODS) $(INTERNAL_MODS) $(PKG_MODS) $(CMD_MODS) $(OTHER_MODS)
 CGO_MODS := ./receiver/hostmetricsreceiver
-CWAGENT_MODS := $(shell ls | grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]]*' amazon-cloudwatch-agent/go.mod | sed -n 's|.*/\([^/]*\)$|\1|p' | sort -u)
+CWAGENT_MODS := $(shell ls | grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]]*' /amazon-cloudwatch-agent/go.mod | sed -n 's|.*/\([^/]*\)$|\1|p' | sort -u)
 
 FIND_INTEGRATION_TEST_MODS={ find . -type f -name "*integration_test.go" & find . -type f -name "*e2e_test.go" -not -path "./testbed/*"; }
 INTEGRATION_MODS := $(shell $(FIND_INTEGRATION_TEST_MODS) | xargs $(TO_MOD_DIR) | uniq)

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ OVERRIDE_MODS := $(shell find ./override/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) 
 OTHER_MODS := $(shell find . $(EX_COMPONENTS) $(EX_INTERNAL) $(EX_PKG) $(EX_CMD) $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) ) $(PWD)
 ALL_MODS := $(RECEIVER_MODS) $(PROCESSOR_MODS) $(EXPORTER_MODS) $(EXTENSION_MODS) $(CONNECTOR_MODS) $(INTERNAL_MODS) $(PKG_MODS) $(CMD_MODS) $(OTHER_MODS)
 CGO_MODS := ./receiver/hostmetricsreceiver
-CWAGENT_MODS := $(shell ls | grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]]*' /amazon-cloudwatch-agent/go.mod | sed -n 's|.*/\([^/]*\)$|\1|p' | sort -u)
+CWAGENT_MODS := $(shell ls | grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]]*' amazon-cloudwatch-agent/go.mod | sed -n 's|.*/\([^/]*\)$|\1|p' | sort -u)
 
 FIND_INTEGRATION_TEST_MODS={ find . -type f -name "*integration_test.go" & find . -type f -name "*e2e_test.go" -not -path "./testbed/*"; }
 INTEGRATION_MODS := $(shell $(FIND_INTEGRATION_TEST_MODS) | xargs $(TO_MOD_DIR) | uniq)

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ OVERRIDE_MODS := $(shell find ./override/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) 
 OTHER_MODS := $(shell find . $(EX_COMPONENTS) $(EX_INTERNAL) $(EX_PKG) $(EX_CMD) $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) ) $(PWD)
 ALL_MODS := $(RECEIVER_MODS) $(PROCESSOR_MODS) $(EXPORTER_MODS) $(EXTENSION_MODS) $(CONNECTOR_MODS) $(INTERNAL_MODS) $(PKG_MODS) $(CMD_MODS) $(OTHER_MODS)
 CGO_MODS := ./receiver/hostmetricsreceiver
+CWAGENT_MODS := $(shell grep -o 'amazon-contributing/opentelemetry-collector-contrib/[^[:space:]]*' /amazon-cloudwatch-agent/go.mod | sed -n 's|.*/\([^/]*\)$|\1|p' | sort -u)
 
 FIND_INTEGRATION_TEST_MODS={ find . -type f -name "*integration_test.go" & find . -type f -name "*e2e_test.go" -not -path "./testbed/*"; }
 INTEGRATION_MODS := $(shell $(FIND_INTEGRATION_TEST_MODS) | xargs $(TO_MOD_DIR) | uniq)
@@ -278,6 +279,9 @@ for-integration-target: $(INTEGRATION_MODS)
 
 .PHONY: for-cgo-target
 for-cgo-target: $(CGO_MODS)
+
+.PHONY: for-cwagent-target
+for-cwagent-target: $(CWAGENT_MODS)
 
 # Debugging target, which helps to quickly determine whether for-all-target is working or not.
 .PHONY: all-pwd

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ OVERRIDE_MODS := $(shell find ./override/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) 
 OTHER_MODS := $(shell find . $(EX_COMPONENTS) $(EX_INTERNAL) $(EX_PKG) $(EX_CMD) $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) ) $(PWD)
 ALL_MODS := $(RECEIVER_MODS) $(PROCESSOR_MODS) $(EXPORTER_MODS) $(EXTENSION_MODS) $(CONNECTOR_MODS) $(INTERNAL_MODS) $(PKG_MODS) $(CMD_MODS) $(OTHER_MODS)
 CGO_MODS := ./receiver/hostmetricsreceiver
+CWAGENT_MODS := $(CWAGENT_COMPONENTS) # populated from build-and-test action
 
 FIND_INTEGRATION_TEST_MODS={ find . -type f -name "*integration_test.go" & find . -type f -name "*e2e_test.go" -not -path "./testbed/*"; }
 INTEGRATION_MODS := $(shell $(FIND_INTEGRATION_TEST_MODS) | xargs $(TO_MOD_DIR) | uniq)
@@ -89,6 +90,7 @@ all-groups:
 	@echo "\ncmd: $(CMD_MODS)"
 	@echo "\noverride: $(OVERRIDE_MODS)"
 	@echo "\nother: $(OTHER_MODS)"
+	@echo "\ncwagent: $(CWAGENT_MODS)"
 
 .PHONY: all
 all: install-tools all-common goporto multimod-verify gotest otelcontribcol
@@ -278,6 +280,9 @@ for-integration-target: $(INTEGRATION_MODS)
 
 .PHONY: for-cgo-target
 for-cgo-target: $(CGO_MODS)
+
+.PHONY: for-cwagent-target
+for-cwagent-target: $(CWAGENT_MODS)
 
 # Debugging target, which helps to quickly determine whether for-all-target is working or not.
 .PHONY: all-pwd

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ OVERRIDE_MODS := $(shell find ./override/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) 
 OTHER_MODS := $(shell find . $(EX_COMPONENTS) $(EX_INTERNAL) $(EX_PKG) $(EX_CMD) $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) ) $(PWD)
 ALL_MODS := $(RECEIVER_MODS) $(PROCESSOR_MODS) $(EXPORTER_MODS) $(EXTENSION_MODS) $(CONNECTOR_MODS) $(INTERNAL_MODS) $(PKG_MODS) $(CMD_MODS) $(OTHER_MODS)
 CGO_MODS := ./receiver/hostmetricsreceiver
-CWAGENT_MODS := $(CWAGENT_COMPONENTS) # populated from build-and-test action
+CWAGENT_MODS := $(CWAGENT_COMPONENTS) | xargs -n1 -I{} find {} -name "go.mod" -type f # CWAGENT_COMPONENTS is populated from build-and-test action
 
 FIND_INTEGRATION_TEST_MODS={ find . -type f -name "*integration_test.go" & find . -type f -name "*e2e_test.go" -not -path "./testbed/*"; }
 INTEGRATION_MODS := $(shell $(FIND_INTEGRATION_TEST_MODS) | xargs $(TO_MOD_DIR) | uniq)

--- a/internal/aws/k8s/k8sclient/endpoint_slices_test.go
+++ b/internal/aws/k8s/k8sclient/endpoint_slices_test.go
@@ -253,7 +253,8 @@ var endpointSlicesArray = []runtime.Object{
 			},
 			Labels: map[string]string{
 				"kubernetes.io/service-name": "kube-controller-manager",
-			}},
+			},
+		},
 	},
 	&discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/kubelet/client.go
+++ b/internal/kubelet/client.go
@@ -130,7 +130,6 @@ func (p *kubeConfigClientProvider) BuildClient() (Client, error) {
 	}
 
 	joinPath, err := url.JoinPath(authConf.Host, "/api/v1/nodes/", p.endpoint, "/proxy/")
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### Description
Fix the PR build checks on this repo by running `make fmt` and modifying the govulncheck workflow to only look at components referenced in the cloudwatch agent repo.

Also modified PR template to run `make fmt` and verify checks

#### Testing
Tested as part of this PR check: https://github.com/amazon-contributing/opentelemetry-collector-contrib/actions/runs/15144600074/job/42577134176?pr=316

Looks at the following components:
```
./exporter/awscloudwatchlogsexporter
./exporter/awsemfexporter
./exporter/awsxrayexporter
./extension/awsmiddleware
./extension/awsproxy 
./internal/coreinternal 
./internal/k8sconfig 
./internal/kubelet 
./internal/metadataproviders
./override/aws 
./pkg/resourcetotelemetry
./pkg/stanza 
./processor/resourcedetectionprocessor 
./receiver/awscontainerinsightreceiver 
./receiver/awscontainerinsightskueuereceiver 
./receiver/awsxrayreceiver 
./receiver/jmxreceiver 
./receiver/prometheusreceiver
```
