### PR TITLE
Increase cleanInterval and statsCacheDuration to 15 minutes

### DIFF
--- a/internal/aws/metrics/metric_calculator.go
+++ b/internal/aws/metrics/metric_calculator.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	cleanInterval = 5 * time.Minute
+	cleanInterval = 15 * time.Minute
 )
 
 // CalculateFunc defines how to process metric values by the calculator. It

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
@@ -28,7 +28,7 @@ import (
 )
 
 // The amount of time for which to keep stats in memory.
-const statsCacheDuration = 2 * time.Minute
+const statsCacheDuration = 15 * time.Minute
 
 // Max collection interval, it is not meaningful if allowDynamicHousekeeping = false
 var maxHousekeepingInterval = 15 * time.Second


### PR DESCRIPTION
#### Details
Container Insights CPU metrics are lost when setting collection_interval to greater than or equal to 300s

This happens because previous values needed for delta calculations are
being cleaned up before the next collection occurs due to the cache length.

<!--Describe what testing was performed and which tests were added.-->
Tested in EKS cluster running the CloudWatch Agent EKS Add-on with collection interval = 600s

configuration:
```
{
    "agent":{
        "region":"us-east-1"
    },
    "logs":{
        "metrics_collected": {
            "application_signals":{
                "hosted_in":"testing-cluster-collection-interval"
            },
            "kubernetes":{
                "cluster_name":"testing-cluster-collection-interval",
                "enhanced_container_insights":true,
                "metrics_collection_interval":600
            }
        }
    },
    "traces":{
        "traces_collected":{
            "application_signals":{
            }
        }
    }
} 
```

<img width="1436" height="575" alt="Screenshot 2025-07-14 at 8 46 09 AM" src="https://github.com/user-attachments/assets/a0f0eef2-626c-425f-ab7c-a04a83b5a7d8" />

**Previous Behavior**
<img width="1112" height="564" alt="Screenshot 2025-07-14 at 9 18 13 AM" src="https://github.com/user-attachments/assets/a45b8d7c-10a1-4165-bb41-6e20f21e8bcb" />

**Memory Usage**
<img width="1921" height="663" alt="Screenshot 2025-07-14 at 10 00 35 AM" src="https://github.com/user-attachments/assets/6915d206-7b8e-4795-a3cb-48ad086b24f1" />
No noticeable change in memory usage over the past day of running at collection interval = 600

**1 day interval**
<img width="1114" height="862" alt="Screenshot 2025-07-17 at 1 19 31 PM" src="https://github.com/user-attachments/assets/a043dc3a-fbd4-4755-9f6c-61df8fa3b2c8" />

#### Related Issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36109
