### PR TITLE
Handle edge case for ecs observer job relabel

### DIFF
--- a/extension/observer/ecsobserver/README.md
+++ b/extension/observer/ecsobserver/README.md
@@ -33,6 +33,7 @@ extensions:
     cluster_name: 'Cluster-1' # cluster name need manual config
     cluster_region: 'us-west-2' # region can be configured directly or use AWS_REGION env var
     result_file: '/etc/ecs_sd_targets.yaml' # the directory for file must already exists
+    job_label_name: 'prometheus_job' # optional: override for job label name
     services:
       - name_pattern: '^retail-.*$'
     docker_labels:
@@ -86,6 +87,7 @@ service:
 | cluster_region   | Mandatory | target ECS cluster's AWS region name                                                                                |
 | refresh_interval | Optional  | how often to look for changes in endpoints (default: 10s)                                                           |
 | result_file      | Mandatory | path of YAML file to write scrape target results. NOTE: the observer always returns empty in initial implementation |
+| job_label_name   | Optional  | override for prometheus job label name. If empty or set to "job", no behavior change.                               |
 | services         | Optional  | list of service name patterns [detail](#ecs-service-name-based-filter-configuration)                                |
 | task_definitions | Optional  | list of task definition arn patterns [detail](#ecs-task-definition-based-filter-configuration)                      |
 | docker_labels    | Optional  | list of docker labels [detail](#docker-label-based-filter-configuration)                                            |
@@ -302,6 +304,15 @@ Required for prometheus to scrape the target.
 | `__address__`       | ECS Task and TaskDefinition  | string | `host:port` `host` is private ip from ECS Task, `port` is the mapped port |
 | ` __metrics_path__` | ECS TaskDefinition or Config | string | Default is `/metrics`, changes based on config/label                      |
 | `job`               | ECS TaskDefinition or Config | string | Name for scrape job                                                       |
+
+### Job Label Behavior
+
+The `job_label_name` configuration controls how job labels are handled in the targets printed to the results file:
+
+- **Empty or unset or set to "job"**: Preserves the original `job` label from Docker labels or task definitions
+- **Set to custom name**: Renames the `job` label to the specified name (e.g., `prometheus_job`)
+
+This renaming works around Prometheus receiver limitations where the `job` label conflicts with internal processing.
 
 ### Additional Labels
 

--- a/extension/observer/ecsobserver/sd_test.go
+++ b/extension/observer/ecsobserver/sd_test.go
@@ -173,6 +173,41 @@ func TestNewDiscovery(t *testing.T) {
 		assert.Equal(t, string(expectedContent), string(mustReadFile(t, outputFile)))
 	})
 
+	t.Run("job_label_name_empty_string", func(t *testing.T) {
+		cfg2 := cfg
+		cfg2.JobLabelName = ""
+
+		sd, err := newDiscovery(cfg2, opts)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg2.RefreshInterval*2)
+		defer cancel()
+		err = sd.runAndWriteFile(ctx)
+		require.NoError(t, err)
+
+		assert.FileExists(t, outputFile)
+		expectedFile := "testdata/ut_targets_expected_no_job_relabel.yaml"
+		expectedContent := bytes.ReplaceAll(mustReadFile(t, expectedFile), []byte("\r\n"), []byte("\n"))
+		assert.Equal(t, string(expectedContent), string(mustReadFile(t, outputFile)))
+	})
+
+	t.Run("job_label_name_is_job", func(t *testing.T) {
+		cfg2 := cfg
+		cfg2.JobLabelName = "job"
+		sd, err := newDiscovery(cfg2, opts)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg2.RefreshInterval*2)
+		defer cancel()
+		err = sd.runAndWriteFile(ctx)
+		require.NoError(t, err)
+
+		assert.FileExists(t, outputFile)
+		expectedFile := "testdata/ut_targets_expected_no_job_relabel.yaml"
+		expectedContent := bytes.ReplaceAll(mustReadFile(t, expectedFile), []byte("\r\n"), []byte("\n"))
+		assert.Equal(t, string(expectedContent), string(mustReadFile(t, outputFile)))
+	})
+
 	t.Run("fail to write file", func(t *testing.T) {
 		cfg2 := cfg
 		cfg2.ResultFile = "testdata/folder/does/not/exists/ut_targets.yaml"

--- a/extension/observer/ecsobserver/target.go
+++ b/extension/observer/ecsobserver/target.go
@@ -158,7 +158,7 @@ func targetsToFileSDTargets(targets []prometheusECSTarget, jobLabelName string) 
 		// We can't relabel it using prometheus's relabel config as it would cause the same problem on receiver.
 		// We 'relabel' it to job outside prometheus receiver using other processors in collector's pipeline.
 		job := labels[labelJob]
-		if job != "" && jobLabelName != labelJob {
+		if job != "" && jobLabelName != "" && jobLabelName != labelJob {
 			delete(labels, labelJob)
 			labels[jobLabelName] = job
 		}

--- a/extension/observer/ecsobserver/target_test.go
+++ b/extension/observer/ecsobserver/target_test.go
@@ -22,3 +22,58 @@ func TestTargetToLabels(t *testing.T) {
 		assert.Equal(t, "same", m["__meta_ecs_task_tags_ab"])
 	})
 }
+
+func TestTargetsToFileSDTargets(t *testing.T) {
+	targets := []prometheusECSTarget{
+		{
+			Address: "192.168.1.1:9090",
+			Job:     "test-job",
+		},
+	}
+
+	t.Run("job label renamed when custom job_label_name provided", func(t *testing.T) {
+		result, err := targetsToFileSDTargets(targets, "prometheus_job")
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		
+		labels := result[0].Labels
+		assert.Equal(t, "test-job", labels["prometheus_job"])
+		assert.NotContains(t, labels, "job")
+	})
+
+	t.Run("job label kept when job_label_name is 'job'", func(t *testing.T) {
+		result, err := targetsToFileSDTargets(targets, "job")
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		
+		labels := result[0].Labels
+		assert.Equal(t, "test-job", labels["job"])
+		assert.NotContains(t, labels, "prometheus_job")
+	})
+
+	t.Run("job label kept when job_label_name is empty string", func(t *testing.T) {
+		result, err := targetsToFileSDTargets(targets, "")
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		
+		labels := result[0].Labels
+		assert.Equal(t, "test-job", labels["job"])
+		assert.NotContains(t, labels, "")
+	})
+
+	t.Run("no job relabeling when job is empty", func(t *testing.T) {
+		emptyJobTargets := []prometheusECSTarget{
+			{
+				Address: "192.168.1.1:9090",
+				Job:     "",
+			},
+		}
+		result, err := targetsToFileSDTargets(emptyJobTargets, "prometheus_job")
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		
+		labels := result[0].Labels
+		assert.NotContains(t, labels, "job")
+		assert.NotContains(t, labels, "prometheus_job")
+	})
+}

--- a/extension/observer/ecsobserver/target_test.go
+++ b/extension/observer/ecsobserver/target_test.go
@@ -35,7 +35,7 @@ func TestTargetsToFileSDTargets(t *testing.T) {
 		result, err := targetsToFileSDTargets(targets, "prometheus_job")
 		assert.NoError(t, err)
 		assert.Len(t, result, 1)
-		
+
 		labels := result[0].Labels
 		assert.Equal(t, "test-job", labels["prometheus_job"])
 		assert.NotContains(t, labels, "job")
@@ -45,7 +45,7 @@ func TestTargetsToFileSDTargets(t *testing.T) {
 		result, err := targetsToFileSDTargets(targets, "job")
 		assert.NoError(t, err)
 		assert.Len(t, result, 1)
-		
+
 		labels := result[0].Labels
 		assert.Equal(t, "test-job", labels["job"])
 		assert.NotContains(t, labels, "prometheus_job")
@@ -55,7 +55,7 @@ func TestTargetsToFileSDTargets(t *testing.T) {
 		result, err := targetsToFileSDTargets(targets, "")
 		assert.NoError(t, err)
 		assert.Len(t, result, 1)
-		
+
 		labels := result[0].Labels
 		assert.Equal(t, "test-job", labels["job"])
 		assert.NotContains(t, labels, "")
@@ -71,7 +71,7 @@ func TestTargetsToFileSDTargets(t *testing.T) {
 		result, err := targetsToFileSDTargets(emptyJobTargets, "prometheus_job")
 		assert.NoError(t, err)
 		assert.Len(t, result, 1)
-		
+
 		labels := result[0].Labels
 		assert.NotContains(t, labels, "job")
 		assert.NotContains(t, labels, "prometheus_job")

--- a/extension/observer/ecsobserver/testdata/ut_targets_expected_no_job_relabel.yaml
+++ b/extension/observer/ecsobserver/testdata/ut_targets_expected_no_job_relabel.yaml
@@ -1,0 +1,362 @@
+- targets:
+  - 172.168.1.0:2113
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_health_status: ""
+    __meta_ecs_source: t0
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: FARGATE
+    __meta_ecs_task_started_by: deploy0
+    __metrics_path__: /new/metrics
+    job: PROM_JOB_1
+- targets:
+  - 172.168.1.1:2113
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_health_status: ""
+    __meta_ecs_source: t1
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: FARGATE
+    __meta_ecs_task_started_by: deploy0
+    __metrics_path__: /new/metrics
+    job: PROM_JOB_1
+- targets:
+  - 172.168.2.1:2117
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-1
+    __meta_ecs_ec2_private_ip: 172.168.2.1
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni1
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t3
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /metrics
+- targets:
+  - 172.168.2.1:2117
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-1
+    __meta_ecs_ec2_private_ip: 172.168.2.1
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni1
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t3
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /new/metrics
+    job: PROM_JOB_1
+- targets:
+  - 172.168.2.0:2118
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-0
+    __meta_ecs_ec2_private_ip: 172.168.2.0
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni0
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t4
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /metrics
+- targets:
+  - 172.168.2.0:2118
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-0
+    __meta_ecs_ec2_private_ip: 172.168.2.0
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni0
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t4
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /new/metrics
+    job: PROM_JOB_1
+- targets:
+  - 172.168.2.1:2119
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-1
+    __meta_ecs_ec2_private_ip: 172.168.2.1
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni1
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t5
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /metrics
+- targets:
+  - 172.168.2.1:2119
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-1
+    __meta_ecs_ec2_private_ip: 172.168.2.1
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni1
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t5
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /new/metrics
+    job: PROM_JOB_1
+- targets:
+  - 172.168.2.0:2120
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-0
+    __meta_ecs_ec2_private_ip: 172.168.2.0
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni0
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t6
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /metrics
+- targets:
+  - 172.168.2.0:2120
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-0
+    __meta_ecs_ec2_private_ip: 172.168.2.0
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni0
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t6
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /new/metrics
+    job: PROM_JOB_1
+- targets:
+  - 172.168.2.1:2121
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-1
+    __meta_ecs_ec2_private_ip: 172.168.2.1
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni1
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t7
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /metrics
+- targets:
+  - 172.168.2.1:2121
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-1
+    __meta_ecs_ec2_private_ip: 172.168.2.1
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni1
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t7
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /new/metrics
+    job: PROM_JOB_1
+- targets:
+  - 172.168.2.0:2122
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-0
+    __meta_ecs_ec2_private_ip: 172.168.2.0
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni0
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t8
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /metrics
+- targets:
+  - 172.168.2.0:2122
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-0
+    __meta_ecs_ec2_private_ip: 172.168.2.0
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni0
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t8
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /new/metrics
+    job: PROM_JOB_1
+- targets:
+  - 172.168.2.1:2123
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-1
+    __meta_ecs_ec2_private_ip: 172.168.2.1
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni1
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t9
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /metrics
+- targets:
+  - 172.168.2.1:2123
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-1
+    __meta_ecs_ec2_private_ip: 172.168.2.1
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni1
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t9
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /new/metrics
+    job: PROM_JOB_1
+- targets:
+  - 172.168.2.0:2124
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-0
+    __meta_ecs_ec2_private_ip: 172.168.2.0
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni0
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t10
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /metrics
+- targets:
+  - 172.168.2.0:2124
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-0
+    __meta_ecs_ec2_private_ip: 172.168.2.0
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni0
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t10
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /new/metrics
+    job: PROM_JOB_1


### PR DESCRIPTION
#### Description
Bug fix: When "job" label is scraped from Docker Labels or ECS Task Definitions, the label is renamed to configured value of `job_label_name`. This `job_label_name` is identified as optional, but did not handle empty input. Bug fix now handles empty input

#### Link to tracking issue
Internal

#### Testing
All unit tests pass. Introduced additional ECS Observer scenarios to validate result file acts as expected.

#### Documentation
Updated README
