### PR TITLE
Add support for deployment.environment.name

### DIFF
--- a/processor/awsapplicationsignalsprocessor/internal/attributes/attributes.go
+++ b/processor/awsapplicationsignalsprocessor/internal/attributes/attributes.go
@@ -27,4 +27,8 @@ const (
 	ResourceDetectionHostName    = "host.name"
 	ResourceDetectionASG         = "ec2.tag.aws:autoscaling:groupName"
 	ResourceDetectionClusterName = "k8s.cluster.name"
+
+	// deployment resource attributes
+	AttributeDeploymentEnvironment     = "deployment.environment"
+	AttributeDeploymentEnvironmentName = "deployment.environment.name"
 )

--- a/processor/awsapplicationsignalsprocessor/internal/resolver/attributesresolver.go
+++ b/processor/awsapplicationsignalsprocessor/internal/resolver/attributesresolver.go
@@ -12,7 +12,6 @@ import (
 	appsignalsconfig "github.com/amazon-contributing/opentelemetry-collector-contrib/processor/awsapplicationsignalsprocessor/config"
 	attr "github.com/amazon-contributing/opentelemetry-collector-contrib/processor/awsapplicationsignalsprocessor/internal/attributes"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	semconv "go.opentelemetry.io/collector/semconv/v1.22.0"
 	"go.uber.org/zap"
 )
 
@@ -27,16 +26,18 @@ const (
 )
 
 var GenericInheritedAttributes = map[string]string{
-	semconv.AttributeDeploymentEnvironment: attr.AWSLocalEnvironment,
-	attr.ResourceDetectionHostName:         common.AttributeHost,
+	attr.AttributeDeploymentEnvironment:     attr.AWSLocalEnvironment,
+	attr.AttributeDeploymentEnvironmentName: attr.AWSLocalEnvironment,
+	attr.ResourceDetectionHostName:          common.AttributeHost,
 }
 
 // DefaultInheritedAttributes is an allow-list that also renames attributes from the resource detection processor
 var DefaultInheritedAttributes = map[string]string{
-	semconv.AttributeDeploymentEnvironment: attr.AWSLocalEnvironment,
-	attr.ResourceDetectionASG:              common.AttributeEC2AutoScalingGroup,
-	attr.ResourceDetectionHostID:           common.AttributeEC2InstanceID,
-	attr.ResourceDetectionHostName:         common.AttributeHost,
+	attr.AttributeDeploymentEnvironment:     attr.AWSLocalEnvironment,
+	attr.AttributeDeploymentEnvironmentName: attr.AWSLocalEnvironment,
+	attr.ResourceDetectionASG:               common.AttributeEC2AutoScalingGroup,
+	attr.ResourceDetectionHostID:            common.AttributeEC2InstanceID,
+	attr.ResourceDetectionHostName:          common.AttributeHost,
 }
 
 type subResolver interface {

--- a/processor/awsapplicationsignalsprocessor/internal/resolver/attributesresolver_test.go
+++ b/processor/awsapplicationsignalsprocessor/internal/resolver/attributesresolver_test.go
@@ -130,39 +130,42 @@ func TestResourceAttributesResolverWithCustomEnvironment(t *testing.T) {
 			attributesResolver := NewAttributesResolver([]config.Resolver{tt.resolver}, logger)
 			resolver := attributesResolver.subResolvers[0]
 
-			attributes := pcommon.NewMap()
+			// Test hosted in env overrides default env
 			resourceAttributes := pcommon.NewMap()
-			// insert default env
 			resourceAttributes.PutStr(attr.ResourceDetectionASG, "my-asg")
 			resourceAttributes.PutStr(semconv.AttributeAWSECSTaskARN, "arn:aws:ecs:us-west-1:123456789123:task/my-cluster/10838bed-421f-43ef-870a-f43feacbbb5b")
+			resourceAttributes.PutStr(attr.AWSHostedInEnvironment, "hosted_in_env")
+			validateLocalEnvResolution(t, resolver, resourceAttributes, "hosted_in_env")
 
-			// insert custom env
-			resourceAttributes.PutStr(attr.AWSHostedInEnvironment, "env1")
-			_ = resolver.Process(attributes, resourceAttributes)
-			envAttr, ok := attributes.Get(attr.AWSLocalEnvironment)
-			assert.True(t, ok)
-			assert.Equal(t, "env1", envAttr.Str())
-
-			attributes = pcommon.NewMap()
+			// Test deployment env overrides hosted in env
 			resourceAttributes = pcommon.NewMap()
+			resourceAttributes.PutStr(attr.AWSHostedInEnvironment, "hosted_in_env")
+			resourceAttributes.PutStr(attr.AttributeDeploymentEnvironment, "dep_env")
+			validateLocalEnvResolution(t, resolver, resourceAttributes, "dep_env")
 
-			resourceAttributes.PutStr(attr.AWSHostedInEnvironment, "error")
-			resourceAttributes.PutStr(semconv.AttributeDeploymentEnvironment, "env2")
-			_ = resolver.Process(attributes, resourceAttributes)
-			envAttr, ok = attributes.Get(attr.AWSLocalEnvironment)
-			assert.True(t, ok)
-			assert.Equal(t, "env2", envAttr.Str())
-
-			attributes = pcommon.NewMap()
 			resourceAttributes = pcommon.NewMap()
+			resourceAttributes.PutStr(attr.AWSHostedInEnvironment, "hosted_in_env")
+			resourceAttributes.PutStr(attr.AttributeDeploymentEnvironmentName, "dep_env_name")
+			validateLocalEnvResolution(t, resolver, resourceAttributes, "dep_env_name")
 
-			resourceAttributes.PutStr(semconv.AttributeDeploymentEnvironment, "env3")
-			_ = resolver.Process(attributes, resourceAttributes)
-			envAttr, ok = attributes.Get(attr.AWSLocalEnvironment)
-			assert.True(t, ok)
-			assert.Equal(t, "env3", envAttr.Str())
+			// Test deployment env works standalone
+			resourceAttributes = pcommon.NewMap()
+			resourceAttributes.PutStr(attr.AttributeDeploymentEnvironment, "dep_env")
+			validateLocalEnvResolution(t, resolver, resourceAttributes, "dep_env")
+
+			resourceAttributes = pcommon.NewMap()
+			resourceAttributes.PutStr(attr.AttributeDeploymentEnvironmentName, "dep_env_name")
+			validateLocalEnvResolution(t, resolver, resourceAttributes, "dep_env_name")
 		})
 	}
+}
+
+func validateLocalEnvResolution(t *testing.T, resolver subResolver, resourceAttributes pcommon.Map, expectedEnv string) {
+	attributes := pcommon.NewMap()
+	resolver.Process(attributes, resourceAttributes)
+	envAttr, ok := attributes.Get(attr.AWSLocalEnvironment)
+	assert.True(t, ok)
+	assert.Equal(t, expectedEnv, envAttr.Str())
 }
 
 func TestAttributesResolver_Process(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
ApplicationSignalsProcessor relies on the resource attribute `deployment.environment` as a customer-provided override for ApplicationSignals `Environment`. However, `deployment.environment` has been deprecated and replaced with `deployment.environment.name` in the upstream.

Replicate the feature in CWA from this [PR](https://github.com/aws/amazon-cloudwatch-agent/pull/1722). Check the PR for more details.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

<!--Describe what testing was performed and which tests were added.-->
#### Testing
1. `go test` in applicationsignalsprocessor/internal/resolver
2. E2E testing: metrics -> ADOT SDK -> OTLP receiver -> app signal processor -> emf exporter -> any log group 
- Only `deployment.environment` is defined -> `Environment` is set
- Only `deployment.environment.name` is defined -> `Environment` is set
- `deployment.environment=deprecate,deployment.environment.name=test-processor` -> `Environment=deprecate` or `Environment=test-processor`
- `deployment.environment.name=test-processor,deployment.environment=deprecate` -> `Environment=deprecate` or `Environment=test-processor`
- No environment information -> `Environment=ec2:default`


<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
