### PR TITLE
[awscontainerinsightreceiver] Add PersistentVolume and PersistentVolumeClaim metrics

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -35,6 +35,8 @@ const (
 	OperatingSystem         = "OperatingSystem"
 	OperatingSystemWindows  = "windows"
 
+	PersistentVolumeClaimName = "PersistentVolumeClaimName"
+
 	// The following constants are used for metric name construction
 	CPUTotal                         = "cpu_usage_total"
 	CPUUser                          = "cpu_usage_user"
@@ -115,9 +117,12 @@ const (
 	StatusUnknown                                          = "status_unknown"
 	StatusReady                                            = "status_ready"
 	StatusScheduled                                        = "status_scheduled"
+	StatusBound                                            = "status_bound"
+	StatusLost                                             = "status_lost"
 	ReplicasDesired                                        = "replicas_desired"
 	ReplicasReady                                          = "replicas_ready"
 
+	Count                 = "count"
 	RunningPodCount       = "number_of_running_pods"
 	RunningContainerCount = "number_of_running_containers"
 	ContainerCount        = "number_of_containers"
@@ -168,7 +173,6 @@ const (
 	HyperPodUnschedulable                   = "unschedulable"
 
 	// kueue metrics
-
 	KueuePendingWorkloads          = "kueue_pending_workloads"
 	KueueEvictedWorkloadsTotal     = "kueue_evicted_workloads_total"
 	KueueAdmittedActiveWorkloads   = "kueue_admitted_active_workloads"
@@ -200,6 +204,10 @@ const (
 
 	// kueue metric types
 	TypeClusterQueue = "ClusterQueue"
+
+	// PVC and PV metric types
+	TypePersistentVolumeClaim = "PersistentVolumeClaim"
+	TypePersistentVolume      = "PersistentVolume"
 
 	// Special type for pause container
 	// because containerd does not set container name pause container name to POD like docker does.
@@ -350,10 +358,13 @@ func init() {
 		StatusUnknown:                                          UnitCount,
 		StatusReady:                                            UnitCount,
 		StatusScheduled:                                        UnitCount,
+		StatusBound:                                            UnitCount,
+		StatusLost:                                             UnitCount,
 
 		// cluster metrics
 		NodeCount:       UnitCount,
 		FailedNodeCount: UnitCount,
+		Count:           UnitCount,
 
 		// kueue metrics
 		KueuePendingWorkloads:          UnitCount,

--- a/internal/aws/containerinsight/utils.go
+++ b/internal/aws/containerinsight/utils.go
@@ -120,6 +120,8 @@ func getPrefixByMetricType(mType string) string {
 	daemonSet := "daemonset_"
 	statefulSet := "statefulset_"
 	replicaSet := "replicaset_"
+	persistentVolume := "persistent_volume_"
+	persistentVolumeClaim := "persistent_volume_claim_"
 
 	switch mType {
 	case TypeInstance:
@@ -172,6 +174,10 @@ func getPrefixByMetricType(mType string) string {
 		prefix = replicaSet
 	case TypeHyperPodNode:
 		prefix = hyperPodNodeHealthStatus
+	case TypePersistentVolumeClaim:
+		prefix = persistentVolumeClaim
+	case TypePersistentVolume:
+		prefix = persistentVolume
 	default:
 		log.Printf("E! Unexpected MetricType: %s", mType)
 	}

--- a/internal/aws/k8s/k8sclient/persistent_volume.go
+++ b/internal/aws/k8s/k8sclient/persistent_volume.go
@@ -1,0 +1,148 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+type PersistentVolumeClient interface {
+	GetPersistentVolumeMetrics() *PersistentVolumeMetrics
+}
+
+type PersistentVolumeMetrics struct {
+	ClusterCount int
+}
+
+type noOpPersistentVolumeClient struct{}
+
+func (p *noOpPersistentVolumeClient) GetPersistentVolumeMetrics() *PersistentVolumeMetrics {
+	return &PersistentVolumeMetrics{
+		ClusterCount: 0,
+	}
+}
+
+func (p *noOpPersistentVolumeClient) shutdown() {
+}
+
+type PersistentVolumeClientOption func(*PersistentVolume)
+
+func PersistentVolumeSyncCheckerOption(checker initialSyncChecker) PersistentVolumeClientOption {
+	return func(p *PersistentVolume) {
+		p.syncChecker = checker
+	}
+}
+
+type PersistentVolume struct {
+	stopChan chan struct{}
+	stopped  bool
+
+	store *ObjStore
+
+	syncChecker initialSyncChecker
+
+	mu      sync.RWMutex
+	metrics *PersistentVolumeMetrics
+}
+
+func (p *PersistentVolume) refresh() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	metrics := &PersistentVolumeMetrics{
+		ClusterCount: 0,
+	}
+
+	objsList := p.store.List()
+	for _, obj := range objsList {
+		_, ok := obj.(*PersistentVolumeInfo)
+		if !ok {
+			continue
+		}
+		metrics.ClusterCount++
+	}
+	p.metrics = metrics
+}
+
+func (p *PersistentVolume) GetPersistentVolumeMetrics() *PersistentVolumeMetrics {
+	if p.store.GetResetRefreshStatus() {
+		p.refresh()
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.metrics
+}
+
+func newPersistentVolumeClient(clientSet kubernetes.Interface, logger *zap.Logger, options ...PersistentVolumeClientOption) (*PersistentVolume, error) {
+	p := &PersistentVolume{
+		stopChan: make(chan struct{}),
+		metrics: &PersistentVolumeMetrics{
+			ClusterCount: 0,
+		},
+	}
+
+	for _, option := range options {
+		option(p)
+	}
+
+	ctx := context.Background()
+	if _, err := clientSet.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{}); err != nil {
+		return nil, fmt.Errorf("cannot list PersistentVolumes. err: %w", err)
+	}
+
+	// Create a store to hold PersistentVolume objects
+	p.store = NewObjStore(transformFuncPersistentVolume, logger)
+	// Create a ListWatch that knows how to list and watch PersistentVolumes
+	lw := createPersistentVolumeListWatch(clientSet)
+	// Create a Reflector that watches PersistentVolumes and updates the store
+	reflector := cache.NewReflector(lw, &corev1.PersistentVolume{}, p.store, 0)
+	// Start the Reflector in a goroutine
+	go reflector.Run(p.stopChan)
+
+	if p.syncChecker != nil {
+		// Check the init sync for potential connection issue
+		p.syncChecker.Check(reflector, "PersistentVolume initial sync timeout")
+	}
+
+	return p, nil
+}
+
+func (p *PersistentVolume) shutdown() {
+	close(p.stopChan)
+	p.stopped = true
+}
+
+func transformFuncPersistentVolume(obj any) (any, error) {
+	pv, ok := obj.(*corev1.PersistentVolume)
+	if !ok {
+		return nil, fmt.Errorf("input obj %v is not PersistentVolume type", obj)
+	}
+
+	info := &PersistentVolumeInfo{
+		Name: pv.Name,
+	}
+	return info, nil
+}
+
+func createPersistentVolumeListWatch(client kubernetes.Interface) cache.ListerWatcher {
+	ctx := context.Background()
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return client.CoreV1().PersistentVolumes().List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return client.CoreV1().PersistentVolumes().Watch(ctx, opts)
+		},
+	}
+}

--- a/internal/aws/k8s/k8sclient/persistent_volume_claim.go
+++ b/internal/aws/k8s/k8sclient/persistent_volume_claim.go
@@ -1,0 +1,157 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+// PersistentVolumeClaimMetrics holds all the metrics for PVCs
+type PersistentVolumeClaimMetrics struct {
+	PersistentVolumeClaimPhases map[string]corev1.PersistentVolumeClaimPhase // Individual PVC metrics
+}
+
+type PersistentVolumeClaimClient interface {
+	GetPersistentVolumeClaimMetrics() *PersistentVolumeClaimMetrics
+}
+
+type noOpPersistentVolumeClaimClient struct{}
+
+func (p *noOpPersistentVolumeClaimClient) GetPersistentVolumeClaimMetrics() *PersistentVolumeClaimMetrics {
+	return &PersistentVolumeClaimMetrics{
+		PersistentVolumeClaimPhases: make(map[string]corev1.PersistentVolumeClaimPhase),
+	}
+}
+
+func (p *noOpPersistentVolumeClaimClient) shutdown() {
+}
+
+type PersistentVolumeClaimClientOption func(*PersistentVolumeClaim)
+
+func PersistentVolumeClaimSyncCheckerOption(checker initialSyncChecker) PersistentVolumeClaimClientOption {
+	return func(p *PersistentVolumeClaim) {
+		p.syncChecker = checker
+	}
+}
+
+type PersistentVolumeClaim struct {
+	stopChan chan struct{}
+	stopped  bool
+
+	store *ObjStore
+
+	syncChecker initialSyncChecker
+
+	mu      sync.RWMutex
+	metrics *PersistentVolumeClaimMetrics
+}
+
+func (p *PersistentVolumeClaim) refresh() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	metrics := &PersistentVolumeClaimMetrics{
+		PersistentVolumeClaimPhases: make(map[string]corev1.PersistentVolumeClaimPhase),
+	}
+
+	objsList := p.store.List()
+	for _, obj := range objsList {
+		pvcInfo, ok := obj.(*PersistentVolumeClaimInfo)
+		if !ok {
+			continue
+		}
+
+		pvcKey := fmt.Sprintf("%s/%s", pvcInfo.Namespace, pvcInfo.Name)
+		phase := pvcInfo.Status.Phase
+		metrics.PersistentVolumeClaimPhases[pvcKey] = phase
+	}
+	p.metrics = metrics
+}
+
+func (p *PersistentVolumeClaim) GetPersistentVolumeClaimMetrics() *PersistentVolumeClaimMetrics {
+	if p.store.GetResetRefreshStatus() {
+		p.refresh()
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	return p.metrics
+}
+
+func newPersistentVolumeClaimClient(clientSet kubernetes.Interface, logger *zap.Logger, options ...PersistentVolumeClaimClientOption) (*PersistentVolumeClaim, error) {
+	p := &PersistentVolumeClaim{
+		stopChan: make(chan struct{}),
+		metrics: &PersistentVolumeClaimMetrics{
+			PersistentVolumeClaimPhases: make(map[string]corev1.PersistentVolumeClaimPhase),
+		},
+	}
+
+	for _, option := range options {
+		option(p)
+	}
+
+	ctx := context.Background()
+	if _, err := clientSet.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).List(ctx, metav1.ListOptions{}); err != nil {
+		return nil, fmt.Errorf("cannot list PVCs. err: %w", err)
+	}
+
+	// Create a store to hold PVC objects
+	p.store = NewObjStore(transformFuncPersistentVolumeClaim, logger)
+	// Create a ListWatch that knows how to list and watch PVCs
+	lw := createPersistentVolumeClaimListWatch(clientSet, metav1.NamespaceAll)
+	// Create a Reflector that watches PVCs and updates the store
+	reflector := cache.NewReflector(lw, &corev1.PersistentVolumeClaim{}, p.store, 0)
+	// Start the Reflector in a goroutine
+	go reflector.Run(p.stopChan)
+
+	if p.syncChecker != nil {
+		// Check the init sync for potential connection issue
+		p.syncChecker.Check(reflector, "PersistentVolumeClaim initial sync timeout")
+	}
+
+	return p, nil
+}
+
+func (p *PersistentVolumeClaim) shutdown() {
+	close(p.stopChan)
+	p.stopped = true
+}
+
+func transformFuncPersistentVolumeClaim(obj any) (any, error) {
+	pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		return nil, fmt.Errorf("input obj %v is not PersistentVolumeClaim type", obj)
+	}
+
+	info := &PersistentVolumeClaimInfo{
+		Name:      pvc.Name,
+		Namespace: pvc.Namespace,
+		Status: &PersistentVolumeClaimStatus{
+			Phase: pvc.Status.Phase,
+		},
+	}
+	return info, nil
+}
+
+func createPersistentVolumeClaimListWatch(client kubernetes.Interface, ns string) cache.ListerWatcher {
+	ctx := context.Background()
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return client.CoreV1().PersistentVolumeClaims(ns).List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return client.CoreV1().PersistentVolumeClaims(ns).Watch(ctx, opts)
+		},
+	}
+}

--- a/internal/aws/k8s/k8sclient/persistent_volume_claim_info.go
+++ b/internal/aws/k8s/k8sclient/persistent_volume_claim_info.go
@@ -1,0 +1,16 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+
+import corev1 "k8s.io/api/core/v1"
+
+type PersistentVolumeClaimInfo struct {
+	Name      string
+	Namespace string
+	Status    *PersistentVolumeClaimStatus
+}
+
+type PersistentVolumeClaimStatus struct {
+	Phase corev1.PersistentVolumeClaimPhase
+}

--- a/internal/aws/k8s/k8sclient/persistent_volume_claim_test.go
+++ b/internal/aws/k8s/k8sclient/persistent_volume_claim_test.go
@@ -1,0 +1,126 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var pvcObjects = []runtime.Object{
+	&corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-1",
+			Namespace: "test-namespace",
+			UID:       "pvc-1-uid",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimPending,
+		},
+	},
+	&corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-2",
+			Namespace: "test-namespace",
+			UID:       "pvc-2-uid",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimBound,
+		},
+	},
+	&corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-3",
+			Namespace: "another-namespace",
+			UID:       "pvc-3-uid",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimLost,
+		},
+	},
+}
+
+func TestPersistentVolumeClaimClient_GetPVCMetrics(t *testing.T) {
+	setOption := PersistentVolumeClaimSyncCheckerOption(&mockReflectorSyncChecker{})
+
+	fakeClientSet := fake.NewSimpleClientset(pvcObjects...)
+	client, _ := newPersistentVolumeClaimClient(fakeClientSet, zap.NewNop(), setOption)
+
+	for _, obj := range pvcObjects {
+		assert.NoError(t, client.store.Add(obj))
+	}
+
+	metrics := client.GetPersistentVolumeClaimMetrics()
+
+	// Test individual PVC phases
+	expectedPersistentVolumeClaimPhases := map[string]corev1.PersistentVolumeClaimPhase{
+		"test-namespace/pvc-1":    corev1.ClaimPending,
+		"test-namespace/pvc-2":    corev1.ClaimBound,
+		"another-namespace/pvc-3": corev1.ClaimLost,
+	}
+	assert.Equal(t, expectedPersistentVolumeClaimPhases, metrics.PersistentVolumeClaimPhases)
+
+	client.shutdown()
+	assert.True(t, client.stopped)
+}
+
+func TestTransformFuncPersistentVolumeClaim(t *testing.T) {
+	info, err := transformFuncPersistentVolumeClaim(nil)
+	assert.Nil(t, info)
+	assert.Error(t, err)
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "test-namespace",
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimBound,
+		},
+	}
+	result, err := transformFuncPersistentVolumeClaim(pvc)
+	assert.NoError(t, err)
+
+	expectedInfo := &PersistentVolumeClaimInfo{
+		Name:      "test-pvc",
+		Namespace: "test-namespace",
+		Status: &PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimBound,
+		},
+	}
+	assert.Equal(t, expectedInfo, result)
+}
+
+func TestNoOpPersistentVolumeClaimClient(t *testing.T) {
+	client := &noOpPersistentVolumeClaimClient{}
+
+	// Test GetPVCMetrics returns empty but valid metrics
+	metrics := client.GetPersistentVolumeClaimMetrics()
+	assert.NotNil(t, metrics)
+	assert.Equal(t, map[string]corev1.PersistentVolumeClaimPhase{}, metrics.PersistentVolumeClaimPhases)
+
+	// Should not panic
+	client.shutdown()
+}

--- a/internal/aws/k8s/k8sclient/persistent_volume_info.go
+++ b/internal/aws/k8s/k8sclient/persistent_volume_info.go
@@ -1,0 +1,8 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+
+type PersistentVolumeInfo struct {
+	Name string
+}

--- a/internal/aws/k8s/k8sclient/persistent_volume_test.go
+++ b/internal/aws/k8s/k8sclient/persistent_volume_test.go
@@ -1,0 +1,127 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var pvObjects = []runtime.Object{
+	&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv-1",
+			UID:  "pv-1-uid",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "pvc-1",
+				Namespace: "test-namespace",
+			},
+		},
+	},
+	&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv-2",
+			UID:  "pv2-uid",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "pvc-2",
+				Namespace: "another-namespace",
+			},
+		},
+	},
+	&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv-3",
+			UID:  "pv3-uid",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "pvc-3",
+				Namespace: "test-namespace",
+			},
+		},
+	},
+}
+
+func TestPersistentVolumeClient_GetPersistentVolumeMetrics(t *testing.T) {
+	setOption := PersistentVolumeSyncCheckerOption(&mockReflectorSyncChecker{})
+
+	fakeClientSet := fake.NewSimpleClientset(pvObjects...)
+	client, err := newPersistentVolumeClient(fakeClientSet, zap.NewNop(), setOption)
+	assert.NoError(t, err)
+
+	for _, obj := range pvObjects {
+		assert.NoError(t, client.store.Add(obj))
+	}
+
+	metrics := client.GetPersistentVolumeMetrics()
+	assert.NotNil(t, metrics)
+	assert.Equal(t, 3, metrics.ClusterCount)
+
+	client.shutdown()
+	assert.True(t, client.stopped)
+}
+
+func TestPersistentVolumeClient_EmptyStore(t *testing.T) {
+	setOption := PersistentVolumeSyncCheckerOption(&mockReflectorSyncChecker{})
+
+	fakeClientSet := fake.NewSimpleClientset()
+	client, err := newPersistentVolumeClient(fakeClientSet, zap.NewNop(), setOption)
+	assert.NoError(t, err)
+
+	// Test with empty store
+	metrics := client.GetPersistentVolumeMetrics()
+	assert.NotNil(t, metrics)
+	assert.Equal(t, 0, metrics.ClusterCount)
+
+	client.shutdown()
+}
+
+func TestTransformFuncPersistentVolume(t *testing.T) {
+	info, err := transformFuncPersistentVolume(nil)
+	assert.Nil(t, info)
+	assert.Error(t, err)
+
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pv",
+			UID:  "test-pv",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "test-pv",
+				Namespace: "test-namespace",
+			},
+		},
+		Status: corev1.PersistentVolumeStatus{
+			Phase: corev1.VolumeAvailable,
+		},
+	}
+	result, err := transformFuncPersistentVolume(pv)
+	assert.NoError(t, err)
+
+	expectedInfo := &PersistentVolumeInfo{
+		Name: "test-pv",
+	}
+	assert.Equal(t, expectedInfo, result)
+}
+
+func TestNoOpPersistentVolumeClient(t *testing.T) {
+	client := &noOpPersistentVolumeClient{}
+
+	metrics := client.GetPersistentVolumeMetrics()
+	assert.NotNil(t, metrics)
+	assert.Equal(t, 0, metrics.ClusterCount)
+
+	client.shutdown()
+}

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/leaderelection.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/leaderelection.go
@@ -34,14 +34,16 @@ type LeaderElection struct {
 	leaderLockName               string
 	leaderLockUsingConfigMapOnly bool
 
-	k8sClient         K8sClient // *k8sclient.K8sClient
-	epClient          k8sclient.EpClient
-	nodeClient        k8sclient.NodeClient
-	podClient         k8sclient.PodClient
-	deploymentClient  k8sclient.DeploymentClient
-	daemonSetClient   k8sclient.DaemonSetClient
-	statefulSetClient k8sclient.StatefulSetClient
-	replicaSetClient  k8sclient.ReplicaSetClient
+	k8sClient                   K8sClient // *k8sclient.K8sClient
+	epClient                    k8sclient.EpClient
+	nodeClient                  k8sclient.NodeClient
+	podClient                   k8sclient.PodClient
+	deploymentClient            k8sclient.DeploymentClient
+	daemonSetClient             k8sclient.DaemonSetClient
+	statefulSetClient           k8sclient.StatefulSetClient
+	replicaSetClient            k8sclient.ReplicaSetClient
+	persistentVolumeClaimClient k8sclient.PersistentVolumeClaimClient
+	persistentVolumeClient      k8sclient.PersistentVolumeClient
 
 	// the following can be set to mocks in testing
 	broadcaster eventBroadcaster
@@ -180,6 +182,8 @@ func (le *LeaderElection) startLeaderElection(ctx context.Context, lock resource
 					le.daemonSetClient = le.k8sClient.GetDaemonSetClient()
 					le.statefulSetClient = le.k8sClient.GetStatefulSetClient()
 					le.replicaSetClient = le.k8sClient.GetReplicaSetClient()
+					le.persistentVolumeClaimClient = le.k8sClient.GetPersistentVolumeClaimClient()
+					le.persistentVolumeClient = le.k8sClient.GetPersistentVolumeClient()
 					le.mu.Unlock()
 
 					if le.isLeadingC != nil {


### PR DESCRIPTION
# PersistentVolume and PersistentVolumeClaim Metrics

## Overview

This PR introduces comprehensive monitoring support for Kubernetes PersistentVolumes (PV) and PersistentVolumeClaims (PVC) in the AWS Container Insights receiver. 

### Why Monitor PV/PVC Metrics?

- **Storage Health Monitoring**: Identify stuck or failed storage requests
- **Capacity Planning**: Track storage usage patterns and growth
- **Resource Optimization**: Understand storage consumption across namespaces

---

## EMF Logs

```
{
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName"
                ],
                [
                    "ClusterName",
                    "Namespace"
                ],
                [
                    "ClusterName",
                    "Namespace",
                    "PersistentVolumeClaimName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "persistent_volume_claim_status_bound",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "persistent_volume_claim_status_lost",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "persistent_volume_claim_count",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "persistent_volume_claim_status_pending",
                    "Unit": "Count",
                    "StorageResolution": 60
                }
            ]
        }
    ],
    "ClusterName": "basic-cluster",
    "Namespace": "kube-system",
    "PersistentVolumeClaimName": "local-path-pvc",
    "PlatformType": "AWS::EKS",
    "Sources": [
        "apiserver"
    ],
    "Timestamp": "1756379989530",
    "Type": "PersistentVolumeClaim",
    "Version": "0",
    "persistent_volume_claim_count": 1,
    "persistent_volume_claim_status_bound": 1,
    "persistent_volume_claim_status_lost": 0,
    "persistent_volume_claim_status_pending": 0
}
```
---
```
{
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "persistent_volume_count",
                    "Unit": "Count",
                    "StorageResolution": 60
                }
            ]
        }
    ],
    "ClusterName": "basic-cluster",
    "PlatformType": "AWS::EKS",
    "Sources": [
        "apiserver"
    ],
    "Timestamp": "1756380049525",
    "Type": "PersistentVolume",
    "Version": "0",
    "persistent_volume_count": 8
}
```
---
## Graphs
<img width="920" height="772" alt="image" src="https://github.com/user-attachments/assets/35a8e154-13cb-4715-bbbf-ab7970ca7707" />
