### PR TITLE
Fix duplicate metrics

### DIFF
--- a/receiver/awscontainerinsightskueuereceiver/internal/kueuescraper/kueue_prometheus_scraper.go
+++ b/receiver/awscontainerinsightskueuereceiver/internal/kueuescraper/kueue_prometheus_scraper.go
@@ -148,6 +148,11 @@ func NewKueuePrometheusScraper(opts KueuePrometheusScraperOpts) (*KueuePrometheu
 
 func GetKueueRelabelConfigs(clusterName string) []*relabel.Config {
 	relabelConfigs := []*relabel.Config{
+		{ // Keep only if target's node matches the collector's node
+			Action:       relabel.Keep,
+			SourceLabels: model.LabelNames{"__meta_kubernetes_endpoint_node_name"},
+			Regex:        relabel.MustNewRegexp("${K8S_NODE_NAME}"),
+		},
 		{ // filter by metric name: keep only the Kueue metrics specified via regex in `kueueMetricAllowList`
 			Action:       relabel.Keep,
 			Regex:        relabel.MustNewRegexp(kueueMetricsAllowRegex),


### PR DESCRIPTION
#### Description
Fix duplicate metrics issue in KueuePrometheusScrapers. Previously, the scraper was incorrectly handling the Kueue metrics collection, resulting in duplicate metrics being reported. This change updates the scraper logic to properly handle metric collection and ensures each metric is reported only once.

#### Link to tracking issue
Fixes duplicate metrics reporting in Kueue Prometheus scraper

#### Testing
- Deployed and tested in personal AWS account
- Verified metrics are collected correctly without duplication
- Monitored metrics flow in CloudWatch to confirm fix