### PR TITLE
Ability to set collection role for Container Insights receiver

### DIFF
--- a/receiver/awscontainerinsightreceiver/config.go
+++ b/receiver/awscontainerinsightreceiver/config.go
@@ -11,6 +11,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil"
 )
 
+type CollectionRole string
+
+const (
+	LEADER CollectionRole = "LEADER"
+	NODE   CollectionRole = "NODE"
+	ALL    CollectionRole = "ALL"
+)
+
 // Config defines configuration for aws ecs container metrics receiver.
 type Config struct {
 	// AWSSessionSettings contains the common configuration options
@@ -19,6 +27,9 @@ type Config struct {
 
 	// CollectionInterval is the interval at which metrics should be collected. The default is 60 second.
 	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+
+	// CollectionRole defines the role of the collector hosting the receiver
+	CollectionRole CollectionRole `mapstructure:"collection_role"`
 
 	// ContainerOrchestrator is the type of container orchestration service, e.g. eks or ecs. The default is eks.
 	ContainerOrchestrator string `mapstructure:"container_orchestrator"`

--- a/receiver/awscontainerinsightreceiver/config_test.go
+++ b/receiver/awscontainerinsightreceiver/config_test.go
@@ -35,6 +35,7 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "collection_interval_settings"),
 			expected: &Config{
 				CollectionInterval:        60 * time.Second,
+				CollectionRole:            ALL,
 				ContainerOrchestrator:     "eks",
 				TagService:                true,
 				PrefFullPodName:           false,
@@ -46,6 +47,7 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "cluster_name"),
 			expected: &Config{
 				CollectionInterval:        60 * time.Second,
+				CollectionRole:            ALL,
 				ContainerOrchestrator:     "eks",
 				TagService:                true,
 				PrefFullPodName:           false,
@@ -58,6 +60,7 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "leader_lock_name"),
 			expected: &Config{
 				CollectionInterval:        60 * time.Second,
+				CollectionRole:            ALL,
 				ContainerOrchestrator:     "eks",
 				TagService:                true,
 				PrefFullPodName:           false,
@@ -69,6 +72,7 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "leader_lock_using_config_map_only"),
 			expected: &Config{
 				CollectionInterval:           60 * time.Second,
+				CollectionRole:               ALL,
 				ContainerOrchestrator:        "eks",
 				TagService:                   true,
 				PrefFullPodName:              false,
@@ -81,6 +85,7 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "enable_control_plane_metrics"),
 			expected: &Config{
 				CollectionInterval:        60 * time.Second,
+				CollectionRole:            ALL,
 				ContainerOrchestrator:     "eks",
 				TagService:                true,
 				PrefFullPodName:           false,
@@ -92,6 +97,7 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "custom_kube_config_path"),
 			expected: &Config{
 				CollectionInterval:    60 * time.Second,
+				CollectionRole:        ALL,
 				ContainerOrchestrator: "eks",
 				TagService:            true,
 				PrefFullPodName:       false,

--- a/receiver/awscontainerinsightreceiver/factory.go
+++ b/receiver/awscontainerinsightreceiver/factory.go
@@ -19,6 +19,9 @@ const (
 	// Default collection interval. Every 60s the receiver will collect metrics
 	defaultCollectionInterval = 60 * time.Second
 
+	// Default collector role. Collect all metrics by default
+	defaultCollectionRole = ALL
+
 	// Default container orchestrator service is aws eks
 	defaultContainerOrchestrator = "eks"
 
@@ -64,6 +67,7 @@ func createDefaultConfig() component.Config {
 		ClusterName:                 defaultClusterName,
 		LeaderLockName:              defaultLeaderLockName,
 		EnableControlPlaneMetrics:   defaultEnableControlPlaneMetrics,
+		CollectionRole:              defaultCollectionRole,
 	}
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Container Insights receiver currently collects a combination of metrics that are specific to a particular node in a cluster and also metrics that are common to the entire cluster.
When the collector is run as a daemonset, since the common metrics need to be collected by only one replica, the receiver runs a leader election process where one of the daemonset replicas elects itself as the leader and takes on the responsibility to collect the common metrics.

This model works well for small clusters and avoids any additional setup. However, this model does start to cause issues on large clusters running a high number of workloads. Specifically, there is no way to independently scale the leader pod alone such that it gets more cpu & mem to account for all the extra work its doing. Additionally, it is not possible to schedule the leader pod to specific large infra nodes in the cluster if desired.

With this change, we now provide the ability to configure a `collection_role` on the receiver.
If set to `LEADER`, the receiver will only collect metrics the leader pod previously would i.e. only metrics common to the cluster.
If set to `NODE`, the receiver will only collect metrics specific to the node.
If unspecified or explicitly set to `ALL`, it behaves the way it previously did by collecting all metrics and running leader election.

In order to benefit from these changes, large clusters are now expected to manage two separate installations of the collector:
* A daemonset collector that specifies the `collection_role` as `NODE`.
* A deployment collector that specifies the `collection_role` as `LEADER`.

This allows for independently managing and scaling the deployment collector on these large clusters.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Deployed a daemonset agent with the NODE role and a deployment agent with the LEADER role in a cluster that has 2 nodes.
```
gents:
  - name: cloudwatch-agent
    env:
      - name: CWAGENT_ROLE
        value: CI_NODE
  - name: cloudwatch-agent-ci
    mode: deployment
    config:
      {
        "logs": {
          "metrics_collected": {
            "kubernetes": {
              "enhanced_container_insights": true
            }
          }
        }
      }
    env:
      - name: CWAGENT_ROLE
        value: CI_LEADER
```
\
<img width="1191" height="80" alt="image" src="https://github.com/user-attachments/assets/4b19a88c-89a9-4b63-8ae6-a04a94664ff9" />
\
As expected, the sample count of a cluster wide metric such as `cluster_node_count` is 1. 
<img width="1258" height="351" alt="image" src="https://github.com/user-attachments/assets/330d3528-51d4-46bf-b0ad-1d725e32d7e5" />
\
The sample count of a node specific metric such as `pod_number_of_running_containers` is 2.
<img width="1893" height="351" alt="image" src="https://github.com/user-attachments/assets/45074d33-be51-4b6f-864e-0e127ab2fb3a" />