### PR TITLE
Add new Neuroncore capacity metrics

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -146,6 +146,13 @@ const (
 	GpuRequest          = "gpu_request"
 	GpuReservedCapacity = "gpu_reserved_capacity"
 
+	NeuroncoreLimit              = "neuroncore_limit"
+	NeuroncoreUsageTotal         = "neuroncore_usage_total"
+	NeuroncoreRequest            = "neuroncore_request"
+	NeuroncoreReservedCapacity   = "neuroncore_reserved_capacity"
+	NeuroncoreUnreservedCapacity = "neuroncore_unreserved_capacity"
+	NeuroncoreAvailableCapacity  = "neuroncore_available_capacity"
+
 	HyperPodUnschedulablePendingReplacement = "unschedulable_pending_replacement"
 	HyperPodUnschedulablePendingReboot      = "unschedulable_pending_reboot"
 	HyperPodSchedulable                     = "schedulable"
@@ -366,6 +373,13 @@ func init() {
 		GpuUsageTotal:       UnitCount,
 		GpuRequest:          UnitCount,
 		GpuReservedCapacity: UnitPercent,
+
+		NeuroncoreLimit:              UnitCount,
+		NeuroncoreUsageTotal:         UnitCount,
+		NeuroncoreRequest:            UnitCount,
+		NeuroncoreReservedCapacity:   UnitPercent,
+		NeuroncoreUnreservedCapacity: UnitPercent,
+		NeuroncoreAvailableCapacity:  UnitCount,
 
 		HyperPodUnschedulablePendingReplacement: UnitCount,
 		HyperPodUnschedulablePendingReboot:      UnitCount,

--- a/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo.go
@@ -120,31 +120,25 @@ func (n *nodeInfo) getNodeStatusCapacityGPUs() (uint64, bool) {
 	return forceConvertToInt64(gpus, n.logger), true
 }
 
-func (n *nodeInfo) getNodeStatusCapacityNeuron() (uint64, bool) {
+func (n *nodeInfo) getNeuronResourceCapacity(resourceKey v1.ResourceName) (uint64, bool) {
 	capacityResources, ok := n.provider.NodeToCapacityMap()[n.nodeName]
 	if !ok {
 		return 0, false
 	}
-	neuron := capacityResources.Name(resourceSpecNeuronKey, resource.DecimalExponent).Value()
-	return forceConvertToInt64(neuron, n.logger), true
+	value := capacityResources.Name(resourceKey, resource.DecimalExponent).Value()
+	return forceConvertToInt64(value, n.logger), true
+}
+
+func (n *nodeInfo) getNodeStatusCapacityNeuron() (uint64, bool) {
+	return n.getNeuronResourceCapacity(resourceSpecNeuronKey)
 }
 
 func (n *nodeInfo) getNodeStatusCapacityNeuroncore() (uint64, bool) {
-	capacityResources, ok := n.provider.NodeToCapacityMap()[n.nodeName]
-	if !ok {
-		return 0, false
-	}
-	neuroncore := capacityResources.Name(resourceSpecNeuroncoreKey, resource.DecimalExponent).Value()
-	return forceConvertToInt64(neuroncore, n.logger), true
+	return n.getNeuronResourceCapacity(resourceSpecNeuroncoreKey)
 }
 
 func (n *nodeInfo) getNodeStatusCapacityNeurondevice() (uint64, bool) {
-	capacityResources, ok := n.provider.NodeToCapacityMap()[n.nodeName]
-	if !ok {
-		return 0, false
-	}
-	neurondevice := capacityResources.Name(resourceSpecNeuronDeviceKey, resource.DecimalExponent).Value()
-	return forceConvertToInt64(neurondevice, n.logger), true
+	return n.getNeuronResourceCapacity(resourceSpecNeuronDeviceKey)
 }
 
 func (n *nodeInfo) getNeuronCoresPerDevice() (int, bool) {

--- a/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/nodeinfo.go
@@ -15,12 +15,14 @@ import (
 )
 
 type nodeStats struct {
-	podCnt        int
-	containerCnt  int
-	cpuReq        uint64
-	memReq        uint64
-	gpuReq        uint64
-	gpuUsageTotal uint64
+	podCnt               int
+	containerCnt         int
+	cpuReq               uint64
+	memReq               uint64
+	gpuReq               uint64
+	gpuUsageTotal        uint64
+	neuroncoreReq        uint64
+	neuroncoreUsageTotal uint64
 }
 
 type nodeInfo struct {
@@ -116,6 +118,64 @@ func (n *nodeInfo) getNodeStatusCapacityGPUs() (uint64, bool) {
 	}
 	gpus := capacityResources.Name(resourceSpecNvidiaGpuKey, resource.DecimalExponent).Value()
 	return forceConvertToInt64(gpus, n.logger), true
+}
+
+func (n *nodeInfo) getNodeStatusCapacityNeuron() (uint64, bool) {
+	capacityResources, ok := n.provider.NodeToCapacityMap()[n.nodeName]
+	if !ok {
+		return 0, false
+	}
+	neuron := capacityResources.Name(resourceSpecNeuronKey, resource.DecimalExponent).Value()
+	return forceConvertToInt64(neuron, n.logger), true
+}
+
+func (n *nodeInfo) getNodeStatusCapacityNeuroncore() (uint64, bool) {
+	capacityResources, ok := n.provider.NodeToCapacityMap()[n.nodeName]
+	if !ok {
+		return 0, false
+	}
+	neuroncore := capacityResources.Name(resourceSpecNeuroncoreKey, resource.DecimalExponent).Value()
+	return forceConvertToInt64(neuroncore, n.logger), true
+}
+
+func (n *nodeInfo) getNodeStatusCapacityNeurondevice() (uint64, bool) {
+	capacityResources, ok := n.provider.NodeToCapacityMap()[n.nodeName]
+	if !ok {
+		return 0, false
+	}
+	neurondevice := capacityResources.Name(resourceSpecNeuronDeviceKey, resource.DecimalExponent).Value()
+	return forceConvertToInt64(neurondevice, n.logger), true
+}
+
+func (n *nodeInfo) getNeuronCoresPerDevice() (int, bool) {
+	devices, hasDevices := n.getNodeStatusCapacityNeuron()
+	cores, hasCores := n.getNodeStatusCapacityNeuroncore()
+
+	if hasDevices && hasCores && devices > 0 && cores > 0 {
+		return int(cores / devices), true
+	}
+
+	return 0, false
+}
+
+func (n *nodeInfo) getNodeStatusCapacityNeuronCores() (uint64, bool) {
+	if cores, ok := n.getNodeStatusCapacityNeuroncore(); ok {
+		return cores, true
+	}
+
+	coresPerDevice, hasRatio := n.getNeuronCoresPerDevice()
+	if !hasRatio {
+		return 0, false
+	}
+
+	if devices, ok := n.getNodeStatusCapacityNeuron(); ok {
+		return devices * uint64(coresPerDevice), true
+	}
+	if devices, ok := n.getNodeStatusCapacityNeurondevice(); ok {
+		return devices * uint64(coresPerDevice), true
+	}
+
+	return 0, false
 }
 
 func (n *nodeInfo) getNodeStatusCondition(conditionType v1.NodeConditionType) (uint64, bool) {

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -486,7 +486,6 @@ func (p *PodStore) getNeuronCoresFromPod(pod *corev1.Pod) (limitCores, requestCo
 func (p *PodStore) decorateNeuron(metric CIMetric, pod *corev1.Pod) {
 	if p.includeEnhancedMetrics && p.enableAcceleratedComputeMetrics && metric.GetTag(ci.MetricType) == ci.TypePod &&
 		pod.Status.Phase != corev1.PodSucceeded && pod.Status.Phase != corev1.PodFailed {
-
 		coresLimit, coresRequest, hasNeuron := p.getNeuronCoresFromPod(pod)
 
 		if hasNeuron {

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -29,6 +29,9 @@ const (
 	memoryKey          = "memory"
 	cpuKey             = "cpu"
 	gpuKey             = "nvidia.com/gpu"
+	neuronKey          = "aws.amazon.com/neuron"
+	neuroncoreKey      = "aws.amazon.com/neuroncore"
+	neuronDeviceKey    = "aws.amazon.com/neurondevice"
 	splitRegexStr      = "\\.|-"
 	kubeProxy          = "kube-proxy"
 )
@@ -247,6 +250,7 @@ func (p *PodStore) Decorate(ctx context.Context, metric CIMetric, kubernetesBlob
 		p.decorateCPU(metric, &entry.pod)
 		p.decorateMem(metric, &entry.pod)
 		p.decorateGPU(metric, &entry.pod)
+		p.decorateNeuron(metric, &entry.pod)
 		p.addStatus(metric, &entry.pod)
 		addContainerCount(metric, &entry.pod)
 		addContainerID(&entry.pod, metric, kubernetesBlob, p.logger)
@@ -298,6 +302,8 @@ func (p *PodStore) refreshInternal(now time.Time, podList []corev1.Pod) {
 	var memRequest uint64
 	var gpuRequest uint64
 	var gpuUsageTotal uint64
+	var neuroncoreRequest uint64
+	var neuroncoreUsageTotal uint64
 
 	for i := range podList {
 		pod := podList[i]
@@ -312,6 +318,12 @@ func (p *PodStore) refreshInternal(now time.Time, podList []corev1.Pod) {
 			cpuRequest += tmpCPUReq
 			tmpMemReq, _ := getResourceSettingForPod(&pod, p.nodeInfo.getMemCapacity(), memoryKey, getRequestForContainer)
 			memRequest += tmpMemReq
+			if coresLimit, coresReq, hasNeuron := p.getNeuronCoresFromPod(&pod); hasNeuron {
+				neuroncoreRequest += coresReq
+				if pod.Status.Phase == corev1.PodRunning {
+					neuroncoreUsageTotal += coresLimit
+				}
+			}
 			if tmpGpuLimit, ok := getResourceSettingForPod(&pod, 0, gpuKey, getLimitForContainer); ok {
 				tmpGpuReq, _ := getResourceSettingForPod(&pod, 0, gpuKey, getRequestForContainer)
 				gpuRequest += tmpGpuReq
@@ -337,12 +349,14 @@ func (p *PodStore) refreshInternal(now time.Time, podList []corev1.Pod) {
 	}
 
 	p.nodeInfo.setNodeStats(nodeStats{
-		podCnt:        podCount,
-		containerCnt:  containerCount,
-		memReq:        memRequest,
-		cpuReq:        cpuRequest,
-		gpuReq:        gpuRequest,
-		gpuUsageTotal: gpuUsageTotal,
+		podCnt:               podCount,
+		containerCnt:         containerCount,
+		memReq:               memRequest,
+		cpuReq:               cpuRequest,
+		gpuReq:               gpuRequest,
+		gpuUsageTotal:        gpuUsageTotal,
+		neuroncoreReq:        neuroncoreRequest,
+		neuroncoreUsageTotal: neuroncoreUsageTotal,
 	})
 }
 
@@ -408,6 +422,17 @@ func (p *PodStore) decorateNode(metric CIMetric) {
 				metric.AddField(ci.MetricName(ci.TypeNode, ci.GpuUsageTotal), nodeStats.gpuUsageTotal)
 				metric.AddField(ci.MetricName(ci.TypeNode, ci.GpuReservedCapacity), float64(nodeStats.gpuReq)/float64(nodeStatusCapacityGPUs)*100)
 			}
+
+			if nodeStatusCapacityNeuroncore, ok := p.nodeInfo.getNodeStatusCapacityNeuronCores(); ok && nodeStatusCapacityNeuroncore != 0 {
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.NeuroncoreRequest), nodeStats.neuroncoreReq)
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.NeuroncoreLimit), nodeStatusCapacityNeuroncore)
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.NeuroncoreUsageTotal), nodeStats.neuroncoreUsageTotal)
+
+				reservedCapacity := float64(nodeStats.neuroncoreReq) / float64(nodeStatusCapacityNeuroncore) * 100
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.NeuroncoreReservedCapacity), reservedCapacity)
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.NeuroncoreUnreservedCapacity), 100.0-reservedCapacity)
+				metric.AddField(ci.MetricName(ci.TypeNode, ci.NeuroncoreAvailableCapacity), nodeStatusCapacityNeuroncore-nodeStats.neuroncoreReq)
+			}
 		}
 	}
 }
@@ -426,6 +451,57 @@ func (p *PodStore) decorateGPU(metric CIMetric, pod *corev1.Pod) {
 			metric.AddField(ci.MetricName(ci.TypePod, ci.GpuUsageTotal), podGpuUsageTotal)
 			if nodeStatusCapacityGPUs, ok := p.nodeInfo.getNodeStatusCapacityGPUs(); ok && nodeStatusCapacityGPUs != 0 {
 				metric.AddField(ci.MetricName(ci.TypePod, ci.GpuReservedCapacity), float64(podGpuLimit)/float64(nodeStatusCapacityGPUs)*100)
+			}
+		}
+	}
+}
+
+func (p *PodStore) getCoresPerNeuronDevice() (int, bool) {
+	return p.nodeInfo.getNeuronCoresPerDevice()
+}
+
+func (p *PodStore) getNeuronCoresFromPod(pod *corev1.Pod) (limitCores, requestCores uint64, hasNeuron bool) {
+	if coreLimit, ok := getResourceSettingForPod(pod, 0, neuroncoreKey, getLimitForContainer); ok {
+		coreRequest, _ := getResourceSettingForPod(pod, 0, neuroncoreKey, getRequestForContainer)
+		return coreLimit, coreRequest, true
+	}
+
+	coresPerDevice, hasRatio := p.getCoresPerNeuronDevice()
+	if !hasRatio {
+		p.logger.Debug("Cannot determine neuron cores per device ratio, skipping device-based neuron metrics")
+		return 0, 0, false
+	}
+
+	deviceKeys := []corev1.ResourceName{neuronKey, neuronDeviceKey}
+	for _, deviceKey := range deviceKeys {
+		if deviceLimit, ok := getResourceSettingForPod(pod, 0, deviceKey, getLimitForContainer); ok {
+			deviceRequest, _ := getResourceSettingForPod(pod, 0, deviceKey, getRequestForContainer)
+			return deviceLimit * uint64(coresPerDevice), deviceRequest * uint64(coresPerDevice), true
+		}
+	}
+
+	return 0, 0, false
+}
+
+func (p *PodStore) decorateNeuron(metric CIMetric, pod *corev1.Pod) {
+	if p.includeEnhancedMetrics && p.enableAcceleratedComputeMetrics && metric.GetTag(ci.MetricType) == ci.TypePod &&
+		pod.Status.Phase != corev1.PodSucceeded && pod.Status.Phase != corev1.PodFailed {
+
+		coresLimit, coresRequest, hasNeuron := p.getNeuronCoresFromPod(pod)
+
+		if hasNeuron {
+			metric.AddField(ci.MetricName(ci.TypePod, ci.NeuroncoreRequest), coresRequest)
+			metric.AddField(ci.MetricName(ci.TypePod, ci.NeuroncoreLimit), coresLimit)
+
+			var podNeuroncoreUsageTotal uint64
+			if pod.Status.Phase == corev1.PodRunning {
+				podNeuroncoreUsageTotal = coresLimit
+			}
+			metric.AddField(ci.MetricName(ci.TypePod, ci.NeuroncoreUsageTotal), podNeuroncoreUsageTotal)
+
+			if nodeCapacityCores, ok := p.nodeInfo.getNodeStatusCapacityNeuronCores(); ok && nodeCapacityCores != 0 {
+				reservedCapacity := float64(coresLimit) / float64(nodeCapacityCores) * 100
+				metric.AddField(ci.MetricName(ci.TypePod, ci.NeuroncoreReservedCapacity), reservedCapacity)
 			}
 		}
 	}

--- a/receiver/awscontainerinsightreceiver/internal/stores/utils.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/utils.go
@@ -23,6 +23,9 @@ const (
 	kubeAllowedStringAlphaNums = "bcdfghjklmnpqrstvwxz2456789"
 	cronJobAllowedString       = "0123456789"
 	resourceSpecNvidiaGpuKey   = "nvidia.com/gpu"
+	resourceSpecNeuronKey      = "aws.amazon.com/neuron"
+	resourceSpecNeuroncoreKey  = "aws.amazon.com/neuroncore"
+	resourceSpecNeuronDeviceKey = "aws.amazon.com/neurondevice"
 )
 
 func createPodKeyFromMetaData(pod *corev1.Pod) string {

--- a/receiver/awscontainerinsightreceiver/internal/stores/utils.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/utils.go
@@ -20,11 +20,11 @@ import (
 const (
 	// kubeAllowedStringAlphaNums holds the characters allowed in replicaset names from as parent deployment
 	// https://github.com/kubernetes/apimachinery/blob/master/pkg/util/rand/rand.go#L83
-	kubeAllowedStringAlphaNums = "bcdfghjklmnpqrstvwxz2456789"
-	cronJobAllowedString       = "0123456789"
-	resourceSpecNvidiaGpuKey   = "nvidia.com/gpu"
-	resourceSpecNeuronKey      = "aws.amazon.com/neuron"
-	resourceSpecNeuroncoreKey  = "aws.amazon.com/neuroncore"
+	kubeAllowedStringAlphaNums  = "bcdfghjklmnpqrstvwxz2456789"
+	cronJobAllowedString        = "0123456789"
+	resourceSpecNvidiaGpuKey    = "nvidia.com/gpu"
+	resourceSpecNeuronKey       = "aws.amazon.com/neuron"
+	resourceSpecNeuroncoreKey   = "aws.amazon.com/neuroncore"
 	resourceSpecNeuronDeviceKey = "aws.amazon.com/neurondevice"
 )
 

--- a/receiver/awscontainerinsightreceiver/internal/stores/utils_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/utils_test.go
@@ -67,8 +67,11 @@ type mockNodeInfoProvider struct{}
 func (m *mockNodeInfoProvider) NodeToCapacityMap() map[string]v1.ResourceList {
 	return map[string]v1.ResourceList{
 		"testNode1": {
-			"pods":           *resource.NewQuantity(5, resource.DecimalSI),
-			"nvidia.com/gpu": *resource.NewQuantity(20, resource.DecimalExponent),
+			"pods":                        *resource.NewQuantity(5, resource.DecimalSI),
+			"nvidia.com/gpu":              *resource.NewQuantity(20, resource.DecimalExponent),
+			"aws.amazon.com/neuron":       *resource.NewQuantity(16, resource.DecimalSI),
+			"aws.amazon.com/neuroncore":   *resource.NewQuantity(32, resource.DecimalSI),
+			"aws.amazon.com/neurondevice": *resource.NewQuantity(16, resource.DecimalSI),
 		},
 		"testNode2": {
 			"pods": *resource.NewQuantity(10, resource.DecimalSI),
@@ -79,8 +82,11 @@ func (m *mockNodeInfoProvider) NodeToCapacityMap() map[string]v1.ResourceList {
 func (m *mockNodeInfoProvider) NodeToAllocatableMap() map[string]v1.ResourceList {
 	return map[string]v1.ResourceList{
 		"testNode1": {
-			"pods":           *resource.NewQuantity(15, resource.DecimalSI),
-			"nvidia.com/gpu": *resource.NewQuantity(20, resource.DecimalExponent),
+			"pods":                        *resource.NewQuantity(15, resource.DecimalSI),
+			"nvidia.com/gpu":              *resource.NewQuantity(20, resource.DecimalExponent),
+			"aws.amazon.com/neuron":       *resource.NewQuantity(16, resource.DecimalSI),
+			"aws.amazon.com/neuroncore":   *resource.NewQuantity(32, resource.DecimalSI),
+			"aws.amazon.com/neurondevice": *resource.NewQuantity(16, resource.DecimalSI),
 		},
 		"testNode2": {
 			"pods": *resource.NewQuantity(20, resource.DecimalSI),


### PR DESCRIPTION
## Description

This PR is enhancing metric offering by adding new neuroncore resource allocation metrics

#### Changes:
* Add new node level Neuroncore metrics: "node_neuroncore_limit", "node_neuroncore_usage_total", "node_neuroncore_reserved_capacity", "node_neuroncore_unreserved_capacity", "node_neuroncore_available_capacity"
* Add new pod level Neuroncore metrics: "pod_neuroncore_request", "pod_neuroncore_limit", "pod_neuroncore_usage_total", "pod_neuroncore_reserved_capacity", "pod_neuroncore_available_capacity"
* Add testing for new metrics

## Example Metric Output
<img width="1431" height="235" alt="Screenshot 2025-08-07 at 18 52 47" src="https://github.com/user-attachments/assets/e633c2ba-bbda-4148-b887-e5f327a19dce" />

### EMF Output

```
{
    "AutoScalingGroupName": "eks-trn-managed-nodes-0ccc1bbd-096c-1a2c-a32b-29bb5dc63cb8",
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName",
                    "InstanceId",
                    "NodeName"
                ],
                [
                    "ClusterName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "node_status_condition_disk_pressure",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_number_of_running_containers",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_neuroncore_unreserved_capacity",
                    "Unit": "Percent",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_memory_working_set",
                    "Unit": "Bytes",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_status_condition_pid_pressure",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_status_capacity_pods",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_status_condition_memory_pressure",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_status_condition_unknown",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_neuroncore_usage_total",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_cpu_limit",
                    "Unit": "",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_memory_limit",
                    "Unit": "Bytes",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_cpu_utilization",
                    "Unit": "Percent",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_cpu_usage_total",
                    "Unit": "",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_number_of_running_pods",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_status_condition_ready",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_status_allocatable_pods",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_cpu_reserved_capacity",
                    "Unit": "Percent",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_memory_reserved_capacity",
                    "Unit": "Percent",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_neuroncore_reserved_capacity",
                    "Unit": "Percent",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_memory_utilization",
                    "Unit": "Percent",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_network_total_bytes",
                    "Unit": "Bytes/Second",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_neuroncore_limit",
                    "Unit": "Count",
                    "StorageResolution": 60
                },
                {
                    "Name": "node_neuroncore_available_capacity",
                    "Unit": "Count",
                    "StorageResolution": 60
                }
            ]
        }
    ],
    "ClusterName": "neuron-train",
    "InstanceId": "i-0918fc2d24342cefc",
    "InstanceType": "trn1.32xlarge",
    "NodeName": "ip-192-168-3-146.us-west-2.compute.internal",
    "PlatformType": "AWS::EKS",
    "Sources": [
        "cadvisor",
        "/proc",
        "pod",
        "calculated"
    ],
    "Timestamp": "1754587344522",
    "Type": "Node",
    "Version": "0",
    "kubernetes": {
        "host": "ip-192-168-3-146.us-west-2.compute.internal"
    },
    "node_cpu_request": 1206,
    "node_cpu_usage_system": 12.252071240042845,
    "node_cpu_usage_user": 49.00828496017138,
    "node_memory_cache": 1764864000,
    "node_memory_failcnt": 0,
    "node_memory_failures_total": 1266.1780502309875,
    "node_memory_hierarchical_pgfault": 1266.1780502309875,
    "node_memory_hierarchical_pgmajfault": 0,
    "node_memory_mapped_file": 692404224,
    "node_memory_max_usage": 0,
    "node_memory_pgfault": 1266.1780502309875,
    "node_memory_pgmajfault": 0,
    "node_memory_request": 927989760,
    "node_memory_rss": 730656768,
    "node_memory_swap": 0,
    "node_memory_usage": 2495520768,
    "node_network_rx_bytes": 59777.349161224454,
    "node_network_rx_dropped": 0,
    "node_network_rx_errors": 0,
    "node_network_rx_packets": 58.74459757225876,
    "node_network_tx_bytes": 7711.453638482966,
    "node_network_tx_dropped": 0,
    "node_network_tx_errors": 0,
    "node_network_tx_packets": 32.78654263835465,
    "node_neuroncore_request": 0,
    "node_cpu_limit": 128000,
    "node_cpu_reserved_capacity": 0.9421875,
    "node_cpu_usage_total": 61.260356200214225,
    "node_cpu_utilization": 0.047859653281417364,
    "node_memory_limit": 532520398848,
    "node_memory_reserved_capacity": 0.1742637018239147,
    "node_memory_utilization": 0.24598210675754653,
    "node_memory_working_set": 1309904896,
    "node_network_total_bytes": 67488.80279970742,
    "node_neuroncore_available_capacity": 32,
    "node_neuroncore_limit": 32,
    "node_neuroncore_reserved_capacity": 0,
    "node_neuroncore_unreserved_capacity": 100,
    "node_neuroncore_usage_total": 0,
    "node_number_of_running_containers": 12,
    "node_number_of_running_pods": 11,
    "node_status_allocatable_pods": 250,
    "node_status_capacity_pods": 250,
    "node_status_condition_disk_pressure": 0,
    "node_status_condition_memory_pressure": 0,
    "node_status_condition_pid_pressure": 0,
    "node_status_condition_ready": 1,
    "node_status_condition_unknown": 0
}

```

#### Related PR:
* https://github.com/aws/amazon-cloudwatch-agent/pull/1816
