### PR TITLE
Increase CW and EMF log event size limit from 256KB to 1MB

### DIFF
--- a/internal/aws/cwlogs/pusher.go
+++ b/internal/aws/cwlogs/pusher.go
@@ -17,11 +17,10 @@ import (
 const (
 	// http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html
 	// In truncation logic, it assuming this constant value is larger than perEventHeaderBytes + len(truncatedSuffix)
-	defaultMaxEventPayloadBytes = 1024 * 256 // 256KB
+	defaultMaxEventPayloadBytes = 1024 * 1024 // 1MB
 	// http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
-	maxRequestEventCount   = 10000
-	perEventHeaderBytes    = 26
-	maxRequestPayloadBytes = 1024 * 1024 * 1
+	maxRequestEventCount = 10000
+	perEventHeaderBytes  = 26
 
 	truncatedSuffix = "[Truncated...]"
 
@@ -225,7 +224,7 @@ func newLogPusher(streamKey StreamKey,
 // listed here: http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html
 //
 // Need to pay attention to the below 2 limits:
-// Event size 256 KB (maximum). This limit cannot be changed.
+// Event size 1 MB (maximum). This limit cannot be changed.
 // Batch size 1 MB (maximum). This limit cannot be changed.
 func (p *logPusher) AddLogEntry(logEvent *Event) error {
 	var err error


### PR DESCRIPTION
# Increase CloudWatch Logs event size limit from 256KB to 1MB

## Description

This PR updates the internal/aws/cwlogs package to support the CloudWatch Logs event size limit increase from 256KB to 1MB. The changes ensure that log events up to 1MB in size can be properly processed and sent to CloudWatch Logs without truncation.

No changes made to truncation logic.

## Changes

- Increased `defaultMaxEventPayloadBytes` constant from 256KB to 1MB
- Fixed a bug in the `exceedsLimit` function by using `maxRequestPayloadBytes` instead of `maxEventPayloadBytes` for batch size checks
- Added test cases to verify the behavior with the new limit:
  - Events at exactly 1MB
  - Events over 1MB (truncation)
  - Events between 256KB and 1MB
  - Batch handling with large events
  - Correct limit usage for batch size checks

## Testing
Built into cw agent and deployed on EC2 without errors.

### Passing Stress Tests
- https://github.com/aws/amazon-cloudwatch-agent/actions/runs/16328788036
- https://github.com/aws/amazon-cloudwatch-agent/actions/runs/16327798828

Added unit tests to verify edge cases and behaviors with the new limit. Checks:
- Events up to 1MB pass through unchanged
- Events over 1MB are properly truncated
- Batch size limits are correctly enforced
- Events between the old limit (256KB) and new limit (1MB) are handled correctly
