### PR TITLE
Add Persistent Volume and Persistent Volume Claim Metrics Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ internal/tools/testresults/*
 go.work*
 
 /result
+receiver/awscontainerinsightreceiver/internal/k8sapiserver/debug.test*
+receiver/awscontainerinsightreceiver/internal/k8sapiserver/debug.test*

--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -126,7 +126,8 @@ const (
 	ContainerRestartCount = "number_of_container_restarts"
 	RunningTaskCount      = "number_of_running_tasks"
 
-	PVCCount = "pvc_count"
+	PVCCount = "number_of_persistent_volume_claims"
+	PVCount  = "number_of_persistent_volumes"
 
 	DiskIOServiceBytesPrefix = "diskio_io_service_bytes_"
 	DiskIOServicedPrefix     = "diskio_io_serviced_"
@@ -162,30 +163,31 @@ const (
 	KueueClusterQueueNominalQuota  = "kueue_cluster_queue_nominal_quota"
 
 	// Define the metric types
-	TypeCluster             = "Cluster"
-	TypeClusterService      = "ClusterService"
-	TypeClusterDeployment   = "ClusterDeployment"
-	TypeClusterDaemonSet    = "ClusterDaemonSet"
-	TypeClusterStatefulSet  = "ClusterStatefulSet"
-	TypeClusterReplicaSet   = "ClusterReplicaSet"
+	TypeCluster            = "Cluster"
+	TypeClusterService     = "ClusterService"
+	TypeClusterDeployment  = "ClusterDeployment"
+	TypeClusterDaemonSet   = "ClusterDaemonSet"
+	TypeClusterStatefulSet = "ClusterStatefulSet"
+	TypeClusterReplicaSet  = "ClusterReplicaSet"
+	TypeClusterNamespace   = "ClusterNamespace"
+	TypeService            = "Service"
+	TypeInstance           = "Instance" // mean EC2 Instance in ECS
+	TypeNode               = "Node"     // mean EC2 Instance in EKS
+	TypeInstanceFS         = "InstanceFS"
+	TypeNodeFS             = "NodeFS"
+	TypeInstanceNet        = "InstanceNet"
+	TypeNodeNet            = "NodeNet"
+	TypeInstanceDiskIO     = "InstanceDiskIO"
+	TypeNodeDiskIO         = "NodeDiskIO"
+	TypePod                = "Pod"
+	TypePodNet             = "PodNet"
+	TypeContainer          = "Container"
+	TypeContainerFS        = "ContainerFS"
+	TypeContainerDiskIO    = "ContainerDiskIO"
+
 	TypeClusterPVC          = "ClusterPVC"
 	TypeClusterPV           = "ClusterPV"
-	TypeClusterNamespace    = "ClusterNamespace"
 	TypeClusterNamespacePVC = "ClusterNamespacePVC"
-	TypeService             = "Service"
-	TypeInstance            = "Instance" // mean EC2 Instance in ECS
-	TypeNode                = "Node"     // mean EC2 Instance in EKS
-	TypeInstanceFS          = "InstanceFS"
-	TypeNodeFS              = "NodeFS"
-	TypeInstanceNet         = "InstanceNet"
-	TypeNodeNet             = "NodeNet"
-	TypeInstanceDiskIO      = "InstanceDiskIO"
-	TypeNodeDiskIO          = "NodeDiskIO"
-	TypePod                 = "Pod"
-	TypePodNet              = "PodNet"
-	TypeContainer           = "Container"
-	TypeContainerFS         = "ContainerFS"
-	TypeContainerDiskIO     = "ContainerDiskIO"
 
 	// kueue metric types
 	TypeClusterQueue = "ClusterQueue"
@@ -378,5 +380,6 @@ func init() {
 		HyperPodUnschedulable:                   UnitCount,
 
 		PVCCount: UnitCount,
+		PVCount:  UnitCount,
 	}
 }

--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -126,6 +126,8 @@ const (
 	ContainerRestartCount = "number_of_container_restarts"
 	RunningTaskCount      = "number_of_running_tasks"
 
+	PVCCount = "pvc_count"
+
 	DiskIOServiceBytesPrefix = "diskio_io_service_bytes_"
 	DiskIOServicedPrefix     = "diskio_io_serviced_"
 	DiskIOAsync              = "Async"
@@ -160,27 +162,30 @@ const (
 	KueueClusterQueueNominalQuota  = "kueue_cluster_queue_nominal_quota"
 
 	// Define the metric types
-	TypeCluster            = "Cluster"
-	TypeClusterService     = "ClusterService"
-	TypeClusterDeployment  = "ClusterDeployment"
-	TypeClusterDaemonSet   = "ClusterDaemonSet"
-	TypeClusterStatefulSet = "ClusterStatefulSet"
-	TypeClusterReplicaSet  = "ClusterReplicaSet"
-	TypeClusterNamespace   = "ClusterNamespace"
-	TypeService            = "Service"
-	TypeInstance           = "Instance" // mean EC2 Instance in ECS
-	TypeNode               = "Node"     // mean EC2 Instance in EKS
-	TypeInstanceFS         = "InstanceFS"
-	TypeNodeFS             = "NodeFS"
-	TypeInstanceNet        = "InstanceNet"
-	TypeNodeNet            = "NodeNet"
-	TypeInstanceDiskIO     = "InstanceDiskIO"
-	TypeNodeDiskIO         = "NodeDiskIO"
-	TypePod                = "Pod"
-	TypePodNet             = "PodNet"
-	TypeContainer          = "Container"
-	TypeContainerFS        = "ContainerFS"
-	TypeContainerDiskIO    = "ContainerDiskIO"
+	TypeCluster             = "Cluster"
+	TypeClusterService      = "ClusterService"
+	TypeClusterDeployment   = "ClusterDeployment"
+	TypeClusterDaemonSet    = "ClusterDaemonSet"
+	TypeClusterStatefulSet  = "ClusterStatefulSet"
+	TypeClusterReplicaSet   = "ClusterReplicaSet"
+	TypeClusterPVC          = "ClusterPVC"
+	TypeClusterPV           = "ClusterPV"
+	TypeClusterNamespace    = "ClusterNamespace"
+	TypeClusterNamespacePVC = "ClusterNamespacePVC"
+	TypeService             = "Service"
+	TypeInstance            = "Instance" // mean EC2 Instance in ECS
+	TypeNode                = "Node"     // mean EC2 Instance in EKS
+	TypeInstanceFS          = "InstanceFS"
+	TypeNodeFS              = "NodeFS"
+	TypeInstanceNet         = "InstanceNet"
+	TypeNodeNet             = "NodeNet"
+	TypeInstanceDiskIO      = "InstanceDiskIO"
+	TypeNodeDiskIO          = "NodeDiskIO"
+	TypePod                 = "Pod"
+	TypePodNet              = "PodNet"
+	TypeContainer           = "Container"
+	TypeContainerFS         = "ContainerFS"
+	TypeContainerDiskIO     = "ContainerDiskIO"
 
 	// kueue metric types
 	TypeClusterQueue = "ClusterQueue"
@@ -371,5 +376,7 @@ func init() {
 		HyperPodUnschedulablePendingReboot:      UnitCount,
 		HyperPodSchedulable:                     UnitCount,
 		HyperPodUnschedulable:                   UnitCount,
+
+		PVCCount: UnitCount,
 	}
 }

--- a/internal/aws/containerinsight/utils.go
+++ b/internal/aws/containerinsight/utils.go
@@ -172,6 +172,10 @@ func getPrefixByMetricType(mType string) string {
 		prefix = replicaSet
 	case TypeHyperPodNode:
 		prefix = hyperPodNodeHealthStatus
+	case TypeClusterPV, TypeClusterPVC:
+		prefix = ""
+	case TypeClusterNamespacePVC:
+		prefix = ""
 	default:
 		log.Printf("E! Unexpected MetricType: %s", mType)
 	}

--- a/internal/aws/k8s/k8sclient/clientset.go
+++ b/internal/aws/k8s/k8sclient/clientset.go
@@ -223,6 +223,11 @@ type pvcClientWithStopper interface {
 	stopper
 }
 
+type pvClientWithStopper interface {
+	PVClient
+	stopper
+}
+
 type K8sClient struct {
 	kubeConfigPath       string
 	initSyncPollInterval time.Duration
@@ -262,6 +267,9 @@ type K8sClient struct {
 
 	pvcMu sync.Mutex
 	pvc   pvcClientWithStopper
+
+	pvMu sync.Mutex
+	pv   pvClientWithStopper
 
 	logger *zap.Logger
 }
@@ -468,14 +476,16 @@ func (c *K8sClient) ShutdownStatefulSetClient() {
 	})
 }
 
+// --- PV and PVC clients reverted to explicit instantiation ---
+
 func (c *K8sClient) GetPVCClient() PVCClient {
 	var err error
 	c.pvcMu.Lock()
 	defer c.pvcMu.Unlock()
 	if c.pvc == nil || reflect.ValueOf(c.pvc).IsNil() {
-		c.pvc, err = newPVCClient(c.clientSet, c.logger, pvcSyncCheckerOption(c.syncChecker))
+		c.pvc, err = NewPVCClient(c.clientSet, c.logger, c.syncChecker)
 		if err != nil {
-			c.logger.Error("use an no-op PVC client instead because of error", zap.Error(err))
+			c.logger.Error("use a no-op PVC client instead because of error", zap.Error(err))
 			c.pvc = &noOpPVCClient{}
 		}
 	}
@@ -483,9 +493,33 @@ func (c *K8sClient) GetPVCClient() PVCClient {
 }
 
 func (c *K8sClient) ShutdownPVCClient() {
-	shutdownClient(c.pvc, &c.pvcMu, func() {
-		c.pvc = nil
-	})
+	if client, ok := c.pvc.(stopper); ok {
+		shutdownClient(client, &c.pvcMu, func() {
+			c.pvc = nil
+		})
+	}
+}
+
+func (c *K8sClient) GetPVClient() PVClient {
+	var err error
+	c.pvMu.Lock()
+	defer c.pvMu.Unlock()
+	if c.pv == nil || reflect.ValueOf(c.pv).IsNil() {
+		c.pv, err = NewPVClient(c.clientSet, c.logger, c.syncChecker)
+		if err != nil {
+			c.logger.Error("use a no-op PV client instead because of error", zap.Error(err))
+			c.pv = &noOpPVClient{}
+		}
+	}
+	return c.pv
+}
+
+func (c *K8sClient) ShutdownPVClient() {
+	if client, ok := c.pv.(stopper); ok {
+		shutdownClient(client, &c.pvMu, func() {
+			c.pv = nil
+		})
+	}
 }
 
 func (c *K8sClient) GetClientSet() kubernetes.Interface {
@@ -506,6 +540,7 @@ func (c *K8sClient) Shutdown() {
 	c.ShutdownDaemonSetClient()
 	c.ShutdownStatefulSetClient()
 	c.ShutdownPVCClient()
+	c.ShutdownPVClient()
 
 	// remove the current instance of k8s client from map
 	for key, val := range optionsToK8sClient {

--- a/internal/aws/k8s/k8sclient/clientset.go
+++ b/internal/aws/k8s/k8sclient/clientset.go
@@ -218,6 +218,11 @@ type statefulSetClientWithStopper interface {
 	stopper
 }
 
+type pvcClientWithStopper interface {
+	PVCClient
+	stopper
+}
+
 type K8sClient struct {
 	kubeConfigPath       string
 	initSyncPollInterval time.Duration
@@ -254,6 +259,9 @@ type K8sClient struct {
 
 	ssMu        sync.Mutex
 	statefulSet statefulSetClientWithStopper
+
+	pvcMu sync.Mutex
+	pvc   pvcClientWithStopper
 
 	logger *zap.Logger
 }
@@ -303,6 +311,7 @@ func (c *K8sClient) init(logger *zap.Logger, options ...Option) error {
 	c.deployment = nil
 	c.daemonSet = nil
 	c.statefulSet = nil
+	c.pvc = nil
 
 	return nil
 }
@@ -459,6 +468,26 @@ func (c *K8sClient) ShutdownStatefulSetClient() {
 	})
 }
 
+func (c *K8sClient) GetPVCClient() PVCClient {
+	var err error
+	c.pvcMu.Lock()
+	defer c.pvcMu.Unlock()
+	if c.pvc == nil || reflect.ValueOf(c.pvc).IsNil() {
+		c.pvc, err = newPVCClient(c.clientSet, c.logger, pvcSyncCheckerOption(c.syncChecker))
+		if err != nil {
+			c.logger.Error("use an no-op PVC client instead because of error", zap.Error(err))
+			c.pvc = &noOpPVCClient{}
+		}
+	}
+	return c.pvc
+}
+
+func (c *K8sClient) ShutdownPVCClient() {
+	shutdownClient(c.pvc, &c.pvcMu, func() {
+		c.pvc = nil
+	})
+}
+
 func (c *K8sClient) GetClientSet() kubernetes.Interface {
 	return c.clientSet
 }
@@ -476,6 +505,7 @@ func (c *K8sClient) Shutdown() {
 	c.ShutdownDeploymentClient()
 	c.ShutdownDaemonSetClient()
 	c.ShutdownStatefulSetClient()
+	c.ShutdownPVCClient()
 
 	// remove the current instance of k8s client from map
 	for key, val := range optionsToK8sClient {

--- a/internal/aws/k8s/k8sclient/pv.go
+++ b/internal/aws/k8s/k8sclient/pv.go
@@ -1,0 +1,90 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+type PVClient interface {
+	Client
+}
+
+type pvClient struct {
+	*BaseResourceClient[*corev1.PersistentVolume]
+}
+
+type noOpPVClient struct {
+	noOpClient
+}
+
+// PV-specific functions
+func refreshFuncPV(objs []*corev1.PersistentVolume) (int, map[string]int) {
+	totalCount := 0
+	for _, pv := range objs {
+		if pv == nil {
+			continue
+		}
+		totalCount++
+	}
+	return totalCount, map[string]int{} // PVs are not namespaced, so we return an empty map
+}
+
+func transformFuncPV(obj interface{}) (*corev1.PersistentVolume, error) {
+	pv, ok := obj.(*corev1.PersistentVolume)
+	if !ok {
+		return nil, fmt.Errorf("input obj %v is not PersistentVolume type", obj)
+	}
+	return pv, nil
+}
+
+func createPVListWatch(client kubernetes.Interface, ns string) cache.ListerWatcher {
+	ctx := context.Background()
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return client.CoreV1().PersistentVolumes().List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return client.CoreV1().PersistentVolumes().Watch(ctx, opts)
+		},
+	}
+}
+
+func testPVList(clientSet kubernetes.Interface) error {
+	ctx := context.Background()
+	_, err := clientSet.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+	return err
+}
+
+func newPVObject() *corev1.PersistentVolume {
+	return &corev1.PersistentVolume{}
+}
+
+func NewPVClient(clientSet kubernetes.Interface, logger *zap.Logger, syncChecker initialSyncChecker) (*pvClient, error) {
+	config := ResourceConfig[*corev1.PersistentVolume]{
+		ResourceName:  "PV",
+		ListWatchFunc: createPVListWatch,
+		TransformFunc: transformFuncPV,
+		RefreshFunc:   refreshFuncPV,
+		TestListFunc:  testPVList,
+		NewObjectFunc: newPVObject,
+		Namespace:     "", // PVs are cluster-scoped
+	}
+
+	base, err := NewBaseResourceClient(clientSet, logger, config, syncChecker)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pvClient{base}, nil
+}

--- a/internal/aws/k8s/k8sclient/pv_test.go
+++ b/internal/aws/k8s/k8sclient/pv_test.go
@@ -1,0 +1,112 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var pvObjects = []runtime.Object{
+	&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv-1",
+			UID:  "pv-1-uid",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "pvc-1",
+				Namespace: "test-namespace",
+			},
+		},
+	},
+	&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv-2",
+			UID:  "pv2-uid",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "pvc-2",
+				Namespace: "another-namespace",
+			},
+		},
+	},
+	&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv-3",
+			UID:  "pv3-uid",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "pvc-3",
+				Namespace: "test-namespace",
+			},
+		},
+	},
+}
+
+func TestPVClient_TotalPVCount(t *testing.T) {
+	setOption := &mockReflectorSyncChecker{}
+
+	fakeClientSet := fake.NewSimpleClientset(pvObjects...)
+	client, err := NewPVClient(fakeClientSet, zap.NewNop(), setOption)
+	assert.NoError(t, err)
+
+	pvs := make([]any, len(pvObjects))
+	for i := range pvObjects {
+		pvs[i] = pvObjects[i]
+	}
+	assert.NoError(t, client.store.Replace(pvs, ""))
+
+	// Set the refreshed flag to true to trigger a refresh in TotalPVCount
+	client.store.mu.Lock()
+	client.store.refreshed = true
+	client.store.mu.Unlock()
+
+	expectedCount := 3
+	actualCount := client.TotalCount()
+	assert.Equal(t, expectedCount, actualCount)
+
+	client.shutdown()
+	assert.True(t, client.stopped)
+}
+
+func TestTransformFuncPV(t *testing.T) {
+	info, err := transformFuncPV(nil)
+	assert.Nil(t, info)
+	assert.Error(t, err)
+
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pv",
+			UID:  "test-pv",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "test-pv",
+				Namespace: "test-namespace",
+			},
+		},
+	}
+	result, err := transformFuncPV(pv)
+	assert.NoError(t, err)
+	assert.Equal(t, pv, result)
+}
+
+func TestNoOpPVClient(t *testing.T) {
+	client := &noOpPVClient{}
+
+	totalCount := client.TotalCount()
+	assert.Equal(t, 0, totalCount)
+
+	// Should not panic
+	client.shutdown()
+}

--- a/internal/aws/k8s/k8sclient/pvc.go
+++ b/internal/aws/k8s/k8sclient/pvc.go
@@ -6,7 +6,6 @@ package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-c
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -18,128 +17,40 @@ import (
 )
 
 type PVCClient interface {
-	// NamespaceToPVCCount returns a map of namespace to PVC count
-	NamespaceToPVCCount() map[string]int
-	// TotalPVCCount returns the total number of PVCs in the cluster
-	TotalPVCCount() int
-}
-
-type noOpPVCClient struct{}
-
-func (p *noOpPVCClient) NamespaceToPVCCount() map[string]int {
-	return map[string]int{}
-}
-
-func (p *noOpPVCClient) TotalPVCCount() int {
-	return 0
-}
-
-func (p *noOpPVCClient) shutdown() {
-}
-
-type pvcClientOption func(*pvcClient)
-
-func pvcSyncCheckerOption(checker initialSyncChecker) pvcClientOption {
-	return func(p *pvcClient) {
-		p.syncChecker = checker
-	}
+	CountByNamespaceClient
 }
 
 type pvcClient struct {
-	stopChan chan struct{}
-	stopped  bool
-
-	store *ObjStore
-
-	syncChecker initialSyncChecker
-
-	mu                sync.RWMutex
-	namespaceToPVCMap map[string]int
-	totalCount        int
+	*BaseResourceClient[*corev1.PersistentVolumeClaim]
 }
 
-func (p *pvcClient) refresh() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+type noOpPVCClient struct {
+	noOpClient
+}
 
+func (p *noOpPVCClient) CountByNamespace() map[string]int { return map[string]int{} }
+
+func (p *pvcClient) CountByNamespace() map[string]int {
+	return p.GetExtraMap()
+}
+
+// PVC-specific functions
+func refreshFuncPVC(objs []*corev1.PersistentVolumeClaim) (int, map[string]int) {
 	namespaceToPVCMap := make(map[string]int)
 	totalCount := 0
 
-	objsList := p.store.List()
-	for _, obj := range objsList {
-		pvc, ok := obj.(*corev1.PersistentVolumeClaim)
-		if !ok {
+	for _, pvc := range objs {
+		if pvc == nil {
 			continue
 		}
 		namespaceToPVCMap[pvc.Namespace]++
 		totalCount++
 	}
 
-	p.namespaceToPVCMap = namespaceToPVCMap
-	p.totalCount = totalCount
+	return totalCount, namespaceToPVCMap
 }
 
-func (p *pvcClient) NamespaceToPVCCount() map[string]int {
-	if p.store.GetResetRefreshStatus() {
-		p.refresh()
-	}
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-
-	result := make(map[string]int)
-	for ns, count := range p.namespaceToPVCMap {
-		result[ns] = count
-	}
-	return result
-}
-
-func (p *pvcClient) TotalPVCCount() int {
-	if p.store.GetResetRefreshStatus() {
-		p.refresh()
-	}
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	return p.totalCount
-}
-
-func newPVCClient(clientSet kubernetes.Interface, logger *zap.Logger, options ...pvcClientOption) (*pvcClient, error) {
-	p := &pvcClient{
-		stopChan:          make(chan struct{}),
-		namespaceToPVCMap: make(map[string]int),
-	}
-
-	for _, option := range options {
-		option(p)
-	}
-
-	ctx := context.Background()
-	if _, err := clientSet.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).List(ctx, metav1.ListOptions{}); err != nil {
-		return nil, fmt.Errorf("cannot list PVCs. err: %w", err)
-	}
-
-	// Create a store to hold PVC objects
-	p.store = NewObjStore(transformFuncPVC, logger)
-	// Create a ListWatch that knows how to list and watch PVCs
-	lw := createPVCListWatch(clientSet, metav1.NamespaceAll)
-	// Create a Reflector that watches PVCs and updates the store
-	reflector := cache.NewReflector(lw, &corev1.PersistentVolumeClaim{}, p.store, 0)
-	// Start the Reflector in a goroutine
-	go reflector.Run(p.stopChan)
-
-	if p.syncChecker != nil {
-		// Check the init sync for potential connection issue
-		p.syncChecker.Check(reflector, "PVC initial sync timeout")
-	}
-
-	return p, nil
-}
-
-func (p *pvcClient) shutdown() {
-	close(p.stopChan)
-	p.stopped = true
-}
-
-func transformFuncPVC(obj interface{}) (interface{}, error) {
+func transformFuncPVC(obj interface{}) (*corev1.PersistentVolumeClaim, error) {
 	pvc, ok := obj.(*corev1.PersistentVolumeClaim)
 	if !ok {
 		return nil, fmt.Errorf("input obj %v is not PersistentVolumeClaim type", obj)
@@ -157,4 +68,33 @@ func createPVCListWatch(client kubernetes.Interface, ns string) cache.ListerWatc
 			return client.CoreV1().PersistentVolumeClaims(ns).Watch(ctx, opts)
 		},
 	}
+}
+
+func testPVCList(clientSet kubernetes.Interface) error {
+	ctx := context.Background()
+	_, err := clientSet.CoreV1().PersistentVolumeClaims("").List(ctx, metav1.ListOptions{})
+	return err
+}
+
+func newPVCObject() *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{}
+}
+
+func NewPVCClient(clientSet kubernetes.Interface, logger *zap.Logger, syncChecker initialSyncChecker) (*pvcClient, error) {
+	config := ResourceConfig[*corev1.PersistentVolumeClaim]{
+		ResourceName:  "PVC",
+		ListWatchFunc: createPVCListWatch,
+		TransformFunc: transformFuncPVC,
+		RefreshFunc:   refreshFuncPVC,
+		TestListFunc:  testPVCList,
+		NewObjectFunc: newPVCObject,
+		Namespace:     metav1.NamespaceAll,
+	}
+
+	base, err := NewBaseResourceClient(clientSet, logger, config, syncChecker)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pvcClient{base}, nil
 }

--- a/internal/aws/k8s/k8sclient/pvc.go
+++ b/internal/aws/k8s/k8sclient/pvc.go
@@ -1,0 +1,160 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+type PVCClient interface {
+	// NamespaceToPVCCount returns a map of namespace to PVC count
+	NamespaceToPVCCount() map[string]int
+	// TotalPVCCount returns the total number of PVCs in the cluster
+	TotalPVCCount() int
+}
+
+type noOpPVCClient struct{}
+
+func (p *noOpPVCClient) NamespaceToPVCCount() map[string]int {
+	return map[string]int{}
+}
+
+func (p *noOpPVCClient) TotalPVCCount() int {
+	return 0
+}
+
+func (p *noOpPVCClient) shutdown() {
+}
+
+type pvcClientOption func(*pvcClient)
+
+func pvcSyncCheckerOption(checker initialSyncChecker) pvcClientOption {
+	return func(p *pvcClient) {
+		p.syncChecker = checker
+	}
+}
+
+type pvcClient struct {
+	stopChan chan struct{}
+	stopped  bool
+
+	store *ObjStore
+
+	syncChecker initialSyncChecker
+
+	mu                sync.RWMutex
+	namespaceToPVCMap map[string]int
+	totalCount        int
+}
+
+func (p *pvcClient) refresh() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	namespaceToPVCMap := make(map[string]int)
+	totalCount := 0
+
+	objsList := p.store.List()
+	for _, obj := range objsList {
+		pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+		if !ok {
+			continue
+		}
+		namespaceToPVCMap[pvc.Namespace]++
+		totalCount++
+	}
+
+	p.namespaceToPVCMap = namespaceToPVCMap
+	p.totalCount = totalCount
+}
+
+func (p *pvcClient) NamespaceToPVCCount() map[string]int {
+	if p.store.GetResetRefreshStatus() {
+		p.refresh()
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	result := make(map[string]int)
+	for ns, count := range p.namespaceToPVCMap {
+		result[ns] = count
+	}
+	return result
+}
+
+func (p *pvcClient) TotalPVCCount() int {
+	if p.store.GetResetRefreshStatus() {
+		p.refresh()
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.totalCount
+}
+
+func newPVCClient(clientSet kubernetes.Interface, logger *zap.Logger, options ...pvcClientOption) (*pvcClient, error) {
+	p := &pvcClient{
+		stopChan:          make(chan struct{}),
+		namespaceToPVCMap: make(map[string]int),
+	}
+
+	for _, option := range options {
+		option(p)
+	}
+
+	ctx := context.Background()
+	if _, err := clientSet.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).List(ctx, metav1.ListOptions{}); err != nil {
+		return nil, fmt.Errorf("cannot list PVCs. err: %w", err)
+	}
+
+	// Create a store to hold PVC objects
+	p.store = NewObjStore(transformFuncPVC, logger)
+	// Create a ListWatch that knows how to list and watch PVCs
+	lw := createPVCListWatch(clientSet, metav1.NamespaceAll)
+	// Create a Reflector that watches PVCs and updates the store
+	reflector := cache.NewReflector(lw, &corev1.PersistentVolumeClaim{}, p.store, 0)
+	// Start the Reflector in a goroutine
+	go reflector.Run(p.stopChan)
+
+	if p.syncChecker != nil {
+		// Check the init sync for potential connection issue
+		p.syncChecker.Check(reflector, "PVC initial sync timeout")
+	}
+
+	return p, nil
+}
+
+func (p *pvcClient) shutdown() {
+	close(p.stopChan)
+	p.stopped = true
+}
+
+func transformFuncPVC(obj interface{}) (interface{}, error) {
+	pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		return nil, fmt.Errorf("input obj %v is not PersistentVolumeClaim type", obj)
+	}
+	return pvc, nil
+}
+
+func createPVCListWatch(client kubernetes.Interface, ns string) cache.ListerWatcher {
+	ctx := context.Background()
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return client.CoreV1().PersistentVolumeClaims(ns).List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return client.CoreV1().PersistentVolumeClaims(ns).Watch(ctx, opts)
+		},
+	}
+}

--- a/internal/aws/k8s/k8sclient/pvc_test.go
+++ b/internal/aws/k8s/k8sclient/pvc_test.go
@@ -1,0 +1,141 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var pvcObjects = []runtime.Object{
+	&corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-1",
+			Namespace: "test-namespace",
+			UID:       "pvc-1-uid",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimBound,
+		},
+	},
+	&corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-2",
+			Namespace: "test-namespace",
+			UID:       "pvc-2-uid",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimBound,
+		},
+	},
+	&corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-3",
+			Namespace: "another-namespace",
+			UID:       "pvc-3-uid",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimBound,
+		},
+	},
+}
+
+func TestPVCClient_NamespaceToPVCCount(t *testing.T) {
+	setOption := pvcSyncCheckerOption(&mockReflectorSyncChecker{})
+
+	fakeClientSet := fake.NewSimpleClientset(pvcObjects...)
+	client, _ := newPVCClient(fakeClientSet, zap.NewNop(), setOption)
+
+	pvcs := make([]any, len(pvcObjects))
+	for i := range pvcObjects {
+		pvcs[i] = pvcObjects[i]
+	}
+	assert.NoError(t, client.store.Replace(pvcs, ""))
+
+	expectedMap := map[string]int{
+		"test-namespace":    2,
+		"another-namespace": 1,
+	}
+	resultMap := client.NamespaceToPVCCount()
+	assert.Equal(t, expectedMap, resultMap)
+
+	client.shutdown()
+	assert.True(t, client.stopped)
+}
+
+func TestPVCClient_TotalPVCCount(t *testing.T) {
+	setOption := pvcSyncCheckerOption(&mockReflectorSyncChecker{})
+
+	fakeClientSet := fake.NewSimpleClientset(pvcObjects...)
+	client, err := newPVCClient(fakeClientSet, zap.NewNop(), setOption)
+	assert.NoError(t, err)
+
+	pvcs := make([]any, len(pvcObjects))
+	for i := range pvcObjects {
+		pvcs[i] = pvcObjects[i]
+	}
+	assert.NoError(t, client.store.Replace(pvcs, ""))
+
+	// Set the refreshed flag to true to trigger a refresh in TotalPVCCount
+	client.store.mu.Lock()
+	client.store.refreshed = true
+	client.store.mu.Unlock()
+
+	expectedCount := 3
+	actualCount := client.TotalPVCCount()
+	assert.Equal(t, expectedCount, actualCount)
+
+	client.shutdown()
+	assert.True(t, client.stopped)
+}
+
+func TestTransformFuncPVC(t *testing.T) {
+	info, err := transformFuncPVC(nil)
+	assert.Nil(t, info)
+	assert.Error(t, err)
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "test-namespace",
+		},
+	}
+	result, err := transformFuncPVC(pvc)
+	assert.NoError(t, err)
+	assert.Equal(t, pvc, result)
+}
+
+func TestNoOpPVCClient(t *testing.T) {
+	client := &noOpPVCClient{}
+
+	namespaceToPVCCount := client.NamespaceToPVCCount()
+	assert.Equal(t, map[string]int{}, namespaceToPVCCount)
+
+	totalCount := client.TotalPVCCount()
+	assert.Equal(t, 0, totalCount)
+
+	// Should not panic
+	client.shutdown()
+}

--- a/internal/aws/k8s/k8sclient/pvc_test.go
+++ b/internal/aws/k8s/k8sclient/pvc_test.go
@@ -63,10 +63,10 @@ var pvcObjects = []runtime.Object{
 }
 
 func TestPVCClient_NamespaceToPVCCount(t *testing.T) {
-	setOption := pvcSyncCheckerOption(&mockReflectorSyncChecker{})
+	setOption := &mockReflectorSyncChecker{}
 
 	fakeClientSet := fake.NewSimpleClientset(pvcObjects...)
-	client, _ := newPVCClient(fakeClientSet, zap.NewNop(), setOption)
+	client, _ := NewPVCClient(fakeClientSet, zap.NewNop(), setOption)
 
 	pvcs := make([]any, len(pvcObjects))
 	for i := range pvcObjects {
@@ -78,7 +78,7 @@ func TestPVCClient_NamespaceToPVCCount(t *testing.T) {
 		"test-namespace":    2,
 		"another-namespace": 1,
 	}
-	resultMap := client.NamespaceToPVCCount()
+	resultMap := client.CountByNamespace()
 	assert.Equal(t, expectedMap, resultMap)
 
 	client.shutdown()
@@ -86,10 +86,10 @@ func TestPVCClient_NamespaceToPVCCount(t *testing.T) {
 }
 
 func TestPVCClient_TotalPVCCount(t *testing.T) {
-	setOption := pvcSyncCheckerOption(&mockReflectorSyncChecker{})
+	setOption := &mockReflectorSyncChecker{}
 
 	fakeClientSet := fake.NewSimpleClientset(pvcObjects...)
-	client, err := newPVCClient(fakeClientSet, zap.NewNop(), setOption)
+	client, err := NewPVCClient(fakeClientSet, zap.NewNop(), setOption)
 	assert.NoError(t, err)
 
 	pvcs := make([]any, len(pvcObjects))
@@ -104,7 +104,7 @@ func TestPVCClient_TotalPVCCount(t *testing.T) {
 	client.store.mu.Unlock()
 
 	expectedCount := 3
-	actualCount := client.TotalPVCCount()
+	actualCount := client.TotalCount()
 	assert.Equal(t, expectedCount, actualCount)
 
 	client.shutdown()
@@ -130,10 +130,10 @@ func TestTransformFuncPVC(t *testing.T) {
 func TestNoOpPVCClient(t *testing.T) {
 	client := &noOpPVCClient{}
 
-	namespaceToPVCCount := client.NamespaceToPVCCount()
+	namespaceToPVCCount := client.CountByNamespace()
 	assert.Equal(t, map[string]int{}, namespaceToPVCCount)
 
-	totalCount := client.TotalPVCCount()
+	totalCount := client.TotalCount()
 	assert.Equal(t, 0, totalCount)
 
 	// Should not panic

--- a/internal/aws/k8s/k8sclient/resource.go
+++ b/internal/aws/k8s/k8sclient/resource.go
@@ -1,0 +1,160 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+
+import (
+	"fmt"
+	"sync"
+
+	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+// Client is a generic interface for Kubernetes resource clients.
+type Client interface {
+	TotalCount() int // Returns the total number of resources currently observed.
+	shutdown()
+}
+
+type CountByNamespaceClient interface {
+	Client
+	CountByNamespace() map[string]int // CountByNamespace returns a map of namespace to the count of resources in that namespace.
+}
+
+type noOpClient struct{}
+
+func (n *noOpClient) TotalCount() int { return 0 }
+func (n *noOpClient) shutdown()       {}
+
+// ResourceConfig holds the configuration needed to create a resource client
+type ResourceConfig[T any] struct {
+	ResourceName  string
+	ListWatchFunc func(kubernetes.Interface, string) cache.ListerWatcher
+	TransformFunc func(interface{}) (T, error)
+	RefreshFunc   func([]T) (int, map[string]int)
+	TestListFunc  func(kubernetes.Interface) error
+	NewObjectFunc func() T
+	Namespace     string
+}
+
+// BaseResourceClient provides common functionality for all resource clients
+type BaseResourceClient[T any] struct {
+	*ResourceClient[T]
+	config ResourceConfig[T]
+}
+
+// NewBaseResourceClient creates a new base resource client with the given configuration
+func NewBaseResourceClient[T any](
+	clientSet kubernetes.Interface,
+	logger *zap.Logger,
+	config ResourceConfig[T],
+	syncChecker initialSyncChecker,
+) (*BaseResourceClient[T], error) {
+	// Test connectivity
+	if err := config.TestListFunc(clientSet); err != nil {
+		return nil, fmt.Errorf("failed to list %s: %w", config.ResourceName, err)
+	}
+
+	// Create wrapper transform function for ObjStore
+	transformFuncForStore := func(obj interface{}) (interface{}, error) {
+		return config.TransformFunc(obj)
+	}
+
+	resourceClient := &ResourceClient[T]{
+		stopChan:    make(chan struct{}),
+		store:       NewObjStore(transformFuncForStore, logger),
+		transformFn: config.TransformFunc,
+		refreshFunc: config.RefreshFunc,
+		syncChecker: syncChecker,
+	}
+
+	// Create and run Reflector
+	lw := config.ListWatchFunc(clientSet, config.Namespace)
+	reflector := cache.NewReflector(lw, config.NewObjectFunc(), resourceClient.store, 0)
+	go reflector.Run(resourceClient.stopChan)
+
+	// Check initial sync
+	if resourceClient.syncChecker != nil {
+		resourceClient.syncChecker.Check(reflector, fmt.Sprintf("%s initial sync timeout", config.ResourceName))
+	}
+
+	return &BaseResourceClient[T]{
+		ResourceClient: resourceClient,
+		config:         config,
+	}, nil
+}
+
+// TotalCount implements the Client interface.
+func (b *BaseResourceClient[T]) TotalCount() int {
+	return b.GetTotalCount()
+}
+
+// Shutdown implements the Client interface.
+func (b *BaseResourceClient[T]) shutdown() {
+	b.ResourceClient.shutdown()
+}
+
+type ResourceClient[T any] struct {
+	stopChan    chan struct{}
+	stopped     bool
+	store       *ObjStore
+	syncChecker initialSyncChecker
+
+	refreshFunc func([]T) (total int, extra map[string]int)
+	transformFn func(interface{}) (T, error)
+
+	mu         sync.RWMutex
+	totalCount int
+	extraMap   map[string]int
+}
+
+func (r *ResourceClient[T]) refresh() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var objs []T
+	objsList := r.store.List()
+	for _, obj := range objsList {
+		transformedObj, err := r.transformFn(obj)
+		if err != nil {
+			continue // Skip invalid objects
+		}
+		objs = append(objs, transformedObj)
+	}
+
+	totalCount, extraMap := r.refreshFunc(objs)
+	r.totalCount = totalCount
+	r.extraMap = extraMap
+}
+
+func (rc *ResourceClient[T]) GetTotalCount() int {
+	if rc.store.GetResetRefreshStatus() {
+		rc.refresh()
+	}
+	rc.mu.RLock()
+	defer rc.mu.RUnlock()
+	return rc.totalCount
+}
+
+func (rc *ResourceClient[T]) GetExtraMap() map[string]int {
+	if rc.store.GetResetRefreshStatus() {
+		rc.refresh()
+	}
+	rc.mu.RLock()
+	defer rc.mu.RUnlock()
+	// Return a copy
+	out := make(map[string]int, len(rc.extraMap))
+	for k, v := range rc.extraMap {
+		out[k] = v
+	}
+	return out
+}
+
+func (rc *ResourceClient[T]) shutdown() {
+	if !rc.stopped {
+		close(rc.stopChan)
+		rc.stopped = true
+	}
+}

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
@@ -58,6 +58,7 @@ type K8sClient interface {
 	GetStatefulSetClient() k8sclient.StatefulSetClient
 	GetReplicaSetClient() k8sclient.ReplicaSetClient
 	GetPVCClient() k8sclient.PVCClient
+	GetPVClient() k8sclient.PVClient
 	ShutdownNodeClient()
 	ShutdownPodClient()
 	ShutdownPVCClient()
@@ -139,6 +140,7 @@ func (k *K8sAPIServer) GetMetrics() []pmetric.Metrics {
 	if k.includeEnhancedMetrics {
 		result = append(result, k.getHyperPodResiliencyMetrics(clusterName, timestampNs)...)
 		result = append(result, k.getPVCMetrics(clusterName, timestampNs)...)
+		result = append(result, k.getPVMetrics(clusterName, timestampNs)...)
 	}
 
 	return result
@@ -148,6 +150,7 @@ func (k *K8sAPIServer) getClusterMetrics(clusterName, timestampNs string) pmetri
 	fields := map[string]any{
 		"cluster_failed_node_count": k.leaderElection.nodeClient.ClusterFailedNodeCount(),
 		"cluster_node_count":        k.leaderElection.nodeClient.ClusterNodeCount(),
+		// "cluster_" + ci.PVCount:     k.leaderElection.pvClient.TotalCount(),
 	}
 
 	namespaceMap := k.leaderElection.podClient.NamespaceToRunningPodNum()
@@ -172,9 +175,11 @@ func (k *K8sAPIServer) getClusterMetrics(clusterName, timestampNs string) pmetri
 
 func (k *K8sAPIServer) getNamespaceMetrics(clusterName, timestampNs string) []pmetric.Metrics {
 	var metrics []pmetric.Metrics
+	// pvClaimsByNamespace := k.leaderElection.pvcClient.CountByNamespace()
 	for namespace, podNum := range k.leaderElection.podClient.NamespaceToRunningPodNum() {
 		fields := map[string]any{
 			"namespace_number_of_running_pods": podNum,
+			// "namespace_" + ci.PVCCount:         pvClaimsByNamespace[namespace],
 		}
 		attributes := map[string]string{
 			ci.ClusterNameKey: clusterName,
@@ -498,14 +503,14 @@ func (k *K8sAPIServer) getPVCMetrics(clusterName, timestampNs string) []pmetric.
 	}
 
 	// Get namespace-level counts
-	nameSpaceCounts := k.leaderElection.pvcClient.NamespaceToPVCCount()
+	nameSpaceCounts := k.leaderElection.pvcClient.CountByNamespace()
 	// If no PVCs are found, return empty metrics
 	if len(nameSpaceCounts) == 0 {
 		k.logger.Debug("No PVCs found, skipping PVC metrics")
 		return metrics
 	}
 	// Get total PVC count
-	clusterCount := k.leaderElection.pvcClient.TotalPVCCount()
+	clusterCount := k.leaderElection.pvcClient.TotalCount()
 
 	// Create name-space level metrics
 	for namespace, count := range nameSpaceCounts {
@@ -520,7 +525,7 @@ func (k *K8sAPIServer) getPVCMetrics(clusterName, timestampNs string) []pmetric.
 			ci.Version:        "0",
 		}
 		if k.nodeName != "" {
-			attributes["NodeName"] = k.nodeName
+			attributes[ci.NodeNameKey] = k.nodeName
 		}
 		attributes[ci.SourcesKey] = "[\"apiserver\"]"
 		md := ci.ConvertToOTLPMetrics(fields, attributes, k.logger)
@@ -535,6 +540,39 @@ func (k *K8sAPIServer) getPVCMetrics(clusterName, timestampNs string) []pmetric.
 		attributes := map[string]string{
 			ci.ClusterNameKey: clusterName,
 			ci.MetricType:     ci.TypeClusterPVC,
+			ci.Timestamp:      timestampNs,
+			ci.Version:        "0",
+		}
+		if k.nodeName != "" {
+			attributes["NodeName"] = k.nodeName
+		}
+		attributes[ci.SourcesKey] = "[\"apiserver\"]"
+		md := ci.ConvertToOTLPMetrics(fields, attributes, k.logger)
+		metrics = append(metrics, md)
+	}
+	return metrics
+}
+
+func (k *K8sAPIServer) getPVMetrics(clusterName, timestampNs string) []pmetric.Metrics {
+	var metrics []pmetric.Metrics
+
+	// Check if pvClient is initialized
+	if k.leaderElection.pvClient == nil {
+		k.logger.Debug("PV client is not initialized, skipping PV metrics")
+		return metrics
+	}
+
+	// Get total PV count
+	clusterCount := k.leaderElection.pvClient.TotalCount()
+
+	// Create cluster-level metrics
+	if clusterCount > 0 {
+		fields := map[string]any{
+			ci.PVCount: clusterCount,
+		}
+		attributes := map[string]string{
+			ci.ClusterNameKey: clusterName,
+			ci.MetricType:     ci.TypeClusterPV,
 			ci.Timestamp:      timestampNs,
 			ci.Version:        "0",
 		}

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
@@ -57,8 +57,10 @@ type K8sClient interface {
 	GetDaemonSetClient() k8sclient.DaemonSetClient
 	GetStatefulSetClient() k8sclient.StatefulSetClient
 	GetReplicaSetClient() k8sclient.ReplicaSetClient
+	GetPVCClient() k8sclient.PVCClient
 	ShutdownNodeClient()
 	ShutdownPodClient()
+	ShutdownPVCClient()
 }
 
 // K8sAPIServer is a struct that produces metrics from kubernetes api server
@@ -136,6 +138,7 @@ func (k *K8sAPIServer) GetMetrics() []pmetric.Metrics {
 
 	if k.includeEnhancedMetrics {
 		result = append(result, k.getHyperPodResiliencyMetrics(clusterName, timestampNs)...)
+		result = append(result, k.getPVCMetrics(clusterName, timestampNs)...)
 	}
 
 	return result
@@ -481,6 +484,66 @@ func (k *K8sAPIServer) getHyperPodResiliencyMetrics(clusterName, timestampNs str
 				metrics = append(metrics, md)
 			}
 		}
+	}
+	return metrics
+}
+
+func (k *K8sAPIServer) getPVCMetrics(clusterName, timestampNs string) []pmetric.Metrics {
+	var metrics []pmetric.Metrics
+
+	// Check if pvcClient is initialized
+	if k.leaderElection.pvcClient == nil {
+		k.logger.Debug("PVC client is not initialized, skipping PVC metrics")
+		return metrics
+	}
+
+	// Get namespace-level counts
+	nameSpaceCounts := k.leaderElection.pvcClient.NamespaceToPVCCount()
+	// If no PVCs are found, return empty metrics
+	if len(nameSpaceCounts) == 0 {
+		k.logger.Debug("No PVCs found, skipping PVC metrics")
+		return metrics
+	}
+	// Get total PVC count
+	clusterCount := k.leaderElection.pvcClient.TotalPVCCount()
+
+	// Create name-space level metrics
+	for namespace, count := range nameSpaceCounts {
+		fields := map[string]any{
+			ci.PVCCount: count,
+		}
+		attributes := map[string]string{
+			ci.ClusterNameKey: clusterName,
+			ci.MetricType:     ci.TypeClusterNamespacePVC,
+			ci.Timestamp:      timestampNs,
+			ci.K8sNamespace:   namespace,
+			ci.Version:        "0",
+		}
+		if k.nodeName != "" {
+			attributes["NodeName"] = k.nodeName
+		}
+		attributes[ci.SourcesKey] = "[\"apiserver\"]"
+		md := ci.ConvertToOTLPMetrics(fields, attributes, k.logger)
+		metrics = append(metrics, md)
+	}
+
+	// Create cluster-level metrics
+	if clusterCount > 0 {
+		fields := map[string]any{
+			ci.PVCCount: clusterCount,
+		}
+		attributes := map[string]string{
+			ci.ClusterNameKey: clusterName,
+			ci.MetricType:     ci.TypeClusterPVC,
+			ci.Timestamp:      timestampNs,
+			ci.Version:        "0",
+		}
+		if k.nodeName != "" {
+			attributes["NodeName"] = k.nodeName
+		}
+		attributes[ci.SourcesKey] = "[\"apiserver\"]"
+		md := ci.ConvertToOTLPMetrics(fields, attributes, k.logger)
+		metrics = append(metrics, md)
 	}
 	return metrics
 }

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
@@ -66,6 +66,10 @@ func (m *mockK8sClient) GetReplicaSetClient() k8sclient.ReplicaSetClient {
 	return mockClient
 }
 
+func (m *mockK8sClient) GetPVCClient() k8sclient.PVCClient {
+	return mockClient
+}
+
 func (m *mockK8sClient) ShutdownNodeClient() {
 }
 
@@ -84,10 +88,14 @@ func (m *mockK8sClient) ShutdownStatefulSetClient() {
 func (m *mockK8sClient) ShutdownReplicaSetClient() {
 }
 
+func (m *mockK8sClient) ShutdownPVCClient() {
+}
+
 type MockClient struct {
 	k8sclient.PodClient
 	k8sclient.NodeClient
 	k8sclient.EpClient
+	k8sclient.PVCClient
 
 	mock.Mock
 }
@@ -164,6 +172,18 @@ func (client *MockClient) ServiceToPodNum() map[k8sclient.Service]int {
 func (client *MockClient) PodKeyToServiceNames() map[string][]string {
 	args := client.Called()
 	return args.Get(0).(map[string][]string)
+}
+
+// k8sclient.PVCClient
+func (client *MockClient) NamespaceToPVCCount() map[string]int {
+	args := client.Called()
+	return args.Get(0).(map[string]int)
+}
+
+// k8sclient.PVCClient
+func (client *MockClient) TotalPVCCount() int {
+	args := client.Called()
+	return args.Get(0).(int)
 }
 
 type mockEventBroadcaster struct{}
@@ -337,6 +357,12 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 		},
 	})
 
+	mockClient.On("NamespaceToPVCCount").Return(map[string]int{
+		"default":     3,
+		"kube-system": 2,
+	})
+	mockClient.On("TotalPVCCount").Return(5)
+
 	leaderElection := &LeaderElection{
 		k8sClient:         &mockK8sClient{},
 		nodeClient:        mockClient,
@@ -346,6 +372,7 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 		daemonSetClient:   mockClient,
 		statefulSetClient: mockClient,
 		replicaSetClient:  mockClient,
+		pvcClient:         mockClient,
 		leading:           true,
 		broadcaster:       &mockEventBroadcaster{},
 		isLeadingC:        make(chan struct{}),
@@ -378,7 +405,6 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 			assertMetricValueEqual(t, metric, "cluster_failed_node_count", int64(1))
 			assertMetricValueEqual(t, metric, "cluster_node_count", int64(1))
 			assertMetricValueEqual(t, metric, "cluster_number_of_running_pods", int64(2))
-
 		case ci.TypeClusterService:
 			assertMetricValueEqual(t, metric, "service_number_of_running_pods", int64(1))
 			assert.Contains(t, []string{"service1", "service2"}, getStringAttrVal(metric, ci.TypeService))
@@ -416,6 +442,18 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 			assert.Equal(t, "kube-system", getStringAttrVal(metric, ci.K8sNamespace))
 			assert.Equal(t, "statefulset1", getStringAttrVal(metric, ci.PodNameKey))
 			assert.Equal(t, "ClusterStatefulSet", getStringAttrVal(metric, ci.MetricType))
+		case ci.TypeClusterPVC:
+			assertMetricValueEqual(t, metric, ci.PVCCount, int64(5))
+		case ci.TypeClusterNamespacePVC:
+			namespace := getStringAttrVal(metric, ci.K8sNamespace)
+			switch namespace {
+			case "default":
+				assertMetricValueEqual(t, metric, ci.PVCCount, int64(3))
+			case "kube-system":
+				assertMetricValueEqual(t, metric, ci.PVCCount, int64(2))
+			default:
+				assert.Fail(t, "Unexpected namespace: "+namespace)
+			}
 		case ci.TypePod:
 			assertMetricValueEqual(t, metric, "pod_status_pending", int64(1))
 			assertMetricValueEqual(t, metric, "pod_status_running", int64(0))

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
@@ -70,6 +70,10 @@ func (m *mockK8sClient) GetPVCClient() k8sclient.PVCClient {
 	return mockClient
 }
 
+func (m *mockK8sClient) GetPVClient() k8sclient.PVClient {
+	return mockClient
+}
+
 func (m *mockK8sClient) ShutdownNodeClient() {
 }
 
@@ -89,6 +93,9 @@ func (m *mockK8sClient) ShutdownReplicaSetClient() {
 }
 
 func (m *mockK8sClient) ShutdownPVCClient() {
+}
+
+func (m *mockK8sClient) ShutdownPVClient() {
 }
 
 type MockClient struct {
@@ -175,13 +182,13 @@ func (client *MockClient) PodKeyToServiceNames() map[string][]string {
 }
 
 // k8sclient.PVCClient
-func (client *MockClient) NamespaceToPVCCount() map[string]int {
+func (client *MockClient) CountByNamespace() map[string]int {
 	args := client.Called()
 	return args.Get(0).(map[string]int)
 }
 
 // k8sclient.PVCClient
-func (client *MockClient) TotalPVCCount() int {
+func (client *MockClient) TotalCount() int {
 	args := client.Called()
 	return args.Get(0).(int)
 }
@@ -357,11 +364,11 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 		},
 	})
 
-	mockClient.On("NamespaceToPVCCount").Return(map[string]int{
+	mockClient.On("CountByNamespace").Return(map[string]int{
 		"default":     3,
 		"kube-system": 2,
 	})
-	mockClient.On("TotalPVCCount").Return(5)
+	mockClient.On("TotalCount").Return(5)
 
 	leaderElection := &LeaderElection{
 		k8sClient:         &mockK8sClient{},
@@ -373,6 +380,7 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 		statefulSetClient: mockClient,
 		replicaSetClient:  mockClient,
 		pvcClient:         mockClient,
+		pvClient:          mockClient,
 		leading:           true,
 		broadcaster:       &mockEventBroadcaster{},
 		isLeadingC:        make(chan struct{}),
@@ -442,18 +450,6 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 			assert.Equal(t, "kube-system", getStringAttrVal(metric, ci.K8sNamespace))
 			assert.Equal(t, "statefulset1", getStringAttrVal(metric, ci.PodNameKey))
 			assert.Equal(t, "ClusterStatefulSet", getStringAttrVal(metric, ci.MetricType))
-		case ci.TypeClusterPVC:
-			assertMetricValueEqual(t, metric, ci.PVCCount, int64(5))
-		case ci.TypeClusterNamespacePVC:
-			namespace := getStringAttrVal(metric, ci.K8sNamespace)
-			switch namespace {
-			case "default":
-				assertMetricValueEqual(t, metric, ci.PVCCount, int64(3))
-			case "kube-system":
-				assertMetricValueEqual(t, metric, ci.PVCCount, int64(2))
-			default:
-				assert.Fail(t, "Unexpected namespace: "+namespace)
-			}
 		case ci.TypePod:
 			assertMetricValueEqual(t, metric, "pod_status_pending", int64(1))
 			assertMetricValueEqual(t, metric, "pod_status_running", int64(0))
@@ -473,10 +469,26 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 			assertMetricValueEqual(t, metric, "hyperpod_node_health_status_schedulable", int64(1))
 			assertMetricValueEqual(t, metric, "hyperpod_node_health_status_unschedulable", int64(0))
 			assertMetricValueEqual(t, metric, "hyperpod_node_health_status_unschedulable_pending_replacement", int64(0))
+		case ci.TypeClusterPVC:
+			assertMetricValueEqual(t, metric, ci.PVCCount, int64(5))
+			assert.Equal(t, "ClusterPVC", getStringAttrVal(metric, ci.MetricType))
+			assert.Equal(t, "cluster-name", getStringAttrVal(metric, ci.ClusterNameKey))
+		case ci.TypeClusterPV:
+			assertMetricValueEqual(t, metric, ci.PVCount, int64(5))
+			assert.Equal(t, "ClusterPV", getStringAttrVal(metric, ci.MetricType))
+		case ci.TypeClusterNamespacePVC:
+			assert.Equal(t, "ClusterNamespacePVC", getStringAttrVal(metric, ci.MetricType))
+			switch getStringAttrVal(metric, ci.K8sNamespace) {
+			case "default":
+				assertMetricValueEqual(t, metric, ci.PVCCount, int64(3))
+			case "kube-system":
+				assertMetricValueEqual(t, metric, ci.PVCCount, int64(2))
+			default:
+				assert.Fail(t, "Unexpected namespace in ClusterNamespacePVC metric: "+getStringAttrVal(metric, ci.K8sNamespace))
+			}
 		default:
 			assert.Fail(t, "Unexpected metric type: "+metricType)
 		}
 	}
-
 	require.NoError(t, k8sAPIServer.Shutdown())
 }

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/leaderelection.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/leaderelection.go
@@ -43,6 +43,7 @@ type LeaderElection struct {
 	statefulSetClient k8sclient.StatefulSetClient
 	replicaSetClient  k8sclient.ReplicaSetClient
 	pvcClient         k8sclient.PVCClient
+	pvClient          k8sclient.PVClient
 
 	// the following can be set to mocks in testing
 	broadcaster eventBroadcaster
@@ -182,6 +183,7 @@ func (le *LeaderElection) startLeaderElection(ctx context.Context, lock resource
 					le.statefulSetClient = le.k8sClient.GetStatefulSetClient()
 					le.replicaSetClient = le.k8sClient.GetReplicaSetClient()
 					le.pvcClient = le.k8sClient.GetPVCClient()
+					le.pvClient = le.k8sClient.GetPVClient()
 					le.mu.Unlock()
 
 					if le.isLeadingC != nil {

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/leaderelection.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/leaderelection.go
@@ -42,6 +42,7 @@ type LeaderElection struct {
 	daemonSetClient   k8sclient.DaemonSetClient
 	statefulSetClient k8sclient.StatefulSetClient
 	replicaSetClient  k8sclient.ReplicaSetClient
+	pvcClient         k8sclient.PVCClient
 
 	// the following can be set to mocks in testing
 	broadcaster eventBroadcaster
@@ -180,6 +181,7 @@ func (le *LeaderElection) startLeaderElection(ctx context.Context, lock resource
 					le.daemonSetClient = le.k8sClient.GetDaemonSetClient()
 					le.statefulSetClient = le.k8sClient.GetStatefulSetClient()
 					le.replicaSetClient = le.k8sClient.GetReplicaSetClient()
+					le.pvcClient = le.k8sClient.GetPVCClient()
 					le.mu.Unlock()
 
 					if le.isLeadingC != nil {


### PR DESCRIPTION
#### Description
This PR adds comprehensive support for collecting Persistent Volume (PV) and Persistent Volume Claim (PVC) metrics in the AWS Container Insights receiver. This enhancement enables better monitoring and observability of storage resources in Kubernetes clusters.

**Key changes:**
* Added PVC metrics collection with comprehensive test coverage
* Implemented PV metrics support and refactored code architecture
* Decoupled PVs and PVCs to inherit from parent Resource class for better organization
* Enhanced k8s clientset with PV/PVC support following existing patterns
* Integrated PV/PVC metrics into the main k8sapiserver receiver

This provides AWS Container Insights users with complete visibility into Kubernetes storage resources, enabling better capacity planning and monitoring capabilities.

#### Testing
* Added comprehensive unit tests for both PV and PVC clients (`pv_test.go`, `pvc_test.go`)
* Enhanced existing k8sapiserver tests to cover new PV/PVC functionality
* All tests follow existing patterns and maintain compatibility with current codebase
* Verified all existing tests continue to pass with new changes