### PR TITLE
[awscontainerinsightreceiver] Enable container-level disk I/O metrics with workload and volume aggregation dimensions

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -35,6 +35,12 @@ const (
 	OperatingSystem         = "OperatingSystem"
 	OperatingSystemWindows  = "windows"
 
+	VolumeName                = "VolumeName"
+	PersistentVolumeClaimName = "PersistentVolumeClaimName"
+	StorageClass              = "StorageClass"
+	WorkloadName              = "WorkloadName"
+	WorkloadKind              = "WorkloadKind"
+
 	// The following constants are used for metric name construction
 	CPUTotal                         = "cpu_usage_total"
 	CPUUser                          = "cpu_usage_user"

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/diskio_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/diskio_extractor.go
@@ -27,7 +27,7 @@ func (d *DiskIOMetricExtractor) HasValue(info *cInfo.ContainerInfo) bool {
 
 func (d *DiskIOMetricExtractor) GetValue(info *cInfo.ContainerInfo, _ CPUMemInfoProvider, containerType string) []*stores.CIMetricImpl {
 	var metrics []*stores.CIMetricImpl
-	if containerType != ci.TypeNode && containerType != ci.TypeInstance {
+	if containerType != ci.TypeNode && containerType != ci.TypeInstance && containerType != ci.TypeContainer {
 		return metrics
 	}
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/diskio_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/diskio_extractor_test.go
@@ -6,8 +6,8 @@ package extractors
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils"
@@ -19,7 +19,7 @@ func TestDiskIOStats(t *testing.T) {
 	result2 := testutils.LoadContainerInfo(t, "./testdata/CurInfoContainer.json")
 	// for eks node-level metrics
 	containerType := containerinsight.TypeNode
-	extractor := NewDiskIOMetricExtractor(nil)
+	extractor := NewDiskIOMetricExtractor(zap.NewNop())
 
 	var cMetrics []*stores.CIMetricImpl
 	if extractor.HasValue(result[0]) {
@@ -54,7 +54,7 @@ func TestDiskIOStats(t *testing.T) {
 	// for ecs node-level metrics
 	containerType = containerinsight.TypeInstance
 	require.NoError(t, extractor.Shutdown())
-	extractor = NewDiskIOMetricExtractor(nil)
+	extractor = NewDiskIOMetricExtractor(zap.NewNop())
 
 	if extractor.HasValue(result[0]) {
 		cMetrics = extractor.GetValue(result[0], nil, containerType)
@@ -85,10 +85,10 @@ func TestDiskIOStats(t *testing.T) {
 	AssertContainsTaggedField(t, cMetrics[0], expectedFieldsService, expectedTags)
 	AssertContainsTaggedField(t, cMetrics[1], expectedFieldsServiced, expectedTags)
 
-	// for non supported type
-	containerType = containerinsight.TypeContainerDiskIO
+	// for container-level metrics
+	containerType = containerinsight.TypeContainer
 	require.NoError(t, extractor.Shutdown())
-	extractor = NewDiskIOMetricExtractor(nil)
+	extractor = NewDiskIOMetricExtractor(zap.NewNop())
 	defer require.NoError(t, extractor.Shutdown())
 	if extractor.HasValue(result[0]) {
 		cMetrics = extractor.GetValue(result[0], nil, containerType)
@@ -98,5 +98,24 @@ func TestDiskIOStats(t *testing.T) {
 		cMetrics = extractor.GetValue(result2[0], nil, containerType)
 	}
 
-	assert.Empty(t, cMetrics)
+	expectedFieldsService = map[string]any{
+		"container_diskio_io_service_bytes_write": float64(10000),
+		"container_diskio_io_service_bytes_total": float64(10010),
+		"container_diskio_io_service_bytes_async": float64(10000),
+		"container_diskio_io_service_bytes_sync":  float64(10000),
+		"container_diskio_io_service_bytes_read":  float64(10),
+	}
+	expectedFieldsServiced = map[string]any{
+		"container_diskio_io_serviced_async": float64(10),
+		"container_diskio_io_serviced_sync":  float64(10),
+		"container_diskio_io_serviced_read":  float64(10),
+		"container_diskio_io_serviced_write": float64(10),
+		"container_diskio_io_serviced_total": float64(20),
+	}
+	expectedTags = map[string]string{
+		"device": "/dev/xvda",
+		"Type":   "ContainerDiskIO",
+	}
+	AssertContainsTaggedField(t, cMetrics[0], expectedFieldsService, expectedTags)
+	AssertContainsTaggedField(t, cMetrics[1], expectedFieldsServiced, expectedTags)
 }

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor.go
@@ -100,6 +100,9 @@ func getMetricKey(metric *stores.CIMetricImpl) string {
 	case ci.TypeNodeDiskIO:
 		// merge io_serviced, io_service_bytes for type NodeDiskIO
 		metricKey = fmt.Sprintf("metricType:%s,device:%s", ci.TypeNodeDiskIO, metric.GetTags()[ci.DiskDev])
+	case ci.TypeContainerDiskIO:
+		// merge io_serviced, io_service_bytes for type ContainerDiskIO
+		metricKey = fmt.Sprintf("metricType:%s,podId:%s,containerName:%s,device:%s", ci.TypeContainerDiskIO, metric.GetTags()[ci.PodIDKey], metric.GetTags()[ci.ContainerNamekey], metric.GetTags()[ci.DiskDev])
 	default:
 		metricKey = ""
 	}

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -247,6 +247,7 @@ func (p *PodStore) Decorate(ctx context.Context, metric CIMetric, kubernetesBlob
 		p.decorateCPU(metric, &entry.pod)
 		p.decorateMem(metric, &entry.pod)
 		p.decorateGPU(metric, &entry.pod)
+		p.decorateDiskIO(metric, &entry.pod)
 		p.addStatus(metric, &entry.pod)
 		addContainerCount(metric, &entry.pod)
 		addContainerID(&entry.pod, metric, kubernetesBlob, p.logger)
@@ -524,6 +525,159 @@ func (p *PodStore) decorateMem(metric CIMetric, pod *corev1.Pod) {
 				}
 			}
 		}
+	}
+}
+
+func (p *PodStore) decorateDiskIO(metric CIMetric, pod *corev1.Pod) {
+	metricType := metric.GetTag(ci.MetricType)
+
+	// Only decorate container-level disk I/O metrics
+	if metricType != ci.TypeContainerDiskIO {
+		p.logger.Debug("Not a container disk I/O metric", zap.String("metricType", metricType))
+		return
+	}
+
+	containerName := metric.GetTag(ci.ContainerNamekey)
+	if containerName == "" {
+		p.logger.Debug("No container name found")
+		return
+	}
+
+	deviceName := metric.GetTag(ci.DiskDev)
+	if deviceName == "" {
+		p.logger.Debug("No device name found")
+		return
+	}
+
+	// Find the container in the pod spec
+	var containerSpec *corev1.Container
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == containerName {
+			containerSpec = &pod.Spec.Containers[i]
+			break
+		}
+	}
+
+	if containerSpec == nil {
+		return
+	}
+	// Try to find the PVC that corresponds to this device
+	pvcName, volumeName := p.findPVCForDevice(deviceName, containerSpec, pod)
+
+	if pvcName != "" {
+		// Add PVC tags for aggregation
+		metric.AddTag(ci.PersistentVolumeClaimName, pvcName)
+		metric.AddTag(ci.VolumeName, volumeName)
+
+		// Add workload information
+		p.addWorkloadTags(metric, pod)
+	} else {
+		p.logger.Debug("Could not find PVC for disk I/O metric",
+			zap.String("containerName", containerName),
+			zap.String("deviceName", deviceName),
+			zap.String("podName", pod.Name))
+	}
+}
+
+// findPVCForDevice finds the PVC that corresponds to the given device
+func (p *PodStore) findPVCForDevice(deviceName string, containerSpec *corev1.Container, pod *corev1.Pod) (string, string) {
+	// Create a map of volume names to PVC info for quick lookup
+	volumeToPVC := make(map[string]struct {
+		pvcName    string
+		volumeName string
+	})
+
+	for _, volume := range pod.Spec.Volumes {
+		if volume.PersistentVolumeClaim != nil {
+			volumeToPVC[volume.Name] = struct {
+				pvcName    string
+				volumeName string
+			}{
+				pvcName:    volume.PersistentVolumeClaim.ClaimName,
+				volumeName: volume.Name,
+			}
+		}
+	}
+
+	// If there are no PVCs, return empty
+	if len(volumeToPVC) == 0 {
+		return "", ""
+	}
+
+	// Check VolumeDevices (block devices) - these have explicit device paths
+	for _, volumeDevice := range containerSpec.VolumeDevices {
+		if pvcInfo, exists := volumeToPVC[volumeDevice.Name]; exists {
+			// For block devices, check if the device name matches the device path
+			if p.devicePathMatches(deviceName, volumeDevice.DevicePath) {
+				return pvcInfo.pvcName, pvcInfo.volumeName
+			}
+		}
+	}
+
+	// Check VolumeMounts (filesystem mounts) - most PVCs use this approach
+	// Since we can't directly correlate device names to mount paths,
+	// we use a heuristic: if the container has volume mounts to PVCs,
+	// and there's only one PVC, assume the disk I/O belongs to that PVC
+	hasVolumeMount := false
+	for _, volumeMount := range containerSpec.VolumeMounts {
+		if _, exists := volumeToPVC[volumeMount.Name]; exists {
+			hasVolumeMount = true
+			break
+		}
+	}
+
+	// If container has volume mounts to PVCs and there's only one PVC,
+	// we can safely assume the disk I/O belongs to that PVC
+	if hasVolumeMount && len(volumeToPVC) == 1 {
+		for _, pvcInfo := range volumeToPVC {
+			return pvcInfo.pvcName, pvcInfo.volumeName
+		}
+	}
+
+	return "", ""
+}
+
+// devicePathMatches checks if a device name corresponds to a device path
+func (p *PodStore) devicePathMatches(deviceName, devicePath string) bool {
+	// Extract the device name from the path (e.g., /dev/sdb -> sdb)
+	deviceFromPath := strings.TrimPrefix(devicePath, "/dev/")
+
+	// Check for exact match or if one contains the other
+	return deviceName == deviceFromPath ||
+		strings.Contains(deviceName, deviceFromPath) ||
+		strings.Contains(deviceFromPath, deviceName)
+}
+
+// addWorkloadTags adds workload information tags to the metric
+func (p *PodStore) addWorkloadTags(metric CIMetric, pod *corev1.Pod) {
+	if len(pod.OwnerReferences) > 0 {
+		owner := pod.OwnerReferences[0]
+		workloadKind := owner.Kind
+		workloadName := owner.Name
+
+		// Use the same logic as addPodOwnersAndPodName for consistency
+		switch owner.Kind {
+		case ci.ReplicaSet:
+			if p.k8sClient != nil {
+				replicaSetClient := p.k8sClient.GetReplicaSetClient()
+				rsToDeployment := replicaSetClient.ReplicaSetToDeployment()
+				if parent := rsToDeployment[owner.Name]; parent != "" {
+					workloadKind = ci.Deployment
+					workloadName = parent
+				} else if parent := parseDeploymentFromReplicaSet(owner.Name); parent != "" {
+					workloadKind = ci.Deployment
+					workloadName = parent
+				}
+			}
+		case ci.Job:
+			if parent := parseCronJobFromJob(owner.Name); parent != "" {
+				workloadKind = ci.CronJob
+				workloadName = parent
+			}
+		}
+
+		metric.AddTag(ci.WorkloadKind, workloadKind)
+		metric.AddTag(ci.WorkloadName, workloadName)
 	}
 }
 


### PR DESCRIPTION
## Summary

  - Enabled container-level disk I/O metric collection in the diskio extractor
  - Added labeling for `WorkloadKind`, `WorkloadName`, `PersistentVolumeClaimName`, and `VolumeName` dimensions
  - Enables metric aggregation at workload and volume levels for better observability of containerized storage
  usage

##  Metric Aggregation Support

  This enables the CloudWatch Agent to aggregate container disk I/O metrics across multiple dimensions:
```
{
	Dimensions: [][]string{
		{"ClusterName"},
		{"ClusterName", "Namespace"},
		{"ClusterName", "Namespace", "WorkloadKind", "WorkloadName"},
		{"ClusterName", "Namespace", "WorkloadKind", "WorkloadName", "PodName"},
		{"ClusterName", "Namespace", "PersistentVolumeClaimName"},
		{"ClusterName", "Namespace", "PersistentVolumeClaimName", "VolumeName"},
		{"ClusterName", "Namespace", "PodName", "PersistentVolumeClaimName"},
		{"ClusterName", "Namespace", "FullPodName", "PodName", "ContainerName"},
	},
	MetricNameSelectors: []string{
		"container_diskio_io_service_bytes_read", "container_diskio_io_service_bytes_write", "container_diskio_io_service_bytes_total",
		"container_diskio_io_serviced_read", "container_diskio_io_serviced_write", "container_diskio_io_serviced_total",
	},
},
```

  The added labels allow the metric processor to create aggregated views of storage performance at the workload
  and persistent volume level, providing better insights into application storage usage patterns.
---
## EMF Log
```
{
    "AutoScalingGroupName": "eks-x86-nodes-48cc60c7-0841-0374-79c5-e02a81a6cc8f",
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName"
                ],
                [
                    "ClusterName",
                    "Namespace"
                ],
                [
                    "ClusterName",
                    "Namespace",
                    "WorkloadKind",
                    "WorkloadName"
                ],
                [
                    "ClusterName",
                    "Namespace",
                    "PodName",
                    "WorkloadKind",
                    "WorkloadName"
                ],
                [
                    "ClusterName",
                    "Namespace",
                    "PersistentVolumeClaimName"
                ],
                [
                    "ClusterName",
                    "Namespace",
                    "PersistentVolumeClaimName",
                    "VolumeName"
                ],
                [
                    "ClusterName",
                    "Namespace",
                    "PersistentVolumeClaimName",
                    "PodName"
                ],
                [
                    "ClusterName",
                    "ContainerName",
                    "FullPodName",
                    "Namespace",
                    "PodName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "container_diskio_io_service_bytes_write",
                    "Unit": "Bytes/Second",
                    "StorageResolution": 60
                },
                {
                    "Name": "container_diskio_io_serviced_read",
                    "Unit": "Count/Second",
                    "StorageResolution": 60
                },
                {
                    "Name": "container_diskio_io_serviced_write",
                    "Unit": "Count/Second",
                    "StorageResolution": 60
                },
                {
                    "Name": "container_diskio_io_service_bytes_read",
                    "Unit": "Bytes/Second",
                    "StorageResolution": 60
                }
            ]
        }
    ],
    "ClusterName": "basic-cluster",
    "ContainerName": "diskio-worker",
    "EBSVolumeId": "aws://us-east-1c/vol-06229b4b7b5274828",
    "FullPodName": "ebs-diskio-test-59c6c59f7b-7r7qp",
    "InstanceId": "i-0f1d1c5bd2e52cce4",
    "InstanceType": "m5.large",
    "Namespace": "default",
    "NodeName": "ip-192-168-32-35.ec2.internal",
    "PersistentVolumeClaimName": "ebs-claim",
    "PlatformType": "AWS::EKS",
    "PodName": "ebs-diskio-test",
    "Sources": [
        "cadvisor"
    ],
    "Timestamp": "1756374946703",
    "Type": "ContainerDiskIO",
    "Version": "0",
    "VolumeName": "ebs-volume",
    "WorkloadKind": "Deployment",
    "WorkloadName": "ebs-diskio-test",
    "device": "/dev/nvme2n1",
    "kubernetes": {
        "container_name": "diskio-worker",
        "containerd": {
            "container_id": "73a83118cb62cc0cafb70dd62a2ea315e42a5bf5aa4b208df80a16e9e5729be0"
        },
        "host": "ip-192-168-32-35.ec2.internal",
        "labels": {
            "app": "ebs-diskio-test",
            "pod-template-hash": "59c6c59f7b"
        },
        "namespace_name": "default",
        "pod_id": "bb681e99-f50d-47f0-b156-2876c1325a4c",
        "pod_name": "ebs-diskio-test-59c6c59f7b-7r7qp",
        "pod_owners": [
            {
                "owner_kind": "Deployment",
                "owner_name": "ebs-diskio-test"
            }
        ]
    },
    "container_diskio_io_service_bytes_read": 0,
    "container_diskio_io_service_bytes_write": 9452308.748384815,
    "container_diskio_io_serviced_read": 0,
    "container_diskio_io_serviced_write": 36.5889983451915
}
```
--- 
## Graphs
<img width="1140" height="791" alt="image" src="https://github.com/user-attachments/assets/bd23b59f-0d9b-4571-8c49-93e775efaf35" />
<img width="975" height="785" alt="image" src="https://github.com/user-attachments/assets/9d257a8d-9fda-4ddc-ac65-f6732b24394b" />
