### PR TITLE
Increase statsCacheDuration to 15 minutes for cadvisor

### DIFF
--- a/internal/aws/metrics/metric_calculator.go
+++ b/internal/aws/metrics/metric_calculator.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	cleanInterval = 5 * time.Minute
+	cleanInterval = 15 * time.Minute
 )
 
 // CalculateFunc defines how to process metric values by the calculator. It

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
@@ -28,7 +28,7 @@ import (
 )
 
 // The amount of time for which to keep stats in memory.
-const statsCacheDuration = 2 * time.Minute
+const statsCacheDuration = 15 * time.Minute
 
 // Max collection interval, it is not meaningful if allowDynamicHousekeeping = false
 var maxHousekeepingInterval = 15 * time.Second


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
When collection interval is greater than 2 minutes, CPU metrics are not being collected.  This is because the cadvisor cache has a 2 minute TTL.

Increased statsCacheDuration to 15 minutes (from 2 minutes).

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Validated CPU metrics are collected for addtional collection intervals
- Greater than 5 minutes
- Up to 15 minutes
