### PR TITLE
Add PersistentVolume and PersistentVolumeClaim metrics

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -126,6 +126,9 @@ const (
 	ContainerRestartCount = "number_of_container_restarts"
 	RunningTaskCount      = "number_of_running_tasks"
 
+	PVCCount = "number_of_persistent_volume_claims"
+	PVCount  = "number_of_persistent_volumes"
+
 	DiskIOServiceBytesPrefix = "diskio_io_service_bytes_"
 	DiskIOServicedPrefix     = "diskio_io_serviced_"
 	DiskIOAsync              = "Async"
@@ -181,6 +184,10 @@ const (
 	TypeContainer          = "Container"
 	TypeContainerFS        = "ContainerFS"
 	TypeContainerDiskIO    = "ContainerDiskIO"
+
+	TypeClusterPVC          = "ClusterPVC"
+	TypeClusterPV           = "ClusterPV"
+	TypeClusterNamespacePVC = "ClusterNamespacePVC"
 
 	// kueue metric types
 	TypeClusterQueue = "ClusterQueue"
@@ -371,5 +378,8 @@ func init() {
 		HyperPodUnschedulablePendingReboot:      UnitCount,
 		HyperPodSchedulable:                     UnitCount,
 		HyperPodUnschedulable:                   UnitCount,
+
+		PVCCount: UnitCount,
+		PVCount:  UnitCount,
 	}
 }

--- a/internal/aws/containerinsight/utils.go
+++ b/internal/aws/containerinsight/utils.go
@@ -172,6 +172,10 @@ func getPrefixByMetricType(mType string) string {
 		prefix = replicaSet
 	case TypeHyperPodNode:
 		prefix = hyperPodNodeHealthStatus
+	case TypeClusterPV, TypeClusterPVC:
+		prefix = ""
+	case TypeClusterNamespacePVC:
+		prefix = ""
 	default:
 		log.Printf("E! Unexpected MetricType: %s", mType)
 	}

--- a/internal/aws/k8s/k8sclient/clientset.go
+++ b/internal/aws/k8s/k8sclient/clientset.go
@@ -218,6 +218,16 @@ type statefulSetClientWithStopper interface {
 	stopper
 }
 
+type pVolumeClaimClientWithStopper interface {
+	PVolumeClaimClient
+	stopper
+}
+
+type pVolumeClientWithStopper interface {
+	PVolumeClient
+	stopper
+}
+
 type K8sClient struct {
 	kubeConfigPath       string
 	initSyncPollInterval time.Duration
@@ -254,6 +264,12 @@ type K8sClient struct {
 
 	ssMu        sync.Mutex
 	statefulSet statefulSetClientWithStopper
+
+	pvcMu sync.Mutex
+	pvc   pVolumeClaimClientWithStopper
+
+	pvMu sync.Mutex
+	pv   pVolumeClientWithStopper
 
 	logger *zap.Logger
 }
@@ -303,6 +319,7 @@ func (c *K8sClient) init(logger *zap.Logger, options ...Option) error {
 	c.deployment = nil
 	c.daemonSet = nil
 	c.statefulSet = nil
+	c.pvc = nil
 
 	return nil
 }
@@ -459,6 +476,46 @@ func (c *K8sClient) ShutdownStatefulSetClient() {
 	})
 }
 
+func (c *K8sClient) GetPVolumeClaimClient() PVolumeClaimClient {
+	var err error
+	c.pvcMu.Lock()
+	defer c.pvcMu.Unlock()
+	if c.pvc == nil || reflect.ValueOf(c.pvc).IsNil() {
+		c.pvc, err = newPVolumeClaimClient(c.clientSet, c.logger, PVolumeClaimSyncCheckerOption(c.syncChecker))
+		if err != nil {
+			c.logger.Error("use an no-op PVC client instead because of error", zap.Error(err))
+			c.pvc = &noOpPVolumeClaimClient{}
+		}
+	}
+	return c.pvc
+}
+
+func (c *K8sClient) ShutdownPVolumeClaimClient() {
+	shutdownClient(c.pvc, &c.pvcMu, func() {
+		c.pvc = nil
+	})
+}
+
+func (c *K8sClient) GetPVolumeClient() PVolumeClient {
+	var err error
+	c.pvMu.Lock()
+	defer c.pvMu.Unlock()
+	if c.pv == nil || reflect.ValueOf(c.pv).IsNil() {
+		c.pv, err = newPVolumeClient(c.clientSet, c.logger, PVolumeSyncCheckerOption(c.syncChecker))
+		if err != nil {
+			c.logger.Error("use an no-op PV client instead because of error", zap.Error(err))
+			c.pv = &noOpPVolumeClient{}
+		}
+	}
+	return c.pv
+}
+
+func (c *K8sClient) ShutdownPVolumeClient() {
+	shutdownClient(c.pv, &c.pvMu, func() {
+		c.pv = nil
+	})
+}
+
 func (c *K8sClient) GetClientSet() kubernetes.Interface {
 	return c.clientSet
 }
@@ -476,6 +533,8 @@ func (c *K8sClient) Shutdown() {
 	c.ShutdownDeploymentClient()
 	c.ShutdownDaemonSetClient()
 	c.ShutdownStatefulSetClient()
+	c.ShutdownPVolumeClaimClient()
+	c.ShutdownPVolumeClient()
 
 	// remove the current instance of k8s client from map
 	for key, val := range optionsToK8sClient {

--- a/internal/aws/k8s/k8sclient/pv.go
+++ b/internal/aws/k8s/k8sclient/pv.go
@@ -1,0 +1,131 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+type PVolumeClient interface {
+	GetVolumeCount() int
+}
+
+type noOpPVolumeClient struct{}
+
+func (p *noOpPVolumeClient) GetVolumeCount() int {
+	return 0
+}
+
+func (p *noOpPVolumeClient) shutdown() {
+}
+
+type PVolumeClientOption func(*PVolume)
+
+func PVolumeSyncCheckerOption(checker initialSyncChecker) PVolumeClientOption {
+	return func(p *PVolume) {
+		p.syncChecker = checker
+	}
+}
+
+type PVolume struct {
+	stopChan chan struct{}
+	stopped  bool
+
+	store *ObjStore
+
+	syncChecker initialSyncChecker
+
+	mu         sync.RWMutex
+	totalCount int
+}
+
+func (p *PVolume) refresh() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	totalCount := 0
+	objsList := p.store.List()
+	for _, obj := range objsList {
+		_, ok := obj.(*corev1.PersistentVolume)
+		if !ok {
+			continue
+		}
+		totalCount++
+	}
+	p.totalCount = totalCount
+}
+
+func (p *PVolume) GetVolumeCount() int {
+	if p.store.GetResetRefreshStatus() {
+		p.refresh()
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.totalCount
+}
+
+func newPVolumeClient(clientSet kubernetes.Interface, logger *zap.Logger, options ...PVolumeClientOption) (*PVolume, error) {
+	p := &PVolume{
+		stopChan: make(chan struct{}),
+	}
+
+	for _, option := range options {
+		option(p)
+	}
+
+	ctx := context.Background()
+	if _, err := clientSet.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{}); err != nil {
+		return nil, fmt.Errorf("cannot list PVCs. err: %w", err)
+	}
+
+	// Create a store to hold PVC objects
+	p.store = NewObjStore(transformFuncPVolume, logger)
+	// Create a ListWatch that knows how to list and watch PVCs
+	lw := createPVolumeListWatch(clientSet)
+	// Create a Reflector that watches PVCs and updates the store
+	reflector := cache.NewReflector(lw, &corev1.PersistentVolume{}, p.store, 0)
+	// Start the Reflector in a goroutine
+	go reflector.Run(p.stopChan)
+
+	if p.syncChecker != nil {
+		// Check the init sync for potential connection issue
+		p.syncChecker.Check(reflector, "PersistentVolume initial sync timeout")
+	}
+
+	return p, nil
+}
+
+func (p *PVolume) shutdown() {
+	close(p.stopChan)
+	p.stopped = true
+}
+
+func transformFuncPVolume(obj interface{}) (interface{}, error) {
+	pvc, ok := obj.(*corev1.PersistentVolume)
+	if !ok {
+		return nil, fmt.Errorf("input obj %v is not PersistentVolume type", obj)
+	}
+	return pvc, nil
+}
+
+func createPVolumeListWatch(client kubernetes.Interface) cache.ListerWatcher {
+	ctx := context.Background()
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return client.CoreV1().PersistentVolumes().List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return client.CoreV1().PersistentVolumes().Watch(ctx, opts)
+		},
+	}
+}

--- a/internal/aws/k8s/k8sclient/pv_test.go
+++ b/internal/aws/k8s/k8sclient/pv_test.go
@@ -1,0 +1,112 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var pvObjects = []runtime.Object{
+	&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv-1",
+			UID:  "pv-1-uid",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "pvc-1",
+				Namespace: "test-namespace",
+			},
+		},
+	},
+	&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv-2",
+			UID:  "pv2-uid",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "pvc-2",
+				Namespace: "another-namespace",
+			},
+		},
+	},
+	&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv-3",
+			UID:  "pv3-uid",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "pvc-3",
+				Namespace: "test-namespace",
+			},
+		},
+	},
+}
+
+func TestPVClient_TotalPVCount(t *testing.T) {
+	setOption := PVolumeSyncCheckerOption(&mockReflectorSyncChecker{})
+
+	fakeClientSet := fake.NewSimpleClientset(pvObjects...)
+	client, err := newPVolumeClient(fakeClientSet, zap.NewNop(), setOption)
+	assert.NoError(t, err)
+
+	pvs := make([]any, len(pvObjects))
+	for i := range pvObjects {
+		pvs[i] = pvObjects[i]
+	}
+	assert.NoError(t, client.store.Replace(pvs, ""))
+
+	// Set the refreshed flag to true to trigger a refresh in TotalPVCount
+	client.store.mu.Lock()
+	client.store.refreshed = true
+	client.store.mu.Unlock()
+
+	expectedCount := 3
+	actualCount := client.GetVolumeCount()
+	assert.Equal(t, expectedCount, actualCount)
+
+	client.shutdown()
+	assert.True(t, client.stopped)
+}
+
+func TestTransformFuncPV(t *testing.T) {
+	info, err := transformFuncPVolume(nil)
+	assert.Nil(t, info)
+	assert.Error(t, err)
+
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pv",
+			UID:  "test-pv",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "test-pv",
+				Namespace: "test-namespace",
+			},
+		},
+	}
+	result, err := transformFuncPVolume(pv)
+	assert.NoError(t, err)
+	assert.Equal(t, pv, result)
+}
+
+func TestNoOpPVClient(t *testing.T) {
+	client := &noOpPVolumeClient{}
+
+	totalCount := client.GetVolumeCount()
+	assert.Equal(t, 0, totalCount)
+
+	// Should not panic
+	client.shutdown()
+}

--- a/internal/aws/k8s/k8sclient/pvc.go
+++ b/internal/aws/k8s/k8sclient/pvc.go
@@ -1,0 +1,158 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+type PVolumeClaimClient interface {
+	GetNamespaceCount() map[string]int
+	GetClaimCount() int
+}
+
+type noOpPVolumeClaimClient struct{}
+
+func (p *noOpPVolumeClaimClient) GetNamespaceCount() map[string]int {
+	return map[string]int{}
+}
+
+func (p *noOpPVolumeClaimClient) GetClaimCount() int {
+	return 0
+}
+
+func (p *noOpPVolumeClaimClient) shutdown() {
+}
+
+type PVolumeClaimClientOption func(*PVolumeClaim)
+
+func PVolumeClaimSyncCheckerOption(checker initialSyncChecker) PVolumeClaimClientOption {
+	return func(p *PVolumeClaim) {
+		p.syncChecker = checker
+	}
+}
+
+type PVolumeClaim struct {
+	stopChan chan struct{}
+	stopped  bool
+
+	store *ObjStore
+
+	syncChecker initialSyncChecker
+
+	mu         sync.RWMutex
+	nsCount    map[string]int
+	totalCount int
+}
+
+func (p *PVolumeClaim) refresh() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	nsCount := make(map[string]int)
+	totalCount := 0
+
+	objsList := p.store.List()
+	for _, obj := range objsList {
+		pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+		if !ok {
+			continue
+		}
+		nsCount[pvc.Namespace]++
+		totalCount++
+	}
+
+	p.nsCount = nsCount
+	p.totalCount = totalCount
+}
+
+func (p *PVolumeClaim) GetNamespaceCount() map[string]int {
+	if p.store.GetResetRefreshStatus() {
+		p.refresh()
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	result := make(map[string]int)
+	for ns, count := range p.nsCount {
+		result[ns] = count
+	}
+	return result
+}
+
+func (p *PVolumeClaim) GetClaimCount() int {
+	if p.store.GetResetRefreshStatus() {
+		p.refresh()
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.totalCount
+}
+
+func newPVolumeClaimClient(clientSet kubernetes.Interface, logger *zap.Logger, options ...PVolumeClaimClientOption) (*PVolumeClaim, error) {
+	p := &PVolumeClaim{
+		stopChan: make(chan struct{}),
+		nsCount:  make(map[string]int),
+	}
+
+	for _, option := range options {
+		option(p)
+	}
+
+	ctx := context.Background()
+	if _, err := clientSet.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).List(ctx, metav1.ListOptions{}); err != nil {
+		return nil, fmt.Errorf("cannot list PVCs. err: %w", err)
+	}
+
+	// Create a store to hold PVC objects
+	p.store = NewObjStore(transformFuncPVolumeClaim, logger)
+	// Create a ListWatch that knows how to list and watch PVCs
+	lw := createPVolumeClaimListWatch(clientSet, metav1.NamespaceAll)
+	// Create a Reflector that watches PVCs and updates the store
+	reflector := cache.NewReflector(lw, &corev1.PersistentVolumeClaim{}, p.store, 0)
+	// Start the Reflector in a goroutine
+	go reflector.Run(p.stopChan)
+
+	if p.syncChecker != nil {
+		// Check the init sync for potential connection issue
+		p.syncChecker.Check(reflector, "PersistentVolumeClaim initial sync timeout")
+	}
+
+	return p, nil
+}
+
+func (p *PVolumeClaim) shutdown() {
+	close(p.stopChan)
+	p.stopped = true
+}
+
+func transformFuncPVolumeClaim(obj interface{}) (interface{}, error) {
+	pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		return nil, fmt.Errorf("input obj %v is not PersistentVolumeClaim type", obj)
+	}
+	return pvc, nil
+}
+
+func createPVolumeClaimListWatch(client kubernetes.Interface, ns string) cache.ListerWatcher {
+	ctx := context.Background()
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return client.CoreV1().PersistentVolumeClaims(ns).List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return client.CoreV1().PersistentVolumeClaims(ns).Watch(ctx, opts)
+		},
+	}
+}

--- a/internal/aws/k8s/k8sclient/pvc_test.go
+++ b/internal/aws/k8s/k8sclient/pvc_test.go
@@ -1,0 +1,141 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var pvcObjects = []runtime.Object{
+	&corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-1",
+			Namespace: "test-namespace",
+			UID:       "pvc-1-uid",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimBound,
+		},
+	},
+	&corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-2",
+			Namespace: "test-namespace",
+			UID:       "pvc-2-uid",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimBound,
+		},
+	},
+	&corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-3",
+			Namespace: "another-namespace",
+			UID:       "pvc-3-uid",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimBound,
+		},
+	},
+}
+
+func TestPVolumeClaimClient_NamespaceCount(t *testing.T) {
+	setOption := PVolumeClaimSyncCheckerOption(&mockReflectorSyncChecker{})
+
+	fakeClientSet := fake.NewSimpleClientset(pvcObjects...)
+	client, _ := newPVolumeClaimClient(fakeClientSet, zap.NewNop(), setOption)
+
+	pvcs := make([]any, len(pvcObjects))
+	for i := range pvcObjects {
+		pvcs[i] = pvcObjects[i]
+	}
+	assert.NoError(t, client.store.Replace(pvcs, ""))
+
+	expectedMap := map[string]int{
+		"test-namespace":    2,
+		"another-namespace": 1,
+	}
+	resultMap := client.GetNamespaceCount()
+	assert.Equal(t, expectedMap, resultMap)
+
+	client.shutdown()
+	assert.True(t, client.stopped)
+}
+
+func TestPVolumeClaimClient_TotalCount(t *testing.T) {
+	setOption := PVolumeClaimSyncCheckerOption(&mockReflectorSyncChecker{})
+
+	fakeClientSet := fake.NewSimpleClientset(pvcObjects...)
+	client, err := newPVolumeClaimClient(fakeClientSet, zap.NewNop(), setOption)
+	assert.NoError(t, err)
+
+	pvcs := make([]any, len(pvcObjects))
+	for i := range pvcObjects {
+		pvcs[i] = pvcObjects[i]
+	}
+	assert.NoError(t, client.store.Replace(pvcs, ""))
+
+	// Set the refreshed flag to true to trigger a refresh in TotalPVCCount
+	client.store.mu.Lock()
+	client.store.refreshed = true
+	client.store.mu.Unlock()
+
+	expectedCount := 3
+	actualCount := client.GetClaimCount()
+	assert.Equal(t, expectedCount, actualCount)
+
+	client.shutdown()
+	assert.True(t, client.stopped)
+}
+
+func TestTransformFuncPVolumeClaim(t *testing.T) {
+	info, err := transformFuncPVolumeClaim(nil)
+	assert.Nil(t, info)
+	assert.Error(t, err)
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "test-namespace",
+		},
+	}
+	result, err := transformFuncPVolumeClaim(pvc)
+	assert.NoError(t, err)
+	assert.Equal(t, pvc, result)
+}
+
+func TestNoOpPVolumeClaimClient(t *testing.T) {
+	client := &noOpPVolumeClaimClient{}
+
+	nsCount := client.GetNamespaceCount()
+	assert.Equal(t, map[string]int{}, nsCount)
+
+	totalCount := client.GetClaimCount()
+	assert.Equal(t, 0, totalCount)
+
+	// Should not panic
+	client.shutdown()
+}

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
@@ -57,8 +57,11 @@ type K8sClient interface {
 	GetDaemonSetClient() k8sclient.DaemonSetClient
 	GetStatefulSetClient() k8sclient.StatefulSetClient
 	GetReplicaSetClient() k8sclient.ReplicaSetClient
+	GetPVolumeClaimClient() k8sclient.PVolumeClaimClient
+	GetPVolumeClient() k8sclient.PVolumeClient
 	ShutdownNodeClient()
 	ShutdownPodClient()
+	ShutdownPVolumeClient()
 }
 
 // K8sAPIServer is a struct that produces metrics from kubernetes api server
@@ -136,6 +139,8 @@ func (k *K8sAPIServer) GetMetrics() []pmetric.Metrics {
 
 	if k.includeEnhancedMetrics {
 		result = append(result, k.getHyperPodResiliencyMetrics(clusterName, timestampNs)...)
+		result = append(result, k.getPVolumeClaimMetrics(clusterName, timestampNs)...)
+		result = append(result, k.getPVolumeMetrics(clusterName, timestampNs)...)
 	}
 
 	return result
@@ -145,6 +150,7 @@ func (k *K8sAPIServer) getClusterMetrics(clusterName, timestampNs string) pmetri
 	fields := map[string]any{
 		"cluster_failed_node_count": k.leaderElection.nodeClient.ClusterFailedNodeCount(),
 		"cluster_node_count":        k.leaderElection.nodeClient.ClusterNodeCount(),
+		// "cluster_" + ci.PVCount:     k.leaderElection.pvClient.TotalCount(),
 	}
 
 	namespaceMap := k.leaderElection.podClient.NamespaceToRunningPodNum()
@@ -169,9 +175,11 @@ func (k *K8sAPIServer) getClusterMetrics(clusterName, timestampNs string) pmetri
 
 func (k *K8sAPIServer) getNamespaceMetrics(clusterName, timestampNs string) []pmetric.Metrics {
 	var metrics []pmetric.Metrics
+	// pvClaimsByNamespace := k.leaderElection.pvcClient.CountByNamespace()
 	for namespace, podNum := range k.leaderElection.podClient.NamespaceToRunningPodNum() {
 		fields := map[string]any{
 			"namespace_number_of_running_pods": podNum,
+			// "namespace_" + ci.PVCCount:         pvClaimsByNamespace[namespace],
 		}
 		attributes := map[string]string{
 			ci.ClusterNameKey: clusterName,
@@ -481,6 +489,99 @@ func (k *K8sAPIServer) getHyperPodResiliencyMetrics(clusterName, timestampNs str
 				metrics = append(metrics, md)
 			}
 		}
+	}
+	return metrics
+}
+
+func (k *K8sAPIServer) getPVolumeClaimMetrics(clusterName, timestampNs string) []pmetric.Metrics {
+	var metrics []pmetric.Metrics
+
+	// Check if pvcClient is initialized
+	if k.leaderElection.pVolumeClaimClient == nil {
+		k.logger.Debug("PVC client is not initialized, skipping PVC metrics")
+		return metrics
+	}
+
+	// Get namespace-level counts
+	nameSpaceCounts := k.leaderElection.pVolumeClaimClient.GetNamespaceCount()
+	// If no PVCs are found, return empty metrics
+	if len(nameSpaceCounts) == 0 {
+		k.logger.Debug("No PVCs found, skipping PVC metrics")
+		return metrics
+	}
+	// Get total PVC count
+	clusterCount := k.leaderElection.pVolumeClaimClient.GetClaimCount()
+
+	// Create name-space level metrics
+	for namespace, count := range nameSpaceCounts {
+		fields := map[string]any{
+			ci.PVCCount: count,
+		}
+		attributes := map[string]string{
+			ci.ClusterNameKey: clusterName,
+			ci.MetricType:     ci.TypeClusterNamespacePVC,
+			ci.Timestamp:      timestampNs,
+			ci.K8sNamespace:   namespace,
+			ci.Version:        "0",
+		}
+		if k.nodeName != "" {
+			attributes[ci.NodeNameKey] = k.nodeName
+		}
+		attributes[ci.SourcesKey] = "[\"apiserver\"]"
+		md := ci.ConvertToOTLPMetrics(fields, attributes, k.logger)
+		metrics = append(metrics, md)
+	}
+
+	// Create cluster-level metrics
+	if clusterCount > 0 {
+		fields := map[string]any{
+			ci.PVCCount: clusterCount,
+		}
+		attributes := map[string]string{
+			ci.ClusterNameKey: clusterName,
+			ci.MetricType:     ci.TypeClusterPVC,
+			ci.Timestamp:      timestampNs,
+			ci.Version:        "0",
+		}
+		if k.nodeName != "" {
+			attributes["NodeName"] = k.nodeName
+		}
+		attributes[ci.SourcesKey] = "[\"apiserver\"]"
+		md := ci.ConvertToOTLPMetrics(fields, attributes, k.logger)
+		metrics = append(metrics, md)
+	}
+	return metrics
+}
+
+func (k *K8sAPIServer) getPVolumeMetrics(clusterName, timestampNs string) []pmetric.Metrics {
+	var metrics []pmetric.Metrics
+
+	// Check if pvClient is initialized
+	if k.leaderElection.pVolumeClient == nil {
+		k.logger.Debug("PV client is not initialized, skipping PV metrics")
+		return metrics
+	}
+
+	// Get total PV count
+	clusterCount := k.leaderElection.pVolumeClient.GetVolumeCount()
+
+	// Create cluster-level metrics
+	if clusterCount > 0 {
+		fields := map[string]any{
+			ci.PVCount: clusterCount,
+		}
+		attributes := map[string]string{
+			ci.ClusterNameKey: clusterName,
+			ci.MetricType:     ci.TypeClusterPV,
+			ci.Timestamp:      timestampNs,
+			ci.Version:        "0",
+		}
+		if k.nodeName != "" {
+			attributes["NodeName"] = k.nodeName
+		}
+		attributes[ci.SourcesKey] = "[\"apiserver\"]"
+		md := ci.ConvertToOTLPMetrics(fields, attributes, k.logger)
+		metrics = append(metrics, md)
 	}
 	return metrics
 }

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
@@ -66,6 +66,14 @@ func (m *mockK8sClient) GetReplicaSetClient() k8sclient.ReplicaSetClient {
 	return mockClient
 }
 
+func (m *mockK8sClient) GetPVolumeClaimClient() k8sclient.PVolumeClaimClient {
+	return mockClient
+}
+
+func (m *mockK8sClient) GetPVolumeClient() k8sclient.PVolumeClient {
+	return mockClient
+}
+
 func (m *mockK8sClient) ShutdownNodeClient() {
 }
 
@@ -84,11 +92,18 @@ func (m *mockK8sClient) ShutdownStatefulSetClient() {
 func (m *mockK8sClient) ShutdownReplicaSetClient() {
 }
 
+func (m *mockK8sClient) ShutdownPVolumeClaimClient() {
+}
+
+func (m *mockK8sClient) ShutdownPVolumeClient() {
+}
+
 type MockClient struct {
 	k8sclient.PodClient
 	k8sclient.NodeClient
 	k8sclient.EpClient
-
+	k8sclient.PVolumeClaimClient
+	k8sclient.PVolumeClient
 	mock.Mock
 }
 
@@ -164,6 +179,18 @@ func (client *MockClient) ServiceToPodNum() map[k8sclient.Service]int {
 func (client *MockClient) PodKeyToServiceNames() map[string][]string {
 	args := client.Called()
 	return args.Get(0).(map[string][]string)
+}
+
+// k8sclient.PVolumeClaimClient
+func (client *MockClient) GetNamespaceCount() map[string]int {
+	args := client.Called()
+	return args.Get(0).(map[string]int)
+}
+
+// k8sclient.PVolumeClaimClient
+func (client *MockClient) GetClaimCount() int {
+	args := client.Called()
+	return args.Get(0).(int)
 }
 
 type mockEventBroadcaster struct{}
@@ -337,18 +364,26 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 		},
 	})
 
+	mockClient.On("GetNamespaceCount").Return(map[string]int{
+		"default":     3,
+		"kube-system": 2,
+	})
+	mockClient.On("GetClaimCount").Return(5)
+	mockClient.On("GetVolumeCount").Return(5)
+
 	leaderElection := &LeaderElection{
-		k8sClient:         &mockK8sClient{},
-		nodeClient:        mockClient,
-		epClient:          mockClient,
-		podClient:         mockClient,
-		deploymentClient:  mockClient,
-		daemonSetClient:   mockClient,
-		statefulSetClient: mockClient,
-		replicaSetClient:  mockClient,
-		leading:           true,
-		broadcaster:       &mockEventBroadcaster{},
-		isLeadingC:        make(chan struct{}),
+		k8sClient:          &mockK8sClient{},
+		nodeClient:         mockClient,
+		epClient:           mockClient,
+		podClient:          mockClient,
+		deploymentClient:   mockClient,
+		daemonSetClient:    mockClient,
+		statefulSetClient:  mockClient,
+		replicaSetClient:   mockClient,
+		pVolumeClaimClient: mockClient,
+		leading:            true,
+		broadcaster:        &mockEventBroadcaster{},
+		isLeadingC:         make(chan struct{}),
 	}
 
 	t.Setenv("HOST_NAME", hostName)
@@ -378,7 +413,6 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 			assertMetricValueEqual(t, metric, "cluster_failed_node_count", int64(1))
 			assertMetricValueEqual(t, metric, "cluster_node_count", int64(1))
 			assertMetricValueEqual(t, metric, "cluster_number_of_running_pods", int64(2))
-
 		case ci.TypeClusterService:
 			assertMetricValueEqual(t, metric, "service_number_of_running_pods", int64(1))
 			assert.Contains(t, []string{"service1", "service2"}, getStringAttrVal(metric, ci.TypeService))
@@ -435,10 +469,26 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 			assertMetricValueEqual(t, metric, "hyperpod_node_health_status_schedulable", int64(1))
 			assertMetricValueEqual(t, metric, "hyperpod_node_health_status_unschedulable", int64(0))
 			assertMetricValueEqual(t, metric, "hyperpod_node_health_status_unschedulable_pending_replacement", int64(0))
+		case ci.TypeClusterPVC:
+			assertMetricValueEqual(t, metric, ci.PVCCount, int64(5))
+			assert.Equal(t, "ClusterPVC", getStringAttrVal(metric, ci.MetricType))
+			assert.Equal(t, "cluster-name", getStringAttrVal(metric, ci.ClusterNameKey))
+		case ci.TypeClusterPV:
+			assertMetricValueEqual(t, metric, ci.PVCount, int64(5))
+			assert.Equal(t, "ClusterPV", getStringAttrVal(metric, ci.MetricType))
+		case ci.TypeClusterNamespacePVC:
+			assert.Equal(t, "ClusterNamespacePVC", getStringAttrVal(metric, ci.MetricType))
+			switch getStringAttrVal(metric, ci.K8sNamespace) {
+			case "default":
+				assertMetricValueEqual(t, metric, ci.PVCCount, int64(3))
+			case "kube-system":
+				assertMetricValueEqual(t, metric, ci.PVCCount, int64(2))
+			default:
+				assert.Fail(t, "Unexpected namespace in ClusterNamespacePVC metric: "+getStringAttrVal(metric, ci.K8sNamespace))
+			}
 		default:
 			assert.Fail(t, "Unexpected metric type: "+metricType)
 		}
 	}
-
 	require.NoError(t, k8sAPIServer.Shutdown())
 }

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/leaderelection.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/leaderelection.go
@@ -34,14 +34,16 @@ type LeaderElection struct {
 	leaderLockName               string
 	leaderLockUsingConfigMapOnly bool
 
-	k8sClient         K8sClient // *k8sclient.K8sClient
-	epClient          k8sclient.EpClient
-	nodeClient        k8sclient.NodeClient
-	podClient         k8sclient.PodClient
-	deploymentClient  k8sclient.DeploymentClient
-	daemonSetClient   k8sclient.DaemonSetClient
-	statefulSetClient k8sclient.StatefulSetClient
-	replicaSetClient  k8sclient.ReplicaSetClient
+	k8sClient          K8sClient // *k8sclient.K8sClient
+	epClient           k8sclient.EpClient
+	nodeClient         k8sclient.NodeClient
+	podClient          k8sclient.PodClient
+	deploymentClient   k8sclient.DeploymentClient
+	daemonSetClient    k8sclient.DaemonSetClient
+	statefulSetClient  k8sclient.StatefulSetClient
+	replicaSetClient   k8sclient.ReplicaSetClient
+	pVolumeClaimClient k8sclient.PVolumeClaimClient
+	pVolumeClient      k8sclient.PVolumeClient
 
 	// the following can be set to mocks in testing
 	broadcaster eventBroadcaster
@@ -180,6 +182,8 @@ func (le *LeaderElection) startLeaderElection(ctx context.Context, lock resource
 					le.daemonSetClient = le.k8sClient.GetDaemonSetClient()
 					le.statefulSetClient = le.k8sClient.GetStatefulSetClient()
 					le.replicaSetClient = le.k8sClient.GetReplicaSetClient()
+					le.pVolumeClaimClient = le.k8sClient.GetPVolumeClaimClient()
+					// le.pvClient = le.k8sClient.GetPVClient()
 					le.mu.Unlock()
 
 					if le.isLeadingC != nil {

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/leaderelection.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/leaderelection.go
@@ -183,7 +183,7 @@ func (le *LeaderElection) startLeaderElection(ctx context.Context, lock resource
 					le.statefulSetClient = le.k8sClient.GetStatefulSetClient()
 					le.replicaSetClient = le.k8sClient.GetReplicaSetClient()
 					le.pVolumeClaimClient = le.k8sClient.GetPVolumeClaimClient()
-					// le.pvClient = le.k8sClient.GetPVClient()
+					le.pVolumeClient = le.k8sClient.GetPVolumeClient()
 					le.mu.Unlock()
 
 					if le.isLeadingC != nil {


### PR DESCRIPTION
#### Description

Implemented metrics collection for **PersistentVolumes** and **PersistentVolumeClaims** in the AWS Container Insights receiver. Integrated these metrics into the `k8sapiserver` component, and extended it with the necessary logic to support the new data.  

#### Testing

Additional unit tests were written for:
- `pv.go` and `pvc.go` logic
- `k8sapiserver` to validate integration behavior
