### PR TITLE
Add new Tensor Core and GPU capacity metrics

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -141,13 +141,12 @@ const (
 	EfaRxDropped          = "rx_dropped"
 	EfaTxBytes            = "tx_bytes"
 
-	GpuLimit                 = "gpu_limit"
-	GpuUsageTotal            = "gpu_usage_total"
-	GpuRequest               = "gpu_request"
-	GpuReservedCapacity      = "gpu_reserved_capacity"
-	GpuUnreservedCapacity    = "gpu_unreserved_capacity"
-	GpuAvailableCapacity     = "gpu_available_capacity"
-	GpuTensorCoreUtilization = "gpu_tensor_core_utilization"
+	GpuLimit              = "gpu_limit"
+	GpuUsageTotal         = "gpu_usage_total"
+	GpuRequest            = "gpu_request"
+	GpuReservedCapacity   = "gpu_reserved_capacity"
+	GpuUnreservedCapacity = "gpu_unreserved_capacity"
+	GpuAvailableCapacity  = "gpu_available_capacity"
 
 	NeuroncoreLimit              = "neuroncore_limit"
 	NeuroncoreUsageTotal         = "neuroncore_usage_total"
@@ -372,13 +371,12 @@ func init() {
 		EfaRxDropped:          UnitCountPerSec,
 		EfaTxBytes:            UnitBytesPerSec,
 
-		GpuLimit:                 UnitCount,
-		GpuUsageTotal:            UnitCount,
-		GpuRequest:               UnitCount,
-		GpuReservedCapacity:      UnitPercent,
-		GpuUnreservedCapacity:    UnitPercent,
-		GpuAvailableCapacity:     UnitCount,
-		GpuTensorCoreUtilization: UnitPercent,
+		GpuLimit:              UnitCount,
+		GpuUsageTotal:         UnitCount,
+		GpuRequest:            UnitCount,
+		GpuReservedCapacity:   UnitPercent,
+		GpuUnreservedCapacity: UnitPercent,
+		GpuAvailableCapacity:  UnitCount,
 
 		NeuroncoreLimit:              UnitCount,
 		NeuroncoreUsageTotal:         UnitCount,

--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -141,10 +141,13 @@ const (
 	EfaRxDropped          = "rx_dropped"
 	EfaTxBytes            = "tx_bytes"
 
-	GpuLimit            = "gpu_limit"
-	GpuUsageTotal       = "gpu_usage_total"
-	GpuRequest          = "gpu_request"
-	GpuReservedCapacity = "gpu_reserved_capacity"
+	GpuLimit                 = "gpu_limit"
+	GpuUsageTotal            = "gpu_usage_total"
+	GpuRequest               = "gpu_request"
+	GpuReservedCapacity      = "gpu_reserved_capacity"
+	GpuUnreservedCapacity    = "gpu_unreserved_capacity"
+	GpuAvailableCapacity     = "gpu_available_capacity"
+	GpuTensorCoreUtilization = "gpu_tensor_core_utilization"
 
 	NeuroncoreLimit              = "neuroncore_limit"
 	NeuroncoreUsageTotal         = "neuroncore_usage_total"
@@ -369,10 +372,13 @@ func init() {
 		EfaRxDropped:          UnitCountPerSec,
 		EfaTxBytes:            UnitBytesPerSec,
 
-		GpuLimit:            UnitCount,
-		GpuUsageTotal:       UnitCount,
-		GpuRequest:          UnitCount,
-		GpuReservedCapacity: UnitPercent,
+		GpuLimit:                 UnitCount,
+		GpuUsageTotal:            UnitCount,
+		GpuRequest:               UnitCount,
+		GpuReservedCapacity:      UnitPercent,
+		GpuUnreservedCapacity:    UnitPercent,
+		GpuAvailableCapacity:     UnitCount,
+		GpuTensorCoreUtilization: UnitPercent,
 
 		NeuroncoreLimit:              UnitCount,
 		NeuroncoreUsageTotal:         UnitCount,

--- a/internal/aws/containerinsight/utils_test.go
+++ b/internal/aws/containerinsight/utils_test.go
@@ -441,6 +441,8 @@ func TestConvertToOTLPMetricsForNodeMetrics(t *testing.T) {
 		"node_gpu_limit":                      int32(7),
 		"node_gpu_usage_total":                int32(7),
 		"node_gpu_reserved_capacity":          3.0093851356081194,
+		"node_gpu_unreserved_capacity":        2.9303736689169724,
+		"node_gpu_available_capacity":         uint64(35),
 	}
 	expectedUnits = map[string]string{
 		"node_cpu_limit":                      "",
@@ -481,6 +483,8 @@ func TestConvertToOTLPMetricsForNodeMetrics(t *testing.T) {
 		"node_gpu_limit":                      UnitCount,
 		"node_gpu_usage_total":                UnitCount,
 		"node_gpu_reserved_capacity":          UnitPercent,
+		"node_gpu_unreserved_capacity":        UnitPercent,
+		"node_gpu_available_capacity":         UnitCount,
 	}
 	tags = map[string]string{
 		"AutoScalingGroupName": "eks-a6bb9db9-267c-401c-db55-df8ef645b06f",

--- a/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_test.go
@@ -33,6 +33,9 @@ DCGM_FI_DEV_GPU_TEMP{gpu="0",UUID="uuid",device="nvidia0",modelName="NVIDIA A10G
 # HELP DCGM_FI_DEV_GPU_UTIL GPU utilization (in %).
 # TYPE DCGM_FI_DEV_GPU_UTIL gauge
 DCGM_FI_DEV_GPU_UTIL{gpu="0",UUID="uuid",device="nvidia0",modelName="NVIDIA A10G",Hostname="hostname",DCGM_FI_DRIVER_VERSION="470.182.03",container="main",namespace="kube-system",pod="fullname-hash"} 100
+# HELP DCGM_FI_PROF_PIPE_TENSOR_ACTIVE Tensor Core utilization (in %).
+# TYPE DCGM_FI_PROF_PIPE_TENSOR_ACTIVE gauge
+DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{gpu="0",UUID="uuid",device="nvidia0",modelName="NVIDIA A10G",Hostname="hostname",DCGM_FI_DRIVER_VERSION="470.182.03",container="main",namespace="kube-system",pod="fullname-hash"} 85.5
 `
 
 const (
@@ -118,6 +121,20 @@ func TestNewDcgmScraperEndToEnd(t *testing.T) {
 		},
 		"DCGM_FI_DEV_GPU_UTIL": {
 			value: 100,
+			labels: map[string]string{
+				ci.NodeNameKey:      "hostname",
+				ci.K8sNamespace:     "kube-system",
+				ci.ClusterNameKey:   dummyClusterName,
+				ci.InstanceID:       dummyInstanceID,
+				ci.InstanceType:     dummyInstanceType,
+				ci.FullPodNameKey:   "fullname-hash",
+				ci.K8sPodNameKey:    "fullname-hash",
+				ci.ContainerNamekey: "main",
+				ci.GpuDevice:        "nvidia0",
+			},
+		},
+		"DCGM_FI_PROF_PIPE_TENSOR_ACTIVE": {
+			value: 85.5,
 			labels: map[string]string{
 				ci.NodeNameKey:      "hostname",
 				ci.K8sNamespace:     "kube-system",

--- a/receiver/awscontainerinsightreceiver/internal/gpu/metric_unit.go
+++ b/receiver/awscontainerinsightreceiver/internal/gpu/metric_unit.go
@@ -4,19 +4,21 @@
 package gpu // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/gpu"
 
 const (
-	gpuUtil        = "DCGM_FI_DEV_GPU_UTIL"
-	gpuMemUtil     = "DCGM_FI_DEV_FB_USED_PERCENT"
-	gpuMemUsed     = "DCGM_FI_DEV_FB_USED"
-	gpuMemTotal    = "DCGM_FI_DEV_FB_TOTAL"
-	gpuTemperature = "DCGM_FI_DEV_GPU_TEMP"
-	gpuPowerDraw   = "DCGM_FI_DEV_POWER_USAGE"
+	gpuUtil           = "DCGM_FI_DEV_GPU_UTIL"
+	gpuMemUtil        = "DCGM_FI_DEV_FB_USED_PERCENT"
+	gpuMemUsed        = "DCGM_FI_DEV_FB_USED"
+	gpuMemTotal       = "DCGM_FI_DEV_FB_TOTAL"
+	gpuTemperature    = "DCGM_FI_DEV_GPU_TEMP"
+	gpuPowerDraw      = "DCGM_FI_DEV_POWER_USAGE"
+	gpuTensorCoreUtil = "DCGM_FI_PROF_PIPE_TENSOR_ACTIVE"
 )
 
 var MetricToUnit = map[string]string{
-	gpuUtil:        "Percent",
-	gpuMemUtil:     "Percent",
-	gpuMemUsed:     "Bytes",
-	gpuMemTotal:    "Bytes",
-	gpuTemperature: "None",
-	gpuPowerDraw:   "None",
+	gpuUtil:           "Percent",
+	gpuMemUtil:        "Percent",
+	gpuMemUsed:        "Bytes",
+	gpuMemTotal:       "Bytes",
+	gpuTemperature:    "None",
+	gpuPowerDraw:      "None",
+	gpuTensorCoreUtil: "Percent",
 }

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -420,7 +420,12 @@ func (p *PodStore) decorateNode(metric CIMetric) {
 				metric.AddField(ci.MetricName(ci.TypeNode, ci.GpuRequest), nodeStats.gpuReq)
 				metric.AddField(ci.MetricName(ci.TypeNode, ci.GpuLimit), nodeStatusCapacityGPUs)
 				metric.AddField(ci.MetricName(ci.TypeNode, ci.GpuUsageTotal), nodeStats.gpuUsageTotal)
-				metric.AddField(ci.MetricName(ci.TypeNode, ci.GpuReservedCapacity), float64(nodeStats.gpuReq)/float64(nodeStatusCapacityGPUs)*100)
+
+				reservedCapacity := float64(nodeStats.gpuReq) / float64(nodeStatusCapacityGPUs) * 100
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.GpuReservedCapacity), reservedCapacity)
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.GpuUnreservedCapacity), 100.0-reservedCapacity)
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.GpuAvailableCapacity), nodeStatusCapacityGPUs-nodeStats.gpuReq)
+			}
 			}
 
 			if nodeStatusCapacityNeuroncore, ok := p.nodeInfo.getNodeStatusCapacityNeuronCores(); ok && nodeStatusCapacityNeuroncore != 0 {
@@ -450,7 +455,12 @@ func (p *PodStore) decorateGPU(metric CIMetric, pod *corev1.Pod) {
 			}
 			metric.AddField(ci.MetricName(ci.TypePod, ci.GpuUsageTotal), podGpuUsageTotal)
 			if nodeStatusCapacityGPUs, ok := p.nodeInfo.getNodeStatusCapacityGPUs(); ok && nodeStatusCapacityGPUs != 0 {
-				metric.AddField(ci.MetricName(ci.TypePod, ci.GpuReservedCapacity), float64(podGpuLimit)/float64(nodeStatusCapacityGPUs)*100)
+				reservedCapacity := float64(podGpuLimit) / float64(nodeStatusCapacityGPUs) * 100
+				metric.AddField(ci.MetricName(ci.TypePod, ci.GpuReservedCapacity), reservedCapacity)
+			}
+		}
+	}
+}
 			}
 		}
 	}

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -426,7 +426,6 @@ func (p *PodStore) decorateNode(metric CIMetric) {
 				metric.AddField(ci.MetricName(ci.TypeNode, ci.GpuUnreservedCapacity), 100.0-reservedCapacity)
 				metric.AddField(ci.MetricName(ci.TypeNode, ci.GpuAvailableCapacity), nodeStatusCapacityGPUs-nodeStats.gpuReq)
 			}
-			}
 
 			if nodeStatusCapacityNeuroncore, ok := p.nodeInfo.getNodeStatusCapacityNeuronCores(); ok && nodeStatusCapacityNeuroncore != 0 {
 				metric.AddField(ci.MetricName(ci.TypeNode, ci.NeuroncoreRequest), nodeStats.neuroncoreReq)
@@ -457,10 +456,6 @@ func (p *PodStore) decorateGPU(metric CIMetric, pod *corev1.Pod) {
 			if nodeStatusCapacityGPUs, ok := p.nodeInfo.getNodeStatusCapacityGPUs(); ok && nodeStatusCapacityGPUs != 0 {
 				reservedCapacity := float64(podGpuLimit) / float64(nodeStatusCapacityGPUs) * 100
 				metric.AddField(ci.MetricName(ci.TypePod, ci.GpuReservedCapacity), reservedCapacity)
-			}
-		}
-	}
-}
 			}
 		}
 	}

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -1099,6 +1099,8 @@ func TestPodStore_decorateNode(t *testing.T) {
 	assert.Equal(t, uint64(20), metric.GetField("node_gpu_limit").(uint64))
 	assert.Equal(t, uint64(1), metric.GetField("node_gpu_usage_total").(uint64))
 	assert.Equal(t, float64(5), metric.GetField("node_gpu_reserved_capacity").(float64))
+	assert.Equal(t, float64(95), metric.GetField("node_gpu_unreserved_capacity").(float64))
+	assert.Equal(t, uint64(19), metric.GetField("node_gpu_available_capacity").(uint64))
 
 	assert.Equal(t, uint64(0), metric.GetField("node_neuroncore_request").(uint64))
 	assert.Equal(t, uint64(32), metric.GetField("node_neuroncore_limit").(uint64))


### PR DESCRIPTION
## Description
This PR is enhancing metric offering by adding new tensor core utilization and gpu available capacity metrics.

#### Changes
* Add support for DCGM_FI_PROF_PIPE_TENSOR_ACTIVE metric collection
* Add gpu available capacity and unreserved capacity metrics which track how many gpu cores are still available and the ratio of unused cores to the total amount of cores on the node 
* Add tests for these new metrics

## Example Metric Output

Tensor Core:
<img width="1431" height="467" alt="Screenshot 2025-08-07 at 18 17 02" src="https://github.com/user-attachments/assets/350d1515-19c6-49b3-a6cc-9e2f710e2d55" />

GPU:
<img width="1431" height="235" alt="Screenshot 2025-08-07 at 18 20 42" src="https://github.com/user-attachments/assets/5bbd0f36-0e87-4ecb-8370-97ded85d6cab" />
<img width="1431" height="235" alt="Screenshot 2025-08-07 at 18 21 00" src="https://github.com/user-attachments/assets/9fb19b04-6927-4118-b002-3827bf471739" />


### EMF Output

```
{
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName"
                ],
                [
                    "ClusterName",
                    "InstanceId",
                    "NodeName"
                ],
                [
                    "ClusterName",
                    "GpuDevice",
                    "InstanceId",
                    "InstanceType",
                    "NodeName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "node_gpu_temperature",
                    "Unit": "None",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_gpu_power_draw",
                    "Unit": "None",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_gpu_tensor_core_utilization",
                    "Unit": "Percent",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_gpu_utilization",
                    "Unit": "Percent",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_gpu_memory_utilization",
                    "Unit": "Percent",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_gpu_memory_used",
                    "Unit": "Bytes",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_gpu_memory_total",
                    "Unit": "Bytes",
                    "StorageResolution": 60
                }
            ]
        }
    ],
    "ClusterName": "tensorland",
    "GpuDevice": "nvidia0",
    "InstanceId": "i-069eee733383e26ce",
    "InstanceType": "g5.xlarge",
    "NodeName": "ip-192-168-38-45.us-west-2.compute.internal",
    "Sources": [
        "dcgm",
        "pod",
        "calculated"
    ],
    "Timestamp": "1753276216454",
    "Type": "NodeGPU",
    "Version": "0",
    "kubernetes": {
        "host": "ip-192-168-38-45.us-west-2.compute.internal"
    },
    "node_gpu_memory_total": 24146608128,
    "node_gpu_memory_used": 944766976,
    "node_gpu_memory_utilization": 3.949,
    "node_gpu_power_draw": 96.021,
    "node_gpu_temperature": 37,
    "node_gpu_tensor_core_utilization": 7.0931999999999995,
    "node_gpu_utilization": 20
}
```


## Related PRs
* Agent: https://github.com/aws/amazon-cloudwatch-agent/pull/1814
* Observability Helm Charts: https://github.com/aws-observability/helm-charts/pull/235