### PR TITLE
[awscontainerinsightreceiver] Add Ingress metrics

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -130,6 +130,7 @@ const (
 	FailedNodeCount       = "failed_node_count"
 	ContainerRestartCount = "number_of_container_restarts"
 	RunningTaskCount      = "number_of_running_tasks"
+	IngressCount          = "ingress_count"
 
 	DiskIOServiceBytesPrefix = "diskio_io_service_bytes_"
 	DiskIOServicedPrefix     = "diskio_io_serviced_"
@@ -413,5 +414,7 @@ func init() {
 		HyperPodUnschedulablePendingReboot:      UnitCount,
 		HyperPodSchedulable:                     UnitCount,
 		HyperPodUnschedulable:                   UnitCount,
+
+		IngressCount: UnitCount,
 	}
 }

--- a/internal/aws/k8s/k8sclient/ingress.go
+++ b/internal/aws/k8s/k8sclient/ingress.go
@@ -1,0 +1,146 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"go.uber.org/zap"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+type IngressClient interface {
+	GetIngressMetrics() *IngressMetrics
+}
+
+type IngressMetrics struct {
+	NamespaceCount map[string]int
+}
+
+type noOpIngressClient struct{}
+
+func (n *noOpIngressClient) GetIngressMetrics() *IngressMetrics {
+	return &IngressMetrics{
+		NamespaceCount: make(map[string]int),
+	}
+}
+
+func (n *noOpIngressClient) shutdown() {
+}
+
+type ingressClientOption func(*ingressClient)
+
+func ingressSyncCheckerOption(checker initialSyncChecker) ingressClientOption {
+	return func(c *ingressClient) {
+		c.syncChecker = checker
+	}
+}
+
+type ingressClient struct {
+	stopChan chan struct{}
+	stopped  bool
+
+	store *ObjStore
+
+	syncChecker initialSyncChecker
+
+	mu      sync.RWMutex
+	metrics *IngressMetrics
+}
+
+func (d *ingressClient) refresh() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	metrics := &IngressMetrics{
+		NamespaceCount: make(map[string]int),
+	}
+	objsList := d.store.List()
+	for _, obj := range objsList {
+		igInfo, ok := obj.(*IngressInfo)
+		if !ok {
+			continue
+		}
+		metrics.NamespaceCount[igInfo.Namespace]++
+	}
+
+	d.metrics = metrics
+}
+
+func (d *ingressClient) GetIngressMetrics() *IngressMetrics {
+	if d.store.GetResetRefreshStatus() {
+		d.refresh()
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.metrics
+}
+
+func (d *ingressClient) shutdown() {
+	close(d.stopChan)
+	d.stopped = true
+}
+
+func newIngressClient(clientSet kubernetes.Interface, logger *zap.Logger, options ...ingressClientOption) (*ingressClient, error) {
+	d := &ingressClient{
+		stopChan: make(chan struct{}),
+		metrics: &IngressMetrics{
+			NamespaceCount: make(map[string]int),
+		},
+	}
+
+	for _, option := range options {
+		option(d)
+	}
+
+	ctx := context.Background()
+	if _, err := clientSet.NetworkingV1().Ingresses(metav1.NamespaceAll).List(ctx, metav1.ListOptions{}); err != nil {
+		return nil, fmt.Errorf("failed to list ingress. err: %w", err)
+	}
+
+	d.store = NewObjStore(transformFuncIngress, logger)
+	lw := createIngressListWatch(clientSet, metav1.NamespaceAll)
+	reflector := cache.NewReflector(lw, &networkingv1.Ingress{}, d.store, 0)
+
+	go reflector.Run(d.stopChan)
+
+	if d.syncChecker != nil {
+		// check the init sync for potential connection issue
+		d.syncChecker.Check(reflector, "Ingress initial sync timeout")
+	}
+
+	return d, nil
+}
+
+func transformFuncIngress(obj any) (any, error) {
+	ingress, ok := obj.(*networkingv1.Ingress)
+	if !ok {
+		return nil, fmt.Errorf("object is not an ingress: %+v", obj)
+	}
+	info := &IngressInfo{
+		Name:      ingress.Name,
+		Namespace: ingress.Namespace,
+	}
+	return info, nil
+}
+
+func createIngressListWatch(client kubernetes.Interface, ns string) cache.ListerWatcher {
+	ctx := context.Background()
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return client.NetworkingV1().Ingresses(ns).List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return client.NetworkingV1().Ingresses(ns).Watch(ctx, opts)
+		},
+	}
+}

--- a/internal/aws/k8s/k8sclient/ingress_info.go
+++ b/internal/aws/k8s/k8sclient/ingress_info.go
@@ -1,0 +1,9 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+
+type IngressInfo struct {
+	Name      string
+	Namespace string
+}

--- a/internal/aws/k8s/k8sclient/ingress_test.go
+++ b/internal/aws/k8s/k8sclient/ingress_test.go
@@ -1,0 +1,114 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// createTestIngress creates a test ingress object with the given name and namespace
+func createTestIngress(name, namespace string) *networkingv1.Ingress {
+	return &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       types.UID(name + "-uid"),
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: name + ".example.com",
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path: "/",
+									PathType: func() *networkingv1.PathType {
+										pt := networkingv1.PathTypePrefix
+										return &pt
+									}(),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+var ingressObjects = []runtime.Object{
+	createTestIngress("ingress-1", "default"),
+	createTestIngress("ingress-2", "kube-system"),
+	createTestIngress("ingress-3", "default"),
+}
+
+func TestIngressClient_GetIngressMetrics(t *testing.T) {
+	setOption := ingressSyncCheckerOption(&mockReflectorSyncChecker{})
+	fakeClientSet := fake.NewSimpleClientset(ingressObjects...)
+	client, err := newIngressClient(fakeClientSet, zap.NewNop(), setOption)
+	assert.NoError(t, err)
+
+	ingresses := make([]any, len(ingressObjects))
+	for i := range ingressObjects {
+		ingresses[i] = ingressObjects[i]
+	}
+	assert.NoError(t, client.store.Replace(ingresses, ""))
+
+	metrics := client.GetIngressMetrics()
+	assert.NotNil(t, metrics)
+	assert.Len(t, metrics.NamespaceCount, 2)
+	assert.Equal(t, 2, metrics.NamespaceCount["default"])
+	assert.Equal(t, 1, metrics.NamespaceCount["kube-system"])
+
+	client.shutdown()
+	assert.True(t, client.stopped)
+}
+
+func TestIngressClient_EmptyStore(t *testing.T) {
+	setOption := ingressSyncCheckerOption(&mockReflectorSyncChecker{})
+	fakeClientSet := fake.NewSimpleClientset()
+	client, err := newIngressClient(fakeClientSet, zap.NewNop(), setOption)
+	assert.NoError(t, err)
+
+	// Test with empty store
+	metrics := client.GetIngressMetrics()
+	assert.NotNil(t, metrics)
+	assert.Empty(t, metrics.NamespaceCount)
+
+	client.shutdown()
+}
+
+func TestTransformFuncIngress(t *testing.T) {
+	info, err := transformFuncIngress(nil)
+	assert.Nil(t, info)
+	assert.Error(t, err)
+
+	ingress := createTestIngress("test-ingress", "test-namespace")
+
+	result, err := transformFuncIngress(ingress)
+	assert.NoError(t, err)
+
+	ingressInfo, ok := result.(*IngressInfo)
+	assert.True(t, ok)
+	assert.Equal(t, "test-ingress", ingressInfo.Name)
+	assert.Equal(t, "test-namespace", ingressInfo.Namespace)
+}
+
+func TestNoOpIngressClient(t *testing.T) {
+	client := &noOpIngressClient{}
+	metrics := client.GetIngressMetrics()
+	assert.NotNil(t, metrics)
+	assert.Empty(t, metrics.NamespaceCount)
+
+	client.shutdown()
+}

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/leaderelection.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/leaderelection.go
@@ -44,6 +44,7 @@ type LeaderElection struct {
 	replicaSetClient            k8sclient.ReplicaSetClient
 	persistentVolumeClaimClient k8sclient.PersistentVolumeClaimClient
 	persistentVolumeClient      k8sclient.PersistentVolumeClient
+	ingressClient               k8sclient.IngressClient
 
 	// the following can be set to mocks in testing
 	broadcaster eventBroadcaster
@@ -184,6 +185,7 @@ func (le *LeaderElection) startLeaderElection(ctx context.Context, lock resource
 					le.replicaSetClient = le.k8sClient.GetReplicaSetClient()
 					le.persistentVolumeClaimClient = le.k8sClient.GetPersistentVolumeClaimClient()
 					le.persistentVolumeClient = le.k8sClient.GetPersistentVolumeClient()
+					le.ingressClient = le.k8sClient.GetIngressClient()
 					le.mu.Unlock()
 
 					if le.isLeadingC != nil {


### PR DESCRIPTION
# Ingress Metrics

## Overview

This PR introduces monitoring support for Kubernetes Ingress resources in the AWS Container Insights receiver.

---
## EMF Logs
```
{
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName",
                    "Namespace"
                ],
                [
                    "ClusterName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "namespace_number_of_running_pods",
                    "Unit": "Count",
                    "StorageResolution": 60
                }
            ]
        },
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName"
                ],
                [
                    "ClusterName",
                    "Namespace"
                ]
            ],
            "Metrics": [
                {
                    "Name": "ingress_resource_count",
                    "Unit": "Count",
                    "StorageResolution": 60
                }
            ]
        }
    ],
    "ClusterName": "basic-cluster",
    "Namespace": "default",
    "NodeName": "ip-192-168-24-31.ec2.internal",
    "PlatformType": "AWS::EKS",
    "Sources": [
        "apiserver"
    ],
    "Timestamp": "1756373143811",
    "Type": "ClusterNamespace",
    "Version": "0",
    "kubernetes": {
        "namespace_name": "default"
    },
    "ingress_resource_count": 4,
    "namespace_number_of_running_pods": 9
}
```
---
## Graphs
<img width="903" height="176" alt="image" src="https://github.com/user-attachments/assets/1ec7f00c-177d-408a-9701-2c32ba613416" />
<img width="756" height="269" alt="image" src="https://github.com/user-attachments/assets/d1745405-05d8-4934-a9cc-572c3cfcf84b" />
