### PR TITLE
Add new EFA resource allocation metrics

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -370,7 +370,6 @@ func init() {
 		ContainerCount:        UnitCount,
 		ContainerRestartCount: UnitCount,
 		RunningTaskCount:      UnitCount,
-
 		EfaRdmaReadBytes:      UnitBytesPerSec,
 		EfaRdmaWriteBytes:     UnitBytesPerSec,
 		EfaRdmaWriteRecvBytes: UnitBytesPerSec,

--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -155,6 +155,13 @@ const (
 	NeuroncoreUnreservedCapacity = "neuroncore_unreserved_capacity"
 	NeuroncoreAvailableCapacity  = "neuroncore_available_capacity"
 
+	EfaLimit              = "efa_limit"
+	EfaUsageTotal         = "efa_usage_total"
+	EfaRequest            = "efa_request"
+	EfaReservedCapacity   = "efa_reserved_capacity"
+	EfaUnreservedCapacity = "efa_unreserved_capacity"
+	EfaAvailableCapacity  = "efa_available_capacity"
+
 	HyperPodUnschedulablePendingReplacement = "unschedulable_pending_replacement"
 	HyperPodUnschedulablePendingReboot      = "unschedulable_pending_reboot"
 	HyperPodSchedulable                     = "schedulable"
@@ -370,6 +377,13 @@ func init() {
 		EfaRxBytes:            UnitBytesPerSec,
 		EfaRxDropped:          UnitCountPerSec,
 		EfaTxBytes:            UnitBytesPerSec,
+
+		EfaLimit:              UnitCount,
+		EfaUsageTotal:         UnitCount,
+		EfaRequest:            UnitCount,
+		EfaReservedCapacity:   UnitPercent,
+		EfaUnreservedCapacity: UnitPercent,
+		EfaAvailableCapacity:  UnitCount,
 
 		GpuLimit:              UnitCount,
 		GpuUsageTotal:         UnitCount,

--- a/internal/aws/containerinsight/utils_test.go
+++ b/internal/aws/containerinsight/utils_test.go
@@ -443,6 +443,12 @@ func TestConvertToOTLPMetricsForNodeMetrics(t *testing.T) {
 		"node_gpu_reserved_capacity":          3.0093851356081194,
 		"node_gpu_unreserved_capacity":        2.9303736689169724,
 		"node_gpu_available_capacity":         uint64(35),
+		"node_efa_request":                    int32(2),
+		"node_efa_limit":                      int32(4),
+		"node_efa_usage_total":                int32(3),
+		"node_efa_reserved_capacity":          50.0,
+		"node_efa_unreserved_capacity":        50.0,
+		"node_efa_available_capacity":         uint64(2),
 	}
 	expectedUnits = map[string]string{
 		"node_cpu_limit":                      "",
@@ -485,6 +491,12 @@ func TestConvertToOTLPMetricsForNodeMetrics(t *testing.T) {
 		"node_gpu_reserved_capacity":          UnitPercent,
 		"node_gpu_unreserved_capacity":        UnitPercent,
 		"node_gpu_available_capacity":         UnitCount,
+		"node_efa_request":                    UnitCount,
+		"node_efa_limit":                      UnitCount,
+		"node_efa_usage_total":                UnitCount,
+		"node_efa_reserved_capacity":          UnitPercent,
+		"node_efa_unreserved_capacity":        UnitPercent,
+		"node_efa_available_capacity":         UnitCount,
 	}
 	tags = map[string]string{
 		"AutoScalingGroupName": "eks-a6bb9db9-267c-401c-db55-df8ef645b06f",
@@ -738,6 +750,11 @@ func TestConvertToOTLPMetricsForPodMetrics(t *testing.T) {
 		"pod_gpu_limit":                         1,
 		"pod_gpu_usage_total":                   1,
 		"pod_gpu_reserved_capacity":             2.3677681271483983,
+		"pod_efa_request":                       1,
+		"pod_efa_limit":                         2,
+		"pod_efa_usage_total":                   2,
+		"pod_efa_reserved_capacity":             50.0,
+		"pod_efa_available_capacity":            uint64(3),
 	}
 	expectedUnits = map[string]string{
 		"pod_cpu_limit":                         "",
@@ -788,6 +805,11 @@ func TestConvertToOTLPMetricsForPodMetrics(t *testing.T) {
 		"pod_gpu_limit":                         UnitCount,
 		"pod_gpu_usage_total":                   UnitCount,
 		"pod_gpu_reserved_capacity":             UnitPercent,
+		"pod_efa_request":                       UnitCount,
+		"pod_efa_limit":                         UnitCount,
+		"pod_efa_usage_total":                   UnitCount,
+		"pod_efa_reserved_capacity":             UnitPercent,
+		"pod_efa_available_capacity":            UnitCount,
 	}
 	tags = map[string]string{
 		"ClusterName":  "eks-aoc",

--- a/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo.go
@@ -122,6 +122,15 @@ func (n *nodeInfo) getNodeStatusCapacityGPUs() (uint64, bool) {
 	return forceConvertToInt64(gpus, n.logger), true
 }
 
+func (n *nodeInfo) getNodeStatusCapacityEfas() (uint64, bool) {
+	capacityResources, ok := n.provider.NodeToCapacityMap()[n.nodeName]
+	if !ok {
+		return 0, false
+	}
+	efas := capacityResources.Name(resourceSpecEfaKey, resource.DecimalExponent).Value()
+	return forceConvertToInt64(efas, n.logger), true
+}
+
 func (n *nodeInfo) getNeuronResourceCapacity(resourceKey v1.ResourceName) (uint64, bool) {
 	capacityResources, ok := n.provider.NodeToCapacityMap()[n.nodeName]
 	if !ok {

--- a/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo.go
@@ -23,6 +23,8 @@ type nodeStats struct {
 	gpuUsageTotal        uint64
 	neuroncoreReq        uint64
 	neuroncoreUsageTotal uint64
+	efaReq               uint64
+	efaUsageTotal        uint64
 }
 
 type nodeInfo struct {

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -32,7 +32,7 @@ const (
 	neuronKey          = "aws.amazon.com/neuron"
 	neuroncoreKey      = "aws.amazon.com/neuroncore"
 	neuronDeviceKey    = "aws.amazon.com/neurondevice"
-	efaKey          = "vpc.amazonaws.com/efa"
+	efaKey             = "vpc.amazonaws.com/efa"
 	splitRegexStr      = "\\.|-"
 	kubeProxy          = "kube-proxy"
 )
@@ -368,8 +368,8 @@ func (p *PodStore) refreshInternal(now time.Time, podList []corev1.Pod) {
 		gpuUsageTotal:        gpuUsageTotal,
 		neuroncoreReq:        neuroncoreRequest,
 		neuroncoreUsageTotal: neuroncoreUsageTotal,
-		efaReq:           efaRequest,
-		efaUsageTotal:    efaUsageTotal,
+		efaReq:               efaRequest,
+		efaUsageTotal:        efaUsageTotal,
 	})
 }
 
@@ -530,8 +530,6 @@ func (p *PodStore) decorateNeuron(metric CIMetric, pod *corev1.Pod) {
 			if nodeCapacityCores, ok := p.nodeInfo.getNodeStatusCapacityNeuronCores(); ok && nodeCapacityCores != 0 {
 				reservedCapacity := float64(coresLimit) / float64(nodeCapacityCores) * 100
 				metric.AddField(ci.MetricName(ci.TypePod, ci.NeuroncoreReservedCapacity), reservedCapacity)
-				reservedCapacity := float64(podGpuLimit) / float64(nodeStatusCapacityGPUs) * 100
-				metric.AddField(ci.MetricName(ci.TypePod, ci.GpuReservedCapacity), reservedCapacity)
 			}
 		}
 	}

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -32,6 +32,7 @@ const (
 	neuronKey          = "aws.amazon.com/neuron"
 	neuroncoreKey      = "aws.amazon.com/neuroncore"
 	neuronDeviceKey    = "aws.amazon.com/neurondevice"
+	efaKey          = "vpc.amazonaws.com/efa"
 	splitRegexStr      = "\\.|-"
 	kubeProxy          = "kube-proxy"
 )
@@ -251,6 +252,7 @@ func (p *PodStore) Decorate(ctx context.Context, metric CIMetric, kubernetesBlob
 		p.decorateMem(metric, &entry.pod)
 		p.decorateGPU(metric, &entry.pod)
 		p.decorateNeuron(metric, &entry.pod)
+		p.decorateEfa(metric, &entry.pod)
 		p.addStatus(metric, &entry.pod)
 		addContainerCount(metric, &entry.pod)
 		addContainerID(&entry.pod, metric, kubernetesBlob, p.logger)
@@ -304,6 +306,8 @@ func (p *PodStore) refreshInternal(now time.Time, podList []corev1.Pod) {
 	var gpuUsageTotal uint64
 	var neuroncoreRequest uint64
 	var neuroncoreUsageTotal uint64
+	var efaRequest uint64
+	var efaUsageTotal uint64
 
 	for i := range podList {
 		pod := podList[i]
@@ -329,6 +333,13 @@ func (p *PodStore) refreshInternal(now time.Time, podList []corev1.Pod) {
 				gpuRequest += tmpGpuReq
 				if pod.Status.Phase == corev1.PodRunning {
 					gpuUsageTotal += tmpGpuLimit
+				}
+			}
+			if tmpEfaLimit, ok := getResourceSettingForPod(&pod, 0, efaKey, getLimitForContainer); ok {
+				tmpEfaReq, _ := getResourceSettingForPod(&pod, 0, efaKey, getRequestForContainer)
+				efaRequest += tmpEfaReq
+				if pod.Status.Phase == corev1.PodRunning {
+					efaUsageTotal += tmpEfaLimit
 				}
 			}
 		}
@@ -357,6 +368,8 @@ func (p *PodStore) refreshInternal(now time.Time, podList []corev1.Pod) {
 		gpuUsageTotal:        gpuUsageTotal,
 		neuroncoreReq:        neuroncoreRequest,
 		neuroncoreUsageTotal: neuroncoreUsageTotal,
+		efaReq:           efaRequest,
+		efaUsageTotal:    efaUsageTotal,
 	})
 }
 
@@ -437,6 +450,17 @@ func (p *PodStore) decorateNode(metric CIMetric) {
 				metric.AddField(ci.MetricName(ci.TypeNode, ci.NeuroncoreUnreservedCapacity), 100.0-reservedCapacity)
 				metric.AddField(ci.MetricName(ci.TypeNode, ci.NeuroncoreAvailableCapacity), nodeStatusCapacityNeuroncore-nodeStats.neuroncoreReq)
 			}
+
+			if nodeStatusCapacityEfas, ok := p.nodeInfo.getNodeStatusCapacityEfas(); ok && nodeStatusCapacityEfas != 0 {
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.EfaRequest), nodeStats.efaReq)
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.EfaLimit), nodeStatusCapacityEfas)
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.EfaUsageTotal), nodeStats.efaUsageTotal)
+
+				reservedCapacity := float64(nodeStats.efaReq) / float64(nodeStatusCapacityEfas) * 100
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.EfaReservedCapacity), reservedCapacity)
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.EfaUnreservedCapacity), 100.0-reservedCapacity)
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.EfaAvailableCapacity), nodeStatusCapacityEfas-nodeStats.efaReq)
+			}
 		}
 	}
 }
@@ -506,6 +530,28 @@ func (p *PodStore) decorateNeuron(metric CIMetric, pod *corev1.Pod) {
 			if nodeCapacityCores, ok := p.nodeInfo.getNodeStatusCapacityNeuronCores(); ok && nodeCapacityCores != 0 {
 				reservedCapacity := float64(coresLimit) / float64(nodeCapacityCores) * 100
 				metric.AddField(ci.MetricName(ci.TypePod, ci.NeuroncoreReservedCapacity), reservedCapacity)
+				reservedCapacity := float64(podGpuLimit) / float64(nodeStatusCapacityGPUs) * 100
+				metric.AddField(ci.MetricName(ci.TypePod, ci.GpuReservedCapacity), reservedCapacity)
+			}
+		}
+	}
+}
+
+func (p *PodStore) decorateEfa(metric CIMetric, pod *corev1.Pod) {
+	if p.includeEnhancedMetrics && p.enableAcceleratedComputeMetrics && metric.GetTag(ci.MetricType) == ci.TypePod &&
+		pod.Status.Phase != corev1.PodSucceeded && pod.Status.Phase != corev1.PodFailed {
+		if podEfaLimit, ok := getResourceSettingForPod(pod, 0, efaKey, getLimitForContainer); ok {
+			podEfaRequest, _ := getResourceSettingForPod(pod, 0, efaKey, getRequestForContainer)
+			metric.AddField(ci.MetricName(ci.TypePod, ci.EfaRequest), podEfaRequest)
+			metric.AddField(ci.MetricName(ci.TypePod, ci.EfaLimit), podEfaLimit)
+			var podEfaUsageTotal uint64
+			if pod.Status.Phase == corev1.PodRunning { // Set the efa limit as the usage_total for running pods only
+				podEfaUsageTotal = podEfaLimit
+			}
+			metric.AddField(ci.MetricName(ci.TypePod, ci.EfaUsageTotal), podEfaUsageTotal)
+			if nodeStatusCapacityEfas, ok := p.nodeInfo.getNodeStatusCapacityEfas(); ok && nodeStatusCapacityEfas != 0 {
+				reservedCapacity := float64(podEfaLimit) / float64(nodeStatusCapacityEfas) * 100
+				metric.AddField(ci.MetricName(ci.TypePod, ci.EfaReservedCapacity), reservedCapacity)
 			}
 		}
 	}

--- a/receiver/awscontainerinsightreceiver/internal/stores/utils.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/utils.go
@@ -26,6 +26,7 @@ const (
 	resourceSpecNeuronKey       = "aws.amazon.com/neuron"
 	resourceSpecNeuroncoreKey   = "aws.amazon.com/neuroncore"
 	resourceSpecNeuronDeviceKey = "aws.amazon.com/neurondevice"
+	resourceSpecEfaKey          = "vpc.amazonaws.com/efa"
 )
 
 func createPodKeyFromMetaData(pod *corev1.Pod) string {

--- a/receiver/awscontainerinsightreceiver/internal/stores/utils_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/utils_test.go
@@ -72,6 +72,7 @@ func (m *mockNodeInfoProvider) NodeToCapacityMap() map[string]v1.ResourceList {
 			"aws.amazon.com/neuron":       *resource.NewQuantity(16, resource.DecimalSI),
 			"aws.amazon.com/neuroncore":   *resource.NewQuantity(32, resource.DecimalSI),
 			"aws.amazon.com/neurondevice": *resource.NewQuantity(16, resource.DecimalSI),
+			"vpc.amazonaws.com/efa":       *resource.NewQuantity(4, resource.DecimalSI),
 		},
 		"testNode2": {
 			"pods": *resource.NewQuantity(10, resource.DecimalSI),
@@ -87,6 +88,7 @@ func (m *mockNodeInfoProvider) NodeToAllocatableMap() map[string]v1.ResourceList
 			"aws.amazon.com/neuron":       *resource.NewQuantity(16, resource.DecimalSI),
 			"aws.amazon.com/neuroncore":   *resource.NewQuantity(32, resource.DecimalSI),
 			"aws.amazon.com/neurondevice": *resource.NewQuantity(16, resource.DecimalSI),
+			"vpc.amazonaws.com/efa":       *resource.NewQuantity(4, resource.DecimalSI),
 		},
 		"testNode2": {
 			"pods": *resource.NewQuantity(20, resource.DecimalSI),


### PR DESCRIPTION
## Description
This PR is enhancing metric offering by adding new efa resource allocation metrics

#### Changes:
* Add new node level EFA metrics: "node_efa_limit", "node_efa_usage_total", "node_efa_reserved_capacity", "node_efa_unreserved_capacity", "node_efa_available_capacity"
* Add new pod level EFA metrics: "pod_efa_request", "pod_efa_limit", "pod_efa_usage_total", "pod_efa_reserved_capacity", "pod_efa_available_capacity"
* Add testing for new metrics

## Example Metric Output
<img width="1431" height="235" alt="Screenshot 2025-08-07 at 18 30 26" src="https://github.com/user-attachments/assets/21ef5387-5a60-4d22-9745-36f7eba173a3" />
<img width="1431" height="235" alt="Screenshot 2025-08-07 at 18 30 46" src="https://github.com/user-attachments/assets/fa28c6bf-32a4-45ad-9367-321b823504d6" />
<img width="1431" height="235" alt="Screenshot 2025-08-07 at 18 31 14" src="https://github.com/user-attachments/assets/3698603f-7bac-4939-b7ca-93f94c41da9a" />
<img width="1431" height="235" alt="Screenshot 2025-08-07 at 18 31 30" src="https://github.com/user-attachments/assets/1dcec67a-3368-4332-984b-0d2909fba1b4" />
<img width="1431" height="235" alt="Screenshot 2025-08-07 at 18 31 47" src="https://github.com/user-attachments/assets/9f58722d-965d-49e9-9f3d-7fd923f3232b" />
<img width="1431" height="235" alt="Screenshot 2025-08-07 at 18 32 17" src="https://github.com/user-attachments/assets/9ae800dd-6e28-4ddf-9c5b-630c39e731dd" />

### EMF Output
```
{
    "AutoScalingGroupName": "eks-my-c5n-ng-b8cc1dd9-34e4-ca21-c0f7-5e11bb2551bc",
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName",
                    "InstanceId",
                    "NodeName"
                ],
                [
                    "ClusterName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "node_cpu_utilization",
                    "Unit": "Percent",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_efa_available_capacity",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_efa_usage_total",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_cpu_limit",
                    "Unit": "",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_number_of_running_containers",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_memory_limit",
                    "Unit": "Bytes",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_memory_working_set",
                    "Unit": "Bytes",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_efa_unreserved_capacity",
                    "Unit": "Percent",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_status_condition_ready",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_memory_reserved_capacity",
                    "Unit": "Percent",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_number_of_running_pods",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_status_condition_unknown",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_cpu_usage_total",
                    "Unit": "",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_status_condition_disk_pressure",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_efa_reserved_capacity",
                    "Unit": "Percent",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_network_total_bytes",
                    "Unit": "Bytes/Second",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_status_condition_memory_pressure",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_status_capacity_pods",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_cpu_reserved_capacity",
                    "Unit": "Percent",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_efa_limit",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_memory_utilization",
                    "Unit": "Percent",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_status_allocatable_pods",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_status_condition_pid_pressure",
                    "Unit": "Count",
                    "StorageResolution": 60
                }
            ]
        }
    ],
    "ClusterName": "efa-cluster",
    "InstanceId": "i-00fbde5ded13d82d2",
    "InstanceType": "c5n.9xlarge",
    "NodeName": "ip-192-168-67-129.us-west-2.compute.internal",
    "PlatformType": "AWS::EKS",
    "Sources": [
        "cadvisor",
        "/proc",
        "pod",
        "calculated"
    ],
    "Timestamp": "1753350463753",
    "Type": "Node",
    "Version": "0",
    "kubernetes": {
        "host": "ip-192-168-67-129.us-west-2.compute.internal"
    },
    "node_cpu_request": 1460,
    "node_cpu_usage_system": 11.827048921880024,
    "node_cpu_usage_user": 35.966460807359134,
    "node_efa_request": 1,
    "node_memory_cache": 2421981184,
    "node_memory_failcnt": 0,
    "node_memory_failures_total": 739.1419533068637,
    "node_memory_hierarchical_pgfault": 739.109550433105,
    "node_memory_hierarchical_pgmajfault": 0.03240287375857541,
    "node_memory_mapped_file": 638197760,
    "node_memory_max_usage": 0,
    "node_memory_pgfault": 739.109550433105,
    "node_memory_pgmajfault": 0.03240287375857541,
    "node_memory_request": 1888485376,
    "node_memory_rss": 528654336,
    "node_memory_swap": 0,
    "node_memory_usage": 2950635520,
    "node_network_rx_bytes": 54122.40662889035,
    "node_network_rx_dropped": 0,
    "node_network_rx_errors": 0,
    "node_network_rx_packets": 54.01559055554521,
    "node_network_tx_bytes": 5630.5501644063725,
    "node_network_tx_dropped": 0,
    "node_network_tx_errors": 0,
    "node_network_tx_packets": 24.577579745879447,
    "node_cpu_limit": 36000,
    "node_cpu_reserved_capacity": 4.055555555555555,
    "node_cpu_usage_total": 47.79350972923916,
    "node_cpu_utilization": 0.13275974924788655,
    "node_efa_available_capacity": 0,
    "node_efa_limit": 1,
    "node_efa_reserved_capacity": 100,
    "node_efa_unreserved_capacity": 0,
    "node_efa_usage_total": 1,
    "node_memory_limit": 99083689984,
    "node_memory_reserved_capacity": 1.90594978477785,
    "node_memory_utilization": 1.0078604058460658,
    "node_memory_working_set": 998625280,
    "node_network_total_bytes": 59752.956793296726,
    "node_number_of_running_containers": 12,
    "node_number_of_running_pods": 11,
    "node_status_allocatable_pods": 234,
    "node_status_capacity_pods": 234,
    "node_status_condition_disk_pressure": 0,
    "node_status_condition_memory_pressure": 0,
    "node_status_condition_pid_pressure": 0,
    "node_status_condition_ready": 1,
    "node_status_condition_unknown": 0
}
```

#### Related PR:
* https://github.com/aws/amazon-cloudwatch-agent/pull/1815