### PR TITLE
Add mem_shared Metric to Memory Scraper

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/documentation.md
@@ -24,7 +24,7 @@ Bytes of memory in use.
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
-| state | Breakdown of memory usage by type. | Str: ``buffered``, ``cached``, ``inactive``, ``free``, ``slab_reclaimable``, ``slab_unreclaimable``, ``used`` |
+| state | Breakdown of memory usage by type. | Str: ``buffered``, ``cached``, ``inactive``, ``free``, ``shared``, ``slab_reclaimable``, ``slab_unreclaimable``, ``used`` |
 
 ## Optional Metrics
 
@@ -80,4 +80,4 @@ Percentage of memory bytes in use.
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
-| state | Breakdown of memory usage by type. | Str: ``buffered``, ``cached``, ``inactive``, ``free``, ``slab_reclaimable``, ``slab_unreclaimable``, ``used`` |
+| state | Breakdown of memory usage by type. | Str: ``buffered``, ``cached``, ``inactive``, ``free``, ``shared``, ``slab_reclaimable``, ``slab_unreclaimable``, ``used`` |

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics.go
@@ -21,6 +21,7 @@ const (
 	AttributeStateCached
 	AttributeStateInactive
 	AttributeStateFree
+	AttributeStateShared
 	AttributeStateSlabReclaimable
 	AttributeStateSlabUnreclaimable
 	AttributeStateUsed
@@ -37,6 +38,8 @@ func (av AttributeState) String() string {
 		return "inactive"
 	case AttributeStateFree:
 		return "free"
+	case AttributeStateShared:
+		return "shared"
 	case AttributeStateSlabReclaimable:
 		return "slab_reclaimable"
 	case AttributeStateSlabUnreclaimable:
@@ -53,6 +56,7 @@ var MapAttributeState = map[string]AttributeState{
 	"cached":             AttributeStateCached,
 	"inactive":           AttributeStateInactive,
 	"free":               AttributeStateFree,
+	"shared":             AttributeStateShared,
 	"slab_reclaimable":   AttributeStateSlabReclaimable,
 	"slab_unreclaimable": AttributeStateSlabUnreclaimable,
 	"used":               AttributeStateUsed,

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_linux.go
@@ -17,6 +17,7 @@ func (s *memoryScraper) recordMemoryUsageMetric(now pcommon.Timestamp, memInfo *
 	s.mb.RecordSystemMemoryUsageDataPoint(now, int64(memInfo.Free), metadata.AttributeStateFree)
 	s.mb.RecordSystemMemoryUsageDataPoint(now, int64(memInfo.Buffers), metadata.AttributeStateBuffered)
 	s.mb.RecordSystemMemoryUsageDataPoint(now, int64(memInfo.Cached), metadata.AttributeStateCached)
+	s.mb.RecordSystemMemoryUsageDataPoint(now, int64(memInfo.Shared), metadata.AttributeStateShared)
 	s.mb.RecordSystemMemoryUsageDataPoint(now, int64(memInfo.Sreclaimable), metadata.AttributeStateSlabReclaimable)
 	s.mb.RecordSystemMemoryUsageDataPoint(now, int64(memInfo.Sunreclaim), metadata.AttributeStateSlabUnreclaimable)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
@@ -226,8 +226,10 @@ func assertMemoryUsageMetricHasLinuxSpecificStateLabels(t *testing.T, metric pme
 	internal.AssertSumMetricHasAttributeValue(t, metric, 3, "state",
 		pcommon.NewValueStr(metadata.AttributeStateCached.String()))
 	internal.AssertSumMetricHasAttributeValue(t, metric, 4, "state",
-		pcommon.NewValueStr(metadata.AttributeStateSlabReclaimable.String()))
+        pcommon.NewValueStr(metadata.AttributeStateShared.String())) 
 	internal.AssertSumMetricHasAttributeValue(t, metric, 5, "state",
+		pcommon.NewValueStr(metadata.AttributeStateSlabReclaimable.String()))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 6, "state",
 		pcommon.NewValueStr(metadata.AttributeStateSlabUnreclaimable.String()))
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
@@ -226,7 +226,7 @@ func assertMemoryUsageMetricHasLinuxSpecificStateLabels(t *testing.T, metric pme
 	internal.AssertSumMetricHasAttributeValue(t, metric, 3, "state",
 		pcommon.NewValueStr(metadata.AttributeStateCached.String()))
 	internal.AssertSumMetricHasAttributeValue(t, metric, 4, "state",
-        pcommon.NewValueStr(metadata.AttributeStateShared.String())) 
+		pcommon.NewValueStr(metadata.AttributeStateShared.String()))
 	internal.AssertSumMetricHasAttributeValue(t, metric, 5, "state",
 		pcommon.NewValueStr(metadata.AttributeStateSlabReclaimable.String()))
 	internal.AssertSumMetricHasAttributeValue(t, metric, 6, "state",

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
@@ -14,7 +14,7 @@ attributes:
   state:
     description: Breakdown of memory usage by type.
     type: string
-    enum: [buffered, cached, inactive, free, slab_reclaimable, slab_unreclaimable, used]
+    enum: [buffered, cached, inactive, free, shared, slab_reclaimable, slab_unreclaimable, used]
 
 metrics:
   system.memory.limit:


### PR DESCRIPTION
### Description

This PR adds shared memory (`shmem`) metric to the Linux memory scraper in the OpenTelemetry Collector Contrib repository. This enhancement enables the CloudWatch Agent to collect and report shared memory metrics on Linux servers to give more insights into Linux system memory usage.

### Changes

- Added shared memory metric to the system memory usage data points in the Linux memory scraper
- Implemented shared memory data collection in the memory scraper
- Added unit tests to verify shared memory metric collection
- Updated metadata.yaml with shared memory metric definition

### Testing

**Unit Tests**
   - Executed unit tests in memory scraper (`memory_scraper_test.go` and `generated_metrics_test.go`)
   - All tests passed successfully

 **Manual Testing**
   - Built and deployed a local version of the CloudWatch agent with my changes from the OTel on an EC2 instance
   - Configured agent with the following configuration:

```json
{
  "metrics": { 
    "namespace": "mem_shared_testing",
    "metrics_collected": {
      "mem": {
        "measurement": [
          "mem_shared", 
        ],
        "metrics_collection_interval": 10
      }
    }
  }
}
```
   - Verified metrics appearing correctly in CloudWatch console 
   
<img width="1424" height="263" alt="Screenshot 2025-07-23 at 2 02 10 PM" src="https://github.com/user-attachments/assets/2480198f-43d9-4aa1-8818-4c15f98c7b64" />

   - Validated metric accuracy by comparing with direct system values:
      ```bash
     $ cat /proc/meminfo | grep -i shm
     Shmem:               190 kB
     ```
   - Confirmed shared memory value (190 kB) matches between system and emitted metric