### PR TITLE
[awscontainerinsightreceiver] Enable usage of user defined collection interval in awscontainerinsightreceiver

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs.go
+++ b/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs.go
@@ -22,7 +22,10 @@ import (
 )
 
 const (
-	defaultCollectionInterval = 20 * time.Second
+	// acirDefaultCollectionInterval is the hardcoded collection interval that is set in
+	// the awsContainerInsightReceiver when collection interval is not specified in the agent configuration.
+	awsContainerInsightsDefaultCollectionInterval = 60 * time.Second
+	efaDefaultCollectionInterval                  = 20 * time.Second
 )
 
 const (
@@ -106,11 +109,14 @@ type efaCounters struct {
 	txBytes            uint64 // hw_counters/tx_bytes
 }
 
-func NewEfaSyfsScraper(logger *zap.Logger, decorator stores.Decorator, podResourcesStore podResourcesStore, hostInfo hostInfoProvider) *Scraper {
+func NewEfaSyfsScraper(logger *zap.Logger, decorator stores.Decorator, podResourcesStore podResourcesStore, hostInfo hostInfoProvider, collectionInterval time.Duration) *Scraper {
 	ctx, cancel := context.WithCancel(context.Background())
 	podResourcesStore.AddResourceName(efaK8sResourceName)
+	if collectionInterval == awsContainerInsightsDefaultCollectionInterval {
+		collectionInterval = efaDefaultCollectionInterval
+	}
 	e := &Scraper{
-		collectionInterval: defaultCollectionInterval,
+		collectionInterval: collectionInterval,
 		cancel:             cancel,
 		sysFsReader:        defaultSysFsReader(logger),
 		deltaCalculator:    metrics.NewMetricCalculator(calculateDelta),

--- a/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/efa/efaSysfs_test.go
@@ -20,6 +20,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores"
 )
 
+const (
+	dummyCollectionInterval = 60 * time.Second
+)
+
 type mockSysfsReader struct {
 	scrapeCounts map[string]uint64
 }
@@ -250,7 +254,7 @@ var efa1PodContainerMetrics = []expectation{
 var efa1Metrics = []expectation{efa1NodeMetric, efa1PodContainerMetrics[0], efa1PodContainerMetrics[1]}
 
 func TestGetMetrics(t *testing.T) {
-	s := NewEfaSyfsScraper(zap.NewNop(), mockDecorator{}, mockPodResourcesStore{}, mockHost)
+	s := NewEfaSyfsScraper(zap.NewNop(), mockDecorator{}, mockPodResourcesStore{}, mockHost, dummyCollectionInterval)
 	s.sysFsReader = newMockSysfsReader()
 
 	var expectedMetrics []expectation
@@ -269,7 +273,7 @@ func TestGetMetrics(t *testing.T) {
 }
 
 func TestGetMetricsBeforeSuccessfulScrape(t *testing.T) {
-	s := NewEfaSyfsScraper(zap.NewNop(), mockDecorator{}, mockPodResourcesStore{}, mockHost)
+	s := NewEfaSyfsScraper(zap.NewNop(), mockDecorator{}, mockPodResourcesStore{}, mockHost, dummyCollectionInterval)
 
 	result := s.GetMetrics()
 	assert.Empty(t, result)
@@ -296,7 +300,7 @@ func (p mockPodResourcesStoreMissingOneDevice) GetContainerInfo(deviceID string,
 }
 
 func TestGetMetricsMissingDeviceFromPodResources(t *testing.T) {
-	s := NewEfaSyfsScraper(zap.NewNop(), mockDecorator{}, mockPodResourcesStoreMissingOneDevice{}, mockHost)
+	s := NewEfaSyfsScraper(zap.NewNop(), mockDecorator{}, mockPodResourcesStoreMissingOneDevice{}, mockHost, dummyCollectionInterval)
 	s.sysFsReader = newMockSysfsReader()
 
 	assert.NoError(t, s.scrape())
@@ -394,7 +398,7 @@ func findTimestamp(t *testing.T, attrs pcommon.Map) (string, time.Time) {
 }
 
 func TestScrape(t *testing.T) {
-	s := NewEfaSyfsScraper(zap.NewNop(), nil, mockPodResourcesStore{}, mockHost)
+	s := NewEfaSyfsScraper(zap.NewNop(), nil, mockPodResourcesStore{}, mockHost, dummyCollectionInterval)
 	s.sysFsReader = newMockSysfsReader()
 
 	s.hostInfo = mockHost
@@ -515,7 +519,7 @@ func (r mockSysfsReaderError4) GetMACAddressFromDeviceName(_ efaDeviceName) (str
 
 func TestScrapeErrors(t *testing.T) {
 	for _, reader := range []sysFsReader{mockSysfsReaderError1{}, mockSysfsReaderError2{}, mockSysfsReaderError3{}, mockSysfsReaderError4{}} {
-		s := NewEfaSyfsScraper(zap.NewNop(), nil, mockPodResourcesStore{}, mockHost)
+		s := NewEfaSyfsScraper(zap.NewNop(), nil, mockPodResourcesStore{}, mockHost, dummyCollectionInterval)
 
 		s.sysFsReader = reader
 
@@ -547,7 +551,7 @@ func (r mockSysfsReaderNoEfaData) GetMACAddressFromDeviceName(_ efaDeviceName) (
 }
 
 func TestScrapeNoEfaData(t *testing.T) {
-	s := NewEfaSyfsScraper(zap.NewNop(), nil, mockPodResourcesStore{}, mockHost)
+	s := NewEfaSyfsScraper(zap.NewNop(), nil, mockPodResourcesStore{}, mockHost, dummyCollectionInterval)
 
 	s.sysFsReader = mockSysfsReaderNoEfaData{}
 

--- a/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_config.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	caFile                    = "/etc/amazon-cloudwatch-observability-agent-cert/tls-ca.crt"
-	collectionInterval        = 60 * time.Second
 	jobName                   = "containerInsightsDCGMExporterScraper"
 	scraperMetricsPath        = "/metrics"
 	scraperK8sServiceSelector = "k8s-app=dcgm-exporter-service"
@@ -30,7 +29,7 @@ type hostInfoProvider interface {
 	GetInstanceType() string
 }
 
-func GetScraperConfig(hostInfoProvider hostInfoProvider) *config.ScrapeConfig {
+func GetScraperConfig(hostInfoProvider hostInfoProvider, collectionInterval time.Duration) *config.ScrapeConfig {
 	return &config.ScrapeConfig{
 		HTTPClientConfig: configutil.HTTPClientConfig{
 			TLSConfig: configutil.TLSConfig{

--- a/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	configutil "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -36,9 +37,10 @@ DCGM_FI_DEV_GPU_UTIL{gpu="0",UUID="uuid",device="nvidia0",modelName="NVIDIA A10G
 `
 
 const (
-	dummyInstanceID   = "i-0000000000"
-	dummyClusterName  = "cluster-name"
-	dummyInstanceType = "instance-type"
+	dummyInstanceID         = "i-0000000000"
+	dummyClusterName        = "cluster-name"
+	dummyInstanceType       = "instance-type"
+	dummyCollectionInterval = 60 * time.Second
 )
 
 type mockHostInfoProvider struct{}
@@ -148,7 +150,7 @@ func TestNewDcgmScraperEndToEnd(t *testing.T) {
 		Consumer:          mConsumer,
 		Host:              componenttest.NewNopHost(),
 		HostInfoProvider:  mockHostInfoProvider{},
-		ScraperConfigs:    GetScraperConfig(mockHostInfoProvider{}),
+		ScraperConfigs:    GetScraperConfig(mockHostInfoProvider{}, dummyCollectionInterval),
 		Logger:            settings.Logger,
 	})
 	assert.NoError(t, err)

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper.go
@@ -26,8 +26,7 @@ import (
 )
 
 const (
-	caFile             = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-	collectionInterval = 60 * time.Second
+	caFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	// needs to start with "containerInsightsKubeAPIServerScraper" for histogram deltas in the emf exporter
 	jobName                        = "containerInsightsKubeAPIServerScraper"
 	serviceAccountTokenDefaultPath = "/var/run/secrets/kubernetes.io/serviceaccount/token" // #nosec
@@ -73,6 +72,7 @@ type PrometheusScraperOpts struct {
 	Host                component.Host
 	ClusterNameProvider clusterNameProvider
 	LeaderElection      *LeaderElection
+	CollectionInterval  time.Duration
 }
 
 func NewPrometheusScraper(opts PrometheusScraperOpts) (*PrometheusScraper, error) {
@@ -106,8 +106,8 @@ func NewPrometheusScraper(opts PrometheusScraperOpts) (*PrometheusScraper, error
 				CredentialsFile: serviceAccountTokenDefaultPath,
 			},
 		},
-		ScrapeInterval:         model.Duration(collectionInterval),
-		ScrapeTimeout:          model.Duration(collectionInterval),
+		ScrapeInterval:         model.Duration(opts.CollectionInterval),
+		ScrapeTimeout:          model.Duration(opts.CollectionInterval),
 		ScrapeProtocols:        config.DefaultScrapeProtocols,
 		ScrapeFallbackProtocol: config.PrometheusText0_0_4,
 		JobName:                fmt.Sprintf("%s/%s", jobName, opts.Endpoint),

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/prometheus_scraper_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	configutil "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -24,6 +25,10 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/mocks"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+)
+
+const (
+	dummyCollectionInterval = 60 * time.Second
 )
 
 const renameMetric = `
@@ -102,6 +107,7 @@ func TestNewPrometheusScraperBadInputs(t *testing.T) {
 			Host:                componenttest.NewNopHost(),
 			ClusterNameProvider: mockClusterNameProvider{},
 			LeaderElection:      nil,
+			CollectionInterval:  dummyCollectionInterval,
 		},
 		{
 			Ctx:                 context.TODO(),
@@ -111,6 +117,7 @@ func TestNewPrometheusScraperBadInputs(t *testing.T) {
 			Host:                componenttest.NewNopHost(),
 			ClusterNameProvider: mockClusterNameProvider{},
 			LeaderElection:      &leaderElection,
+			CollectionInterval:  dummyCollectionInterval,
 		},
 		{
 			Ctx:                 context.TODO(),
@@ -120,6 +127,7 @@ func TestNewPrometheusScraperBadInputs(t *testing.T) {
 			Host:                nil,
 			ClusterNameProvider: mockClusterNameProvider{},
 			LeaderElection:      &leaderElection,
+			CollectionInterval:  dummyCollectionInterval,
 		},
 		{
 			Ctx:                 context.TODO(),
@@ -129,6 +137,7 @@ func TestNewPrometheusScraperBadInputs(t *testing.T) {
 			Host:                componenttest.NewNopHost(),
 			ClusterNameProvider: nil,
 			LeaderElection:      &leaderElection,
+			CollectionInterval:  dummyCollectionInterval,
 		},
 	}
 
@@ -169,6 +178,7 @@ func TestNewPrometheusScraperEndToEnd(t *testing.T) {
 		Host:                componenttest.NewNopHost(),
 		ClusterNameProvider: mockClusterNameProvider{},
 		LeaderElection:      &leaderElection,
+		CollectionInterval:  dummyCollectionInterval,
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, mockClusterNameProvider{}, scraper.clusterNameProvider)

--- a/receiver/awscontainerinsightreceiver/internal/neuron/neuron_monitor_scraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/neuron/neuron_monitor_scraper_config.go
@@ -20,13 +20,12 @@ import (
 
 const (
 	caFile                    = "/etc/amazon-cloudwatch-observability-agent-cert/tls-ca.crt"
-	collectionInterval        = 60 * time.Second
 	jobName                   = "containerInsightsNeuronMonitorScraper"
 	scraperMetricsPath        = "/metrics"
 	scraperK8sServiceSelector = "k8s-app=neuron-monitor-service"
 )
 
-func GetNeuronScrapeConfig(hostinfo prometheusscraper.HostInfoProvider) *config.ScrapeConfig {
+func GetNeuronScrapeConfig(hostinfo prometheusscraper.HostInfoProvider, collectionInterval time.Duration) *config.ScrapeConfig {
 	return &config.ScrapeConfig{
 		ScrapeProtocols: config.DefaultScrapeProtocols,
 		HTTPClientConfig: configutil.HTTPClientConfig{

--- a/receiver/awscontainerinsightreceiver/internal/neuron/neuron_monitor_scraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/neuron/neuron_monitor_scraper_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -15,10 +16,11 @@ import (
 )
 
 const (
-	dummyClusterName  = "cluster-name"
-	dummyHostName     = "i-000000000"
-	dummyNodeName     = "dummy-nodeName"
-	dummyInstanceType = "instance-type"
+	dummyClusterName        = "cluster-name"
+	dummyHostName           = "i-000000000"
+	dummyNodeName           = "dummy-nodeName"
+	dummyInstanceType       = "instance-type"
+	dummyCollectionInterval = 60 * time.Second
 )
 
 type mockHostInfoProvider struct{}
@@ -132,7 +134,7 @@ func TestNewNeuronScraperEndToEnd(t *testing.T) {
 		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
 		Consumer:          consumer,
 		Host:              componenttest.NewNopHost(),
-		ScraperConfigs:    GetNeuronScrapeConfig(mockHostInfoProvider{}),
+		ScraperConfigs:    GetNeuronScrapeConfig(mockHostInfoProvider{}, dummyCollectionInterval),
 		HostInfoProvider:  mockHostInfoProvider{},
 	}
 
@@ -246,7 +248,7 @@ func TestNewNeuronScraperWithUltraServersEndToEnd(t *testing.T) {
 		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
 		Consumer:          consumer,
 		Host:              componenttest.NewNopHost(),
-		ScraperConfigs:    GetNeuronScrapeConfig(mockHostInfoProvider{}),
+		ScraperConfigs:    GetNeuronScrapeConfig(mockHostInfoProvider{}, dummyCollectionInterval),
 		HostInfoProvider:  mockHostInfoProvider{},
 	}
 

--- a/receiver/awscontainerinsightreceiver/internal/nvme/nvmescraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/nvme/nvmescraper_config.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	collectionInterval        = 60 * time.Second
 	jobName                   = "containerInsightsNVMeExporterScraper"
 	scraperMetricsPath        = "/metrics"
 	scraperK8sServiceSelector = "app=ebs-csi-node"
@@ -29,7 +28,7 @@ type hostInfoProvider interface {
 	GetInstanceType() string
 }
 
-func GetScraperConfig(hostInfoProvider hostInfoProvider) *config.ScrapeConfig {
+func GetScraperConfig(hostInfoProvider hostInfoProvider, collectionInterval time.Duration) *config.ScrapeConfig {
 	return &config.ScrapeConfig{
 		ScrapeInterval:         model.Duration(collectionInterval),
 		ScrapeTimeout:          model.Duration(collectionInterval),

--- a/receiver/awscontainerinsightreceiver/internal/nvme/nvmescraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/nvme/nvmescraper_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	configutil "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -36,10 +37,11 @@ aws_ebs_csi_read_seconds_total{instance_id="i-0131bee5395cc4317",volume_id="vol-
 `
 
 const (
-	dummyInstanceID   = "i-0000000000"
-	dummyClusterName  = "cluster-name"
-	dummyInstanceType = "instance-type"
-	dummyNodeName     = "hostname"
+	dummyInstanceID         = "i-0000000000"
+	dummyClusterName        = "cluster-name"
+	dummyInstanceType       = "instance-type"
+	dummyNodeName           = "hostname"
+	dummyCollectionInterval = 60 * time.Second
 )
 
 type mockHostInfoProvider struct{}
@@ -141,7 +143,7 @@ func TestNewNVMEScraperEndToEnd(t *testing.T) {
 		Consumer:          mConsumer,
 		Host:              componenttest.NewNopHost(),
 		HostInfoProvider:  mockHostInfoProvider{},
-		ScraperConfigs:    GetScraperConfig(mockHostInfoProvider{}),
+		ScraperConfigs:    GetScraperConfig(mockHostInfoProvider{}, dummyCollectionInterval),
 		Logger:            settings.Logger,
 	})
 	assert.NoError(t, err)

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -76,6 +76,10 @@ func newAWSContainerInsightReceiver(
 		nextConsumer: nextConsumer,
 		config:       config,
 	}
+	// Set the default collection interval if not already set
+	if r.config.CollectionInterval == 0 {
+		r.config.CollectionInterval = defaultCollectionInterval
+	}
 	return r, nil
 }
 
@@ -296,6 +300,7 @@ func (acir *awsContainerInsightReceiver) initPrometheusScraper(ctx context.Conte
 		Host:                host,
 		ClusterNameProvider: hostInfo,
 		LeaderElection:      leaderElection,
+		CollectionInterval:  acir.config.CollectionInterval,
 	})
 	return err
 }
@@ -319,7 +324,7 @@ func (acir *awsContainerInsightReceiver) initDcgmScraper(ctx context.Context, ho
 		TelemetrySettings: acir.settings,
 		Consumer:          &decoConsumer,
 		Host:              host,
-		ScraperConfigs:    gpu.GetScraperConfig(hostInfo),
+		ScraperConfigs:    gpu.GetScraperConfig(hostInfo, acir.config.CollectionInterval),
 		HostInfoProvider:  hostInfo,
 		Logger:            acir.settings.Logger,
 	}
@@ -344,7 +349,7 @@ func (acir *awsContainerInsightReceiver) initNVMEScraper(ctx context.Context, ho
 		TelemetrySettings: acir.settings,
 		Consumer:          &decoConsumer,
 		Host:              host,
-		ScraperConfigs:    nvme.GetScraperConfig(hostInfo),
+		ScraperConfigs:    nvme.GetScraperConfig(hostInfo, acir.config.CollectionInterval),
 		HostInfoProvider:  hostInfo,
 		Logger:            acir.settings.Logger,
 	}
@@ -364,6 +369,7 @@ func (acir *awsContainerInsightReceiver) initNeuronScraper(ctx context.Context, 
 	if !acir.config.EnableAcceleratedComputeMetrics {
 		return nil
 	}
+
 	var err error
 
 	decoConsumer := decoratorconsumer.DecorateConsumer{
@@ -398,7 +404,7 @@ func (acir *awsContainerInsightReceiver) initNeuronScraper(ctx context.Context, 
 		TelemetrySettings: acir.settings,
 		Consumer:          &podAttributesDecoratorConsumer,
 		Host:              host,
-		ScraperConfigs:    neuron.GetNeuronScrapeConfig(hostInfo),
+		ScraperConfigs:    neuron.GetNeuronScrapeConfig(hostInfo, acir.config.CollectionInterval),
 		HostInfoProvider:  hostInfo,
 		Logger:            acir.settings.Logger,
 	}
@@ -415,7 +421,12 @@ func (acir *awsContainerInsightReceiver) initEfaSysfsScraper(localNodeDecorator 
 	if acir.podResourcesStore == nil {
 		return errors.New("pod resources store was not initialized")
 	}
-	acir.efaSysfsScraper = efa.NewEfaSyfsScraper(acir.settings.Logger, localNodeDecorator, acir.podResourcesStore, hostInfo)
+	acir.efaSysfsScraper = efa.NewEfaSyfsScraper(
+		acir.settings.Logger,
+		localNodeDecorator,
+		acir.podResourcesStore,
+		hostInfo,
+		acir.config.CollectionInterval)
 	return nil
 }
 

--- a/receiver/awscontainerinsightskueuereceiver/internal/kueuescraper/kueue_prometheus_scraper.go
+++ b/receiver/awscontainerinsightskueuereceiver/internal/kueuescraper/kueue_prometheus_scraper.go
@@ -26,7 +26,6 @@ import (
 )
 
 const (
-	kmCollectionInterval = 60 * time.Second
 	// kmJobName needs to be "containerInsightsKueueMetricsScraper" so metric translator tags the source as the container insights receiver
 	kmJobName                   = "containerInsightsKueueMetricsScraper"
 	kueueNamespace              = "kueue-system"
@@ -66,11 +65,12 @@ type KueuePrometheusScraper struct {
 }
 
 type KueuePrometheusScraperOpts struct {
-	Ctx               context.Context
-	TelemetrySettings component.TelemetrySettings
-	Consumer          consumer.Metrics
-	Host              component.Host
-	ClusterName       string
+	Ctx                context.Context
+	TelemetrySettings  component.TelemetrySettings
+	Consumer           consumer.Metrics
+	Host               component.Host
+	ClusterName        string
+	CollectionInterval time.Duration
 }
 
 func NewKueuePrometheusScraper(opts KueuePrometheusScraperOpts) (*KueuePrometheusScraper, error) {
@@ -94,8 +94,8 @@ func NewKueuePrometheusScraper(opts KueuePrometheusScraperOpts) (*KueuePrometheu
 				CredentialsFile: serviceAccountTokenDefaultPath,
 			},
 		},
-		ScrapeInterval:         model.Duration(kmCollectionInterval),
-		ScrapeTimeout:          model.Duration(kmCollectionInterval),
+		ScrapeInterval:         model.Duration(opts.CollectionInterval),
+		ScrapeTimeout:          model.Duration(opts.CollectionInterval),
 		ScrapeProtocols:        config.DefaultScrapeProtocols,
 		ScrapeFallbackProtocol: config.PrometheusText0_0_4,
 		JobName:                kmJobName,

--- a/receiver/awscontainerinsightskueuereceiver/internal/kueuescraper/kueue_prometheus_scraper_test.go
+++ b/receiver/awscontainerinsightskueuereceiver/internal/kueuescraper/kueue_prometheus_scraper_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
@@ -21,6 +22,10 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightskueuereceiver/internal/mocks"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+)
+
+const (
+	dummyCollectionInterval = 60 * time.Second
 )
 
 const kueueMetrics = `
@@ -70,24 +75,27 @@ func TestNewKueuePrometheusScraperBadInputs(t *testing.T) {
 
 	tests := []KueuePrometheusScraperOpts{
 		{ // case: no consumer
-			Ctx:               context.TODO(),
-			TelemetrySettings: settings,
-			Consumer:          nil,
-			Host:              componenttest.NewNopHost(),
-			ClusterName:       "DummyCluster",
+			Ctx:                context.TODO(),
+			TelemetrySettings:  settings,
+			Consumer:           nil,
+			Host:               componenttest.NewNopHost(),
+			ClusterName:        "DummyCluster",
+			CollectionInterval: dummyCollectionInterval,
 		},
 		{ // case: no host
-			Ctx:               context.TODO(),
-			TelemetrySettings: settings,
-			Consumer:          mockKueueConsumer{},
-			Host:              nil,
-			ClusterName:       "DummyCluster",
+			Ctx:                context.TODO(),
+			TelemetrySettings:  settings,
+			Consumer:           mockKueueConsumer{},
+			Host:               nil,
+			ClusterName:        "DummyCluster",
+			CollectionInterval: dummyCollectionInterval,
 		},
 		{ // case: no cluster name
-			Ctx:               context.TODO(),
-			TelemetrySettings: settings,
-			Consumer:          mockKueueConsumer{},
-			Host:              componenttest.NewNopHost(),
+			Ctx:                context.TODO(),
+			TelemetrySettings:  settings,
+			Consumer:           mockKueueConsumer{},
+			Host:               componenttest.NewNopHost(),
+			CollectionInterval: dummyCollectionInterval,
 		},
 	}
 
@@ -116,11 +124,12 @@ func TestNewKueuePrometheusScraperEndToEnd(t *testing.T) {
 
 	scraper, err := NewKueuePrometheusScraper(
 		KueuePrometheusScraperOpts{
-			Ctx:               context.TODO(),
-			TelemetrySettings: settings,
-			Consumer:          mConsumer,
-			Host:              componenttest.NewNopHost(),
-			ClusterName:       "DummyCluster",
+			Ctx:                context.TODO(),
+			TelemetrySettings:  settings,
+			Consumer:           mConsumer,
+			Host:               componenttest.NewNopHost(),
+			ClusterName:        "DummyCluster",
+			CollectionInterval: dummyCollectionInterval,
 		},
 	)
 	assert.NoError(t, err)

--- a/receiver/awscontainerinsightskueuereceiver/receiver.go
+++ b/receiver/awscontainerinsightskueuereceiver/receiver.go
@@ -40,6 +40,10 @@ func newAWSContainerInsightsKueueReceiver(
 		nextConsumer: nextConsumer,
 		config:       config,
 	}
+	// Set the default collection interval if not already set
+	if r.config.CollectionInterval == 0 {
+		r.config.CollectionInterval = defaultCollectionInterval
+	}
 	return r, nil
 }
 
@@ -92,11 +96,12 @@ func (akr *awsContainerInsightsKueueReceiver) initKueuePrometheusScraper(
 ) error {
 	var err error
 	akr.kueueScraper, err = kueuescraper.NewKueuePrometheusScraper(kueuescraper.KueuePrometheusScraperOpts{
-		Ctx:               ctx,
-		TelemetrySettings: akr.settings,
-		Consumer:          akr.nextConsumer,
-		Host:              host,
-		ClusterName:       akr.config.ClusterName,
+		Ctx:                ctx,
+		TelemetrySettings:  akr.settings,
+		Consumer:           akr.nextConsumer,
+		Host:               host,
+		ClusterName:        akr.config.ClusterName,
+		CollectionInterval: akr.config.CollectionInterval,
 	})
 	return err
 }


### PR DESCRIPTION
#### Description
Container Insights supports configuring a collection interval via the CWAgent json config that dictates how often the metrics should be collected from the various sources such as cadvisor.

The collection internal is not used for all the sources the metrics are retrieved from, including:
- DCGM monitor
- neuron monitor
- kueue metrics
- EFA

This change adjusts the containerinsights receiver to pass the CollectionInterval defined in the receiver config on to each scraper.
(metrics_collection_interval in CW Agent config)

https://github.com/amazon-contributing/opentelemetry-collector-contrib/blob/cb251fe99cbbaa4687bc91d0cb99aea7b2064baa/receiver/awscontainerinsightreceiver/config.go#L19

https://github.com/amazon-contributing/opentelemetry-collector-contrib/blob/cb251fe99cbbaa4687bc91d0cb99aea7b2064baa/receiver/awscontainerinsightskueuereceiver/config.go#L13

Note: For EFA, the original default collection interval value of 20s will be used if:
- collection interval is 60s 
- collection interval is not explicitly defined in agent configuration, 

#### Testing
Tested on an EKS Cluster running GPU and Neuron.

Changed CollectionInterval to 30.
```
{
    "agent":{
        "region":"us-east-1"
    },
    "logs":{
        "metrics_collected":{
            "application_signals":{
                "hosted_in":"multi-accelerator-cluster-1dot32"
            },
            "kubernetes":{
                "cluster_name":"multi-accelerator-cluster-1dot32",
                "enhanced_container_insights":true,
                "metrics_collection_interval": 30
            }
        }
    },
    "traces":{
        "traces_collected" :{
            "application_signals":{}
        }
    }
}    
```
Count of metrics increased from 1 per minute to 2 per minute.

Graph of DCGM Exporter metrics count with multiple collection intervals specified:
15s, 30s, 60s, and not-specified (defaults to 60s)

![Screenshot 2025-06-12 at 12 55 16 PM](https://github.com/user-attachments/assets/7ea8440b-22df-4fd1-b40e-3f1d6232c13c)
