### PR TITLE
[awscontainerinsightsreceiver] Added kubelet scraper for PersistentVolume metrics 

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -170,7 +170,11 @@ const (
 	HyperPodSchedulable                     = "schedulable"
 	HyperPodUnschedulable                   = "unschedulable"
 
-	PersistentVolumeCount = "persistent_volume_count"
+	PersistentVolumeCount       = "persistent_volume_count"
+	PersistentVolumeCapacity    = "persistent_volume_capacity"
+	PersistentVolumeUsed        = "persistent_volume_used"
+	PersistentVolumeAvailable   = "persistent_volume_available"
+	PersistentVolumeUtilization = "persistent_volume_utilization"
 
 	PersistentVolumeClaimCount         = "persistent_volume_claim_count"
 	PersistentVolumeClaimStatusPending = "persistent_volume_claim_status_pending"
@@ -416,7 +420,11 @@ func init() {
 		HyperPodSchedulable:                     UnitCount,
 		HyperPodUnschedulable:                   UnitCount,
 
-		PersistentVolumeCount: UnitCount,
+		PersistentVolumeCapacity:    UnitBytes,
+		PersistentVolumeUsed:        UnitBytes,
+		PersistentVolumeAvailable:   UnitBytes,
+		PersistentVolumeUtilization: UnitPercent,
+		PersistentVolumeCount:       UnitCount,
 
 		PersistentVolumeClaimCount:         UnitCount,
 		PersistentVolumeClaimStatusPending: UnitCount,

--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -35,6 +35,9 @@ const (
 	OperatingSystem         = "OperatingSystem"
 	OperatingSystemWindows  = "windows"
 
+	PersistentVolumeClaimName = "PersistentVolumeClaimName"
+	PersistentVolumeName      = "PersistentVolumeName"
+
 	// The following constants are used for metric name construction
 	CPUTotal                         = "cpu_usage_total"
 	CPUUser                          = "cpu_usage_user"
@@ -167,8 +170,14 @@ const (
 	HyperPodSchedulable                     = "schedulable"
 	HyperPodUnschedulable                   = "unschedulable"
 
-	// kueue metrics
+	PersistentVolumeCount = "persistent_volume_count"
 
+	PersistentVolumeClaimCount         = "persistent_volume_claim_count"
+	PersistentVolumeClaimStatusPending = "persistent_volume_claim_status_pending"
+	PersistentVolumeClaimStatusBound   = "persistent_volume_claim_status_bound"
+	PersistentVolumeClaimStatusLost    = "persistent_volume_claim_status_lost"
+
+	// kueue metrics
 	KueuePendingWorkloads          = "kueue_pending_workloads"
 	KueueEvictedWorkloadsTotal     = "kueue_evicted_workloads_total"
 	KueueAdmittedActiveWorkloads   = "kueue_admitted_active_workloads"
@@ -200,6 +209,10 @@ const (
 
 	// kueue metric types
 	TypeClusterQueue = "ClusterQueue"
+
+	// PVC and PV metric types
+	TypePersistentVolumeClaim = "PersistentVolumeClaim"
+	TypePersistentVolume      = "PersistentVolume"
 
 	// Special type for pause container
 	// because containerd does not set container name pause container name to POD like docker does.
@@ -402,5 +415,12 @@ func init() {
 		HyperPodUnschedulablePendingReboot:      UnitCount,
 		HyperPodSchedulable:                     UnitCount,
 		HyperPodUnschedulable:                   UnitCount,
+
+		PersistentVolumeCount: UnitCount,
+
+		PersistentVolumeClaimCount:         UnitCount,
+		PersistentVolumeClaimStatusPending: UnitCount,
+		PersistentVolumeClaimStatusBound:   UnitCount,
+		PersistentVolumeClaimStatusLost:    UnitCount,
 	}
 }

--- a/internal/aws/containerinsight/utils.go
+++ b/internal/aws/containerinsight/utils.go
@@ -172,6 +172,8 @@ func getPrefixByMetricType(mType string) string {
 		prefix = replicaSet
 	case TypeHyperPodNode:
 		prefix = hyperPodNodeHealthStatus
+	case TypePersistentVolumeClaim, TypePersistentVolume:
+		prefix = ""
 	default:
 		log.Printf("E! Unexpected MetricType: %s", mType)
 	}

--- a/internal/aws/k8s/k8sclient/persistent_volume.go
+++ b/internal/aws/k8s/k8sclient/persistent_volume.go
@@ -1,0 +1,144 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+type PersistentVolumeClient interface {
+	GetPersistentVolumeMetrics() *PersistentVolumeMetrics
+}
+
+type PersistentVolumeMetrics struct {
+	ClusterCount int
+}
+
+type noOpPersistentVolumeClient struct{}
+
+func (p *noOpPersistentVolumeClient) GetPersistentVolumeMetrics() *PersistentVolumeMetrics {
+	return &PersistentVolumeMetrics{
+		ClusterCount: 0,
+	}
+}
+
+func (p *noOpPersistentVolumeClient) shutdown() {
+}
+
+type PersistentVolumeClientOption func(*PersistentVolume)
+
+func PersistentVolumeSyncCheckerOption(checker initialSyncChecker) PersistentVolumeClientOption {
+	return func(p *PersistentVolume) {
+		p.syncChecker = checker
+	}
+}
+
+type PersistentVolume struct {
+	stopChan chan struct{}
+	stopped  bool
+
+	store *ObjStore
+
+	syncChecker initialSyncChecker
+
+	mu      sync.RWMutex
+	metrics *PersistentVolumeMetrics
+}
+
+func (p *PersistentVolume) refresh() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	metrics := &PersistentVolumeMetrics{
+		ClusterCount: 0,
+	}
+
+	objsList := p.store.List()
+	for _, obj := range objsList {
+		_, ok := obj.(*corev1.PersistentVolume)
+		if !ok {
+			continue
+		}
+		metrics.ClusterCount++
+	}
+	p.metrics = metrics
+}
+
+func (p *PersistentVolume) GetPersistentVolumeMetrics() *PersistentVolumeMetrics {
+	if p.store.GetResetRefreshStatus() {
+		p.refresh()
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.metrics
+}
+
+func newPersistentVolumeClient(clientSet kubernetes.Interface, logger *zap.Logger, options ...PersistentVolumeClientOption) (*PersistentVolume, error) {
+	p := &PersistentVolume{
+		stopChan: make(chan struct{}),
+		metrics: &PersistentVolumeMetrics{
+			ClusterCount: 0,
+		},
+	}
+
+	for _, option := range options {
+		option(p)
+	}
+
+	ctx := context.Background()
+	if _, err := clientSet.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{}); err != nil {
+		return nil, fmt.Errorf("cannot list PersistentVolumes. err: %w", err)
+	}
+
+	// Create a store to hold PersistentVolume objects
+	p.store = NewObjStore(transformFuncPersistentVolume, logger)
+	// Create a ListWatch that knows how to list and watch PersistentVolumes
+	lw := createPersistentVolumeListWatch(clientSet)
+	// Create a Reflector that watches PersistentVolumes and updates the store
+	reflector := cache.NewReflector(lw, &corev1.PersistentVolume{}, p.store, 0)
+	// Start the Reflector in a goroutine
+	go reflector.Run(p.stopChan)
+
+	if p.syncChecker != nil {
+		// Check the init sync for potential connection issue
+		p.syncChecker.Check(reflector, "PersistentVolume initial sync timeout")
+	}
+
+	return p, nil
+}
+
+func (p *PersistentVolume) shutdown() {
+	close(p.stopChan)
+	p.stopped = true
+}
+
+func transformFuncPersistentVolume(obj any) (any, error) {
+	pv, ok := obj.(*corev1.PersistentVolume)
+	if !ok {
+		return nil, fmt.Errorf("input obj %v is not PersistentVolume type", obj)
+	}
+	return pv, nil
+}
+
+func createPersistentVolumeListWatch(client kubernetes.Interface) cache.ListerWatcher {
+	ctx := context.Background()
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return client.CoreV1().PersistentVolumes().List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return client.CoreV1().PersistentVolumes().Watch(ctx, opts)
+		},
+	}
+}

--- a/internal/aws/k8s/k8sclient/persistent_volume_claim.go
+++ b/internal/aws/k8s/k8sclient/persistent_volume_claim.go
@@ -1,0 +1,150 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+// PersistentVolumeClaimMetrics holds all the metrics for PVCs
+type PersistentVolumeClaimMetrics struct {
+	PersistentVolumeClaimPhases map[string]corev1.PersistentVolumeClaimPhase // Individual PVC metrics
+}
+
+type PersistentVolumeClaimClient interface {
+	GetPersistentVolumeClaimMetrics() *PersistentVolumeClaimMetrics
+}
+
+type noOpPersistentVolumeClaimClient struct{}
+
+func (p *noOpPersistentVolumeClaimClient) GetPersistentVolumeClaimMetrics() *PersistentVolumeClaimMetrics {
+	return &PersistentVolumeClaimMetrics{
+		PersistentVolumeClaimPhases: make(map[string]corev1.PersistentVolumeClaimPhase),
+	}
+}
+
+func (p *noOpPersistentVolumeClaimClient) shutdown() {
+}
+
+type PersistentVolumeClaimClientOption func(*PersistentVolumeClaim)
+
+func PersistentVolumeClaimSyncCheckerOption(checker initialSyncChecker) PersistentVolumeClaimClientOption {
+	return func(p *PersistentVolumeClaim) {
+		p.syncChecker = checker
+	}
+}
+
+type PersistentVolumeClaim struct {
+	stopChan chan struct{}
+	stopped  bool
+
+	store *ObjStore
+
+	syncChecker initialSyncChecker
+
+	mu      sync.RWMutex
+	metrics *PersistentVolumeClaimMetrics
+}
+
+func (p *PersistentVolumeClaim) refresh() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	metrics := &PersistentVolumeClaimMetrics{
+		PersistentVolumeClaimPhases: make(map[string]corev1.PersistentVolumeClaimPhase),
+	}
+
+	objsList := p.store.List()
+	for _, obj := range objsList {
+		pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+		if !ok {
+			continue
+		}
+
+		namespace := pvc.Namespace
+		pvcKey := fmt.Sprintf("%s/%s", namespace, pvc.Name)
+		phase := pvc.Status.Phase
+		metrics.PersistentVolumeClaimPhases[pvcKey] = phase
+	}
+	p.metrics = metrics
+}
+
+func (p *PersistentVolumeClaim) GetPersistentVolumeClaimMetrics() *PersistentVolumeClaimMetrics {
+	if p.store.GetResetRefreshStatus() {
+		p.refresh()
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	return p.metrics
+}
+
+func newPersistentVolumeClaimClient(clientSet kubernetes.Interface, logger *zap.Logger, options ...PersistentVolumeClaimClientOption) (*PersistentVolumeClaim, error) {
+	p := &PersistentVolumeClaim{
+		stopChan: make(chan struct{}),
+		metrics: &PersistentVolumeClaimMetrics{
+			PersistentVolumeClaimPhases: make(map[string]corev1.PersistentVolumeClaimPhase),
+		},
+	}
+
+	for _, option := range options {
+		option(p)
+	}
+
+	ctx := context.Background()
+	if _, err := clientSet.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).List(ctx, metav1.ListOptions{}); err != nil {
+		return nil, fmt.Errorf("cannot list PVCs. err: %w", err)
+	}
+
+	// Create a store to hold PVC objects
+	p.store = NewObjStore(transformFuncPersistentVolumeClaim, logger)
+	// Create a ListWatch that knows how to list and watch PVCs
+	lw := createPersistentVolumeClaimListWatch(clientSet, metav1.NamespaceAll)
+	// Create a Reflector that watches PVCs and updates the store
+	reflector := cache.NewReflector(lw, &corev1.PersistentVolumeClaim{}, p.store, 0)
+	// Start the Reflector in a goroutine
+	go reflector.Run(p.stopChan)
+
+	if p.syncChecker != nil {
+		// Check the init sync for potential connection issue
+		p.syncChecker.Check(reflector, "PersistentVolumeClaim initial sync timeout")
+	}
+
+	return p, nil
+}
+
+func (p *PersistentVolumeClaim) shutdown() {
+	close(p.stopChan)
+	p.stopped = true
+}
+
+func transformFuncPersistentVolumeClaim(obj any) (any, error) {
+	pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		return nil, fmt.Errorf("input obj %v is not PersistentVolumeClaim type", obj)
+	}
+	return pvc, nil
+}
+
+func createPersistentVolumeClaimListWatch(client kubernetes.Interface, ns string) cache.ListerWatcher {
+	ctx := context.Background()
+	return &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return client.CoreV1().PersistentVolumeClaims(ns).List(ctx, opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return client.CoreV1().PersistentVolumeClaims(ns).Watch(ctx, opts)
+		},
+	}
+}

--- a/internal/aws/k8s/k8sclient/persistent_volume_claim_test.go
+++ b/internal/aws/k8s/k8sclient/persistent_volume_claim_test.go
@@ -1,0 +1,117 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var pvcObjects = []runtime.Object{
+	&corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-1",
+			Namespace: "test-namespace",
+			UID:       "pvc-1-uid",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimPending,
+		},
+	},
+	&corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-2",
+			Namespace: "test-namespace",
+			UID:       "pvc-2-uid",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimBound,
+		},
+	},
+	&corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-3",
+			Namespace: "another-namespace",
+			UID:       "pvc-3-uid",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimLost,
+		},
+	},
+}
+
+func TestPersistentVolumeClaimClient_GetPVCMetrics(t *testing.T) {
+	setOption := PersistentVolumeClaimSyncCheckerOption(&mockReflectorSyncChecker{})
+
+	fakeClientSet := fake.NewSimpleClientset(pvcObjects...)
+	client, _ := newPersistentVolumeClaimClient(fakeClientSet, zap.NewNop(), setOption)
+
+	pvcs := make([]any, len(pvcObjects))
+	for i := range pvcObjects {
+		pvcs[i] = pvcObjects[i]
+	}
+	assert.NoError(t, client.store.Replace(pvcs, ""))
+
+	metrics := client.GetPersistentVolumeClaimMetrics()
+
+	// Test individual PVC phases
+	expectedPersistentVolumeClaimPhases := map[string]corev1.PersistentVolumeClaimPhase{
+		"test-namespace/pvc-1":    corev1.ClaimPending,
+		"test-namespace/pvc-2":    corev1.ClaimBound,
+		"another-namespace/pvc-3": corev1.ClaimLost,
+	}
+	assert.Equal(t, expectedPersistentVolumeClaimPhases, metrics.PersistentVolumeClaimPhases)
+
+	client.shutdown()
+	assert.True(t, client.stopped)
+}
+
+func TestTransformFuncPersistentVolumeClaim(t *testing.T) {
+	info, err := transformFuncPersistentVolumeClaim(nil)
+	assert.Nil(t, info)
+	assert.Error(t, err)
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "test-namespace",
+		},
+	}
+	result, err := transformFuncPersistentVolumeClaim(pvc)
+	assert.NoError(t, err)
+	assert.Equal(t, pvc, result)
+}
+
+func TestNoOpPersistentVolumeClaimClient(t *testing.T) {
+	client := &noOpPersistentVolumeClaimClient{}
+
+	// Test GetPVCMetrics returns empty but valid metrics
+	metrics := client.GetPersistentVolumeClaimMetrics()
+	assert.NotNil(t, metrics)
+	assert.Equal(t, map[string]corev1.PersistentVolumeClaimPhase{}, metrics.PersistentVolumeClaimPhases)
+
+	// Should not panic
+	client.shutdown()
+}

--- a/internal/aws/k8s/k8sclient/persistent_volume_test.go
+++ b/internal/aws/k8s/k8sclient/persistent_volume_test.go
@@ -1,0 +1,122 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var pvObjects = []runtime.Object{
+	&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv-1",
+			UID:  "pv-1-uid",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "pvc-1",
+				Namespace: "test-namespace",
+			},
+		},
+	},
+	&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv-2",
+			UID:  "pv2-uid",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "pvc-2",
+				Namespace: "another-namespace",
+			},
+		},
+	},
+	&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pv-3",
+			UID:  "pv3-uid",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "pvc-3",
+				Namespace: "test-namespace",
+			},
+		},
+	},
+}
+
+func TestPersistentVolumeClient_GetPersistentVolumeMetrics(t *testing.T) {
+	setOption := PersistentVolumeSyncCheckerOption(&mockReflectorSyncChecker{})
+
+	fakeClientSet := fake.NewSimpleClientset(pvObjects...)
+	client, err := newPersistentVolumeClient(fakeClientSet, zap.NewNop(), setOption)
+	assert.NoError(t, err)
+
+	pvs := make([]any, len(pvObjects))
+	for i := range pvObjects {
+		pvs[i] = pvObjects[i]
+	}
+	assert.NoError(t, client.store.Replace(pvs, ""))
+
+	metrics := client.GetPersistentVolumeMetrics()
+	assert.NotNil(t, metrics)
+	assert.Equal(t, 3, metrics.ClusterCount)
+
+	client.shutdown()
+	assert.True(t, client.stopped)
+}
+
+func TestPersistentVolumeClient_EmptyStore(t *testing.T) {
+	setOption := PersistentVolumeSyncCheckerOption(&mockReflectorSyncChecker{})
+
+	fakeClientSet := fake.NewSimpleClientset()
+	client, err := newPersistentVolumeClient(fakeClientSet, zap.NewNop(), setOption)
+	assert.NoError(t, err)
+
+	// Test with empty store
+	metrics := client.GetPersistentVolumeMetrics()
+	assert.NotNil(t, metrics)
+	assert.Equal(t, 0, metrics.ClusterCount)
+
+	client.shutdown()
+}
+
+func TestTransformFuncPersistentVolume(t *testing.T) {
+	info, err := transformFuncPersistentVolume(nil)
+	assert.Nil(t, info)
+	assert.Error(t, err)
+
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pv",
+			UID:  "test-pv",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "test-pv",
+				Namespace: "test-namespace",
+			},
+		},
+	}
+	result, err := transformFuncPersistentVolume(pv)
+	assert.NoError(t, err)
+	assert.Equal(t, pv, result)
+}
+
+func TestNoOpPersistentVolumeClient(t *testing.T) {
+	client := &noOpPersistentVolumeClient{}
+
+	metrics := client.GetPersistentVolumeMetrics()
+	assert.NotNil(t, metrics)
+	assert.Equal(t, 0, metrics.ClusterCount)
+
+	client.shutdown()
+}

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
@@ -57,6 +57,8 @@ type K8sClient interface {
 	GetDaemonSetClient() k8sclient.DaemonSetClient
 	GetStatefulSetClient() k8sclient.StatefulSetClient
 	GetReplicaSetClient() k8sclient.ReplicaSetClient
+	GetPersistentVolumeClaimClient() k8sclient.PersistentVolumeClaimClient
+	GetPersistentVolumeClient() k8sclient.PersistentVolumeClient
 	ShutdownNodeClient()
 	ShutdownPodClient()
 }
@@ -136,6 +138,8 @@ func (k *K8sAPIServer) GetMetrics() []pmetric.Metrics {
 
 	if k.includeEnhancedMetrics {
 		result = append(result, k.getHyperPodResiliencyMetrics(clusterName, timestampNs)...)
+		result = append(result, k.getPersistentVolumeMetrics(clusterName, timestampNs)...)
+		result = append(result, k.getPersistentVolumeClaimMetrics(clusterName, timestampNs)...)
 	}
 
 	return result
@@ -482,6 +486,77 @@ func (k *K8sAPIServer) getHyperPodResiliencyMetrics(clusterName, timestampNs str
 			}
 		}
 	}
+	return metrics
+}
+
+func (k *K8sAPIServer) getPersistentVolumeClaimMetrics(clusterName, timestampNs string) []pmetric.Metrics {
+	var metrics []pmetric.Metrics
+
+	pvcMetrics := k.leaderElection.persistentVolumeClaimClient.GetPersistentVolumeClaimMetrics()
+
+	for pvcName, phase := range pvcMetrics.PersistentVolumeClaimPhases {
+		parts := strings.Split(pvcName, "/")
+		if len(parts) != 2 {
+			k.logger.Warn("Unexpected PVC name", zap.String("pvcName", pvcName))
+			continue
+		}
+		namespace, pvcName := parts[0], parts[1]
+		pvcFields := map[string]any{
+			ci.PersistentVolumeClaimCount:         1,
+			ci.PersistentVolumeClaimStatusPending: 0,
+			ci.PersistentVolumeClaimStatusBound:   0,
+			ci.PersistentVolumeClaimStatusLost:    0,
+		}
+
+		switch phase {
+		case v1.ClaimPending:
+			pvcFields[ci.PersistentVolumeClaimStatusPending] = 1
+		case v1.ClaimBound:
+			pvcFields[ci.PersistentVolumeClaimStatusBound] = 1
+		case v1.ClaimLost:
+			pvcFields[ci.PersistentVolumeClaimStatusLost] = 1
+		default:
+			k.logger.Warn("Unexpected PVC phase", zap.String("PersistentVolumeClaimName", pvcName),
+				zap.String("phase", string(phase)))
+			continue
+		}
+
+		pvcAttributes := map[string]string{
+			ci.ClusterNameKey:            clusterName,
+			ci.MetricType:                ci.TypePersistentVolumeClaim,
+			ci.Timestamp:                 timestampNs,
+			ci.PersistentVolumeClaimName: pvcName,
+			ci.K8sNamespace:              namespace,
+			ci.Version:                   "0",
+			ci.SourcesKey:                "[\"apiserver\"]",
+		}
+
+		md := ci.ConvertToOTLPMetrics(pvcFields, pvcAttributes, k.logger)
+		metrics = append(metrics, md)
+	}
+
+	return metrics
+}
+
+func (k *K8sAPIServer) getPersistentVolumeMetrics(clusterName, timestampNs string) []pmetric.Metrics {
+	var metrics []pmetric.Metrics
+
+	pvMetrics := k.leaderElection.persistentVolumeClient.GetPersistentVolumeMetrics()
+
+	clusterFields := map[string]any{
+		ci.PersistentVolumeCount: pvMetrics.ClusterCount,
+	}
+
+	clusterAttributes := map[string]string{
+		ci.ClusterNameKey: clusterName,
+		ci.MetricType:     ci.TypePersistentVolume,
+		ci.Timestamp:      timestampNs,
+		ci.Version:        "0",
+		ci.SourcesKey:     "[\"apiserver\"]",
+	}
+	md := ci.ConvertToOTLPMetrics(clusterFields, clusterAttributes, k.logger)
+	metrics = append(metrics, md)
+
 	return metrics
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/leaderelection.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/leaderelection.go
@@ -34,14 +34,16 @@ type LeaderElection struct {
 	leaderLockName               string
 	leaderLockUsingConfigMapOnly bool
 
-	k8sClient         K8sClient // *k8sclient.K8sClient
-	epClient          k8sclient.EpClient
-	nodeClient        k8sclient.NodeClient
-	podClient         k8sclient.PodClient
-	deploymentClient  k8sclient.DeploymentClient
-	daemonSetClient   k8sclient.DaemonSetClient
-	statefulSetClient k8sclient.StatefulSetClient
-	replicaSetClient  k8sclient.ReplicaSetClient
+	k8sClient                   K8sClient // *k8sclient.K8sClient
+	epClient                    k8sclient.EpClient
+	nodeClient                  k8sclient.NodeClient
+	podClient                   k8sclient.PodClient
+	deploymentClient            k8sclient.DeploymentClient
+	daemonSetClient             k8sclient.DaemonSetClient
+	statefulSetClient           k8sclient.StatefulSetClient
+	replicaSetClient            k8sclient.ReplicaSetClient
+	persistentVolumeClaimClient k8sclient.PersistentVolumeClaimClient
+	persistentVolumeClient      k8sclient.PersistentVolumeClient
 
 	// the following can be set to mocks in testing
 	broadcaster eventBroadcaster
@@ -180,6 +182,8 @@ func (le *LeaderElection) startLeaderElection(ctx context.Context, lock resource
 					le.daemonSetClient = le.k8sClient.GetDaemonSetClient()
 					le.statefulSetClient = le.k8sClient.GetStatefulSetClient()
 					le.replicaSetClient = le.k8sClient.GetReplicaSetClient()
+					le.persistentVolumeClaimClient = le.k8sClient.GetPersistentVolumeClaimClient()
+					le.persistentVolumeClient = le.k8sClient.GetPersistentVolumeClient()
 					le.mu.Unlock()
 
 					if le.isLeadingC != nil {

--- a/receiver/awscontainerinsightreceiver/internal/kubelet/kubelet_scraper.go
+++ b/receiver/awscontainerinsightreceiver/internal/kubelet/kubelet_scraper.go
@@ -1,0 +1,198 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kubelet // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/kubelet"
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil"
+)
+
+const (
+	defaultCollectionInterval = 60 * time.Second
+)
+
+type Scraper struct {
+	collectionInterval time.Duration
+	cancel             context.CancelFunc
+
+	kubeletClient *kubeletutil.KubeletClient
+	hostInfo      hostInfoProvider
+	store         *kubeletStore
+	logger        *zap.Logger
+}
+
+type hostInfoProvider interface {
+	GetClusterName() string
+}
+
+type kubeletStore struct {
+	timestamp time.Time
+	summary   *stats.Summary
+}
+
+func NewKubeletScraper(kubeletClient *kubeletutil.KubeletClient, hostInfo hostInfoProvider, logger *zap.Logger) *Scraper {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Scraper{
+		collectionInterval: defaultCollectionInterval,
+		cancel:             cancel,
+		kubeletClient:      kubeletClient,
+		hostInfo:           hostInfo,
+		store:              new(kubeletStore),
+		logger:             logger,
+	}
+
+	go s.startScrape(ctx)
+
+	return s
+}
+
+func (s *Scraper) Shutdown() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+}
+
+func (s *Scraper) GetMetrics() []pmetric.Metrics {
+	var result []pmetric.Metrics
+
+	store := s.store
+	if store == nil || store.summary == nil {
+		return result
+	}
+
+	// Aggregate volume metrics by volume name to avoid double counting
+	volumeAggregates := make(map[string]*volumeAggregate)
+
+	// Process volume metrics from pods
+	for _, pod := range store.summary.Pods {
+		if pod.VolumeStats == nil {
+			continue
+		}
+
+		for _, volume := range pod.VolumeStats {
+			if volume.CapacityBytes == nil && volume.UsedBytes == nil && volume.AvailableBytes == nil {
+				continue
+			}
+
+			// Only include volumes that have a PVC reference (actual persistent volumes)
+			// Skip volumes like kube-api-access, tmp, config, etc.
+			if volume.PVCRef == nil {
+				s.logger.Debug("Skipping volume without PVC reference",
+					zap.String("volume_name", volume.Name),
+					zap.String("pod_name", pod.PodRef.Name))
+				continue
+			}
+
+			// Get or create aggregate for this volume
+			agg, exists := volumeAggregates[volume.Name]
+			if !exists {
+				agg = &volumeAggregate{
+					volumeName: volume.Name,
+					usedBytes:  0,
+				}
+				volumeAggregates[volume.Name] = agg
+			}
+
+			// Sum used bytes across pods (this makes sense)
+			if volume.UsedBytes != nil {
+				agg.usedBytes += *volume.UsedBytes
+			}
+
+			// Take max for capacity and available (they should be the same for same volume)
+			if volume.CapacityBytes != nil {
+				if agg.capacityBytes == nil || *volume.CapacityBytes > *agg.capacityBytes {
+					agg.capacityBytes = volume.CapacityBytes
+				}
+			}
+			if volume.AvailableBytes != nil {
+				if agg.availableBytes == nil || *volume.AvailableBytes > *agg.availableBytes {
+					agg.availableBytes = volume.AvailableBytes
+				}
+			}
+		}
+	}
+
+	// Create metrics from aggregated data
+	for _, agg := range volumeAggregates {
+		volumeMetric := stores.NewCIMetric(ci.TypePersistentVolume, s.logger)
+
+		// Add aggregated volume metrics
+		if agg.capacityBytes != nil {
+			metricName := ci.PersistentVolumeCapacity
+			volumeMetric.AddField(metricName, float64(*agg.capacityBytes))
+		}
+		if agg.usedBytes > 0 {
+			metricName := ci.PersistentVolumeUsed
+			volumeMetric.AddField(metricName, float64(agg.usedBytes))
+		}
+		if agg.availableBytes != nil {
+			metricName := ci.PersistentVolumeAvailable
+			volumeMetric.AddField(metricName, float64(*agg.availableBytes))
+		}
+		if agg.capacityBytes != nil && agg.usedBytes > 0 {
+			metricName := ci.PersistentVolumeUtilization
+			volumeMetric.AddField(metricName, float64(agg.usedBytes)/float64(*agg.capacityBytes))
+		}
+
+		// Add tags
+		volumeMetric.AddTag(ci.PersistentVolumeName, agg.volumeName)
+		volumeMetric.AddTag(ci.MetricType, ci.TypePersistentVolume)
+		volumeMetric.AddTag(ci.ClusterNameKey, s.hostInfo.GetClusterName())
+
+		// Only add metrics if we have fields
+		if len(volumeMetric.GetFields()) > 0 {
+			result = append(result, ci.ConvertToOTLPMetrics(volumeMetric.GetFields(), volumeMetric.GetTags(), s.logger))
+		}
+	}
+
+	return result
+}
+
+type volumeAggregate struct {
+	volumeName     string
+	usedBytes      uint64
+	capacityBytes  *uint64
+	availableBytes *uint64
+}
+
+func (s *Scraper) startScrape(ctx context.Context) {
+	ticker := time.NewTicker(s.collectionInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			err := s.scrape()
+			if err != nil {
+				s.logger.Warn("Failed to scrape kubelet metrics", zap.Error(err))
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (s *Scraper) scrape() error {
+	timestamp := time.Now()
+
+	summary, err := s.kubeletClient.Summary(s.logger)
+	if err != nil {
+		return err
+	}
+
+	s.store = &kubeletStore{
+		timestamp: timestamp,
+		summary:   summary,
+	}
+
+	return nil
+}

--- a/receiver/awscontainerinsightreceiver/internal/kubelet/kubelet_scraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/kubelet/kubelet_scraper_test.go
@@ -1,0 +1,246 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kubelet
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil"
+)
+
+const testClusterName = "test-cluster"
+
+type mockHostInfoProvider struct{}
+
+func (m *mockHostInfoProvider) GetClusterName() string {
+	return testClusterName
+}
+
+// Mock kubelet client that implements the interface properly
+type mockKubeletClientImpl struct {
+	summary *stats.Summary
+	err     error
+}
+
+func (m *mockKubeletClientImpl) Summary(_ *zap.Logger) (*stats.Summary, error) {
+	return m.summary, m.err
+}
+
+func (m *mockKubeletClientImpl) ListPods() ([]corev1.Pod, error) {
+	return nil, nil
+}
+
+func uint64Ptr(v uint64) *uint64 {
+	return &v
+}
+
+func TestNewKubeletScraper(t *testing.T) {
+	hostInfo := &mockHostInfoProvider{}
+	// Create a real kubelet client for testing instantiation
+	kubeletClient, err := kubeletutil.NewKubeletClient("127.0.0.1", "10250", nil, zap.NewNop())
+	if err != nil {
+		// If we can't create a real client, skip this test
+		t.Skip("Cannot create kubelet client for testing")
+	}
+
+	scraper := NewKubeletScraper(kubeletClient, hostInfo, zap.NewNop())
+
+	assert.NotNil(t, scraper)
+	assert.Equal(t, defaultCollectionInterval, scraper.collectionInterval)
+	assert.NotNil(t, scraper.cancel)
+	assert.Equal(t, hostInfo, scraper.hostInfo)
+	assert.NotNil(t, scraper.store)
+
+	scraper.Shutdown()
+}
+
+func TestGetMetrics_WithPVCVolumes(t *testing.T) {
+	hostInfo := &mockHostInfoProvider{}
+	kubeletClient, err := kubeletutil.NewKubeletClient("127.0.0.1", "10250", nil, zap.NewNop())
+	if err != nil {
+		t.Skip("Cannot create kubelet client for testing")
+	}
+
+	scraper := NewKubeletScraper(kubeletClient, hostInfo, zap.NewNop())
+	defer scraper.Shutdown()
+
+	// Create test summary with PVC volumes
+	summary := &stats.Summary{
+		Pods: []stats.PodStats{
+			{
+				PodRef: stats.PodReference{Name: "pod1", Namespace: "default"},
+				VolumeStats: []stats.VolumeStats{
+					{
+						Name: "pvc-volume-1",
+						FsStats: stats.FsStats{
+							CapacityBytes:  uint64Ptr(1000000000), // 1GB
+							UsedBytes:      uint64Ptr(500000000),  // 500MB
+							AvailableBytes: uint64Ptr(500000000),  // 500MB
+						},
+						PVCRef: &stats.PVCReference{Name: "test-pvc", Namespace: "default"},
+					},
+					{
+						Name: "kube-api-access", // No PVCRef - should be skipped
+						FsStats: stats.FsStats{
+							CapacityBytes: uint64Ptr(1024),
+							UsedBytes:     uint64Ptr(512),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scraper.store = &kubeletStore{timestamp: time.Now(), summary: summary}
+
+	metrics := scraper.GetMetrics()
+	assert.Len(t, metrics, 1) // Only PVC volume should generate metrics
+
+	// Verify metric content
+	metric := metrics[0]
+	rm := metric.ResourceMetrics()
+	require.Equal(t, 1, rm.Len())
+
+	attrs := rm.At(0).Resource().Attributes()
+	clusterName, exists := attrs.Get(ci.ClusterNameKey)
+	assert.True(t, exists)
+	assert.Equal(t, testClusterName, clusterName.Str())
+
+	volumeName, exists := attrs.Get(ci.PersistentVolumeName)
+	assert.True(t, exists)
+	assert.Equal(t, "pvc-volume-1", volumeName.Str())
+}
+
+func TestGetMetrics_VolumeAggregation(t *testing.T) {
+	hostInfo := &mockHostInfoProvider{}
+	kubeletClient, err := kubeletutil.NewKubeletClient("127.0.0.1", "10250", nil, zap.NewNop())
+	if err != nil {
+		t.Skip("Cannot create kubelet client for testing")
+	}
+
+	scraper := NewKubeletScraper(kubeletClient, hostInfo, zap.NewNop())
+	defer scraper.Shutdown()
+
+	// Create test summary with same volume across multiple pods
+	summary := &stats.Summary{
+		Pods: []stats.PodStats{
+			{
+				PodRef: stats.PodReference{Name: "pod1", Namespace: "default"},
+				VolumeStats: []stats.VolumeStats{
+					{
+						Name: "shared-volume",
+						FsStats: stats.FsStats{
+							CapacityBytes:  uint64Ptr(1000000000), // 1GB
+							UsedBytes:      uint64Ptr(300000000),  // 300MB
+							AvailableBytes: uint64Ptr(700000000),  // 700MB
+						},
+						PVCRef: &stats.PVCReference{Name: "shared-pvc", Namespace: "default"},
+					},
+				},
+			},
+			{
+				PodRef: stats.PodReference{Name: "pod2", Namespace: "default"},
+				VolumeStats: []stats.VolumeStats{
+					{
+						Name: "shared-volume", // Same volume name
+						FsStats: stats.FsStats{
+							CapacityBytes:  uint64Ptr(1000000000), // 1GB
+							UsedBytes:      uint64Ptr(200000000),  // 200MB
+							AvailableBytes: uint64Ptr(800000000),  // 800MB
+						},
+						PVCRef: &stats.PVCReference{Name: "shared-pvc", Namespace: "default"},
+					},
+				},
+			},
+		},
+	}
+
+	scraper.store = &kubeletStore{timestamp: time.Now(), summary: summary}
+
+	metrics := scraper.GetMetrics()
+	assert.Len(t, metrics, 1) // Should aggregate into single metric
+
+	// Verify aggregation by checking metric values
+	metric := metrics[0]
+	rm := metric.ResourceMetrics()
+	sm := rm.At(0).ScopeMetrics()
+
+	var usedBytes, capacityBytes float64
+	for i := 0; i < sm.Len(); i++ {
+		scopeMetrics := sm.At(i)
+		metrics := scopeMetrics.Metrics()
+		for j := 0; j < metrics.Len(); j++ {
+			m := metrics.At(j)
+			dps := m.Gauge().DataPoints()
+			if dps.Len() > 0 {
+				switch m.Name() {
+				case ci.PersistentVolumeUsed:
+					usedBytes = dps.At(0).DoubleValue()
+				case ci.PersistentVolumeCapacity:
+					capacityBytes = dps.At(0).DoubleValue()
+				}
+			}
+		}
+	}
+
+	// Used bytes should be sum: 300MB + 200MB = 500MB
+	assert.Equal(t, float64(500000000), usedBytes)
+	// Capacity should be max: 1GB
+	assert.Equal(t, float64(1000000000), capacityBytes)
+}
+
+func TestGetMetrics_NoStore(t *testing.T) {
+	hostInfo := &mockHostInfoProvider{}
+	kubeletClient, err := kubeletutil.NewKubeletClient("127.0.0.1", "10250", nil, zap.NewNop())
+	if err != nil {
+		t.Skip("Cannot create kubelet client for testing")
+	}
+
+	scraper := NewKubeletScraper(kubeletClient, hostInfo, zap.NewNop())
+	defer scraper.Shutdown()
+
+	// Don't set store
+	metrics := scraper.GetMetrics()
+	assert.Empty(t, metrics)
+}
+
+func TestMockKubeletClient(t *testing.T) {
+	// Test the mock kubelet client implementation
+	summary := &stats.Summary{
+		Pods: []stats.PodStats{
+			{
+				PodRef: stats.PodReference{Name: "test-pod", Namespace: "default"},
+			},
+		},
+	}
+
+	mockClient := &mockKubeletClientImpl{
+		summary: summary,
+		err:     nil,
+	}
+
+	// Test Summary method
+	result, err := mockClient.Summary(zap.NewNop())
+	assert.NoError(t, err)
+	assert.Equal(t, summary, result)
+
+	// Test ListPods method
+	pods, err := mockClient.ListPods()
+	assert.NoError(t, err)
+	assert.Nil(t, pods)
+
+	// Test error case
+	mockClient.err = assert.AnError
+	result, err = mockClient.Summary(zap.NewNop())
+	assert.Error(t, err)
+	assert.Equal(t, summary, result) // Still returns summary even with error
+}

--- a/receiver/awscontainerinsightreceiver/internal/stores/utils.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/utils.go
@@ -148,6 +148,8 @@ func tagMetricSourceLinux(metric CIMetric) {
 		sources = []string{"dcgm", "pod", "calculated"}
 	case ci.TypeContainerNeuron:
 		sources = []string{"neuron", "pod", "calculated"}
+	case ci.TypePersistentVolume:
+		sources = []string{"kubelet", "calculated"}
 	}
 
 	if len(sources) > 0 {
@@ -185,6 +187,8 @@ func tagMetricSourceWindows(metric CIMetric) {
 		sources = append(sources, []string{"kubelet", "calculated"}...)
 	case ci.TypeContainerDiskIO:
 		sources = append(sources, []string{"kubelet"}...)
+	case ci.TypePersistentVolume:
+		sources = append(sources, []string{"kubelet", "calculated"}...)
 	}
 
 	if len(sources) > 0 {

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -28,6 +28,7 @@ import (
 	hostinfo "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/host"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8sapiserver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/kubelet"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/neuron"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/nvme"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/prometheusscraper"
@@ -63,6 +64,7 @@ type awsContainerInsightReceiver struct {
 	nvmeScraper              *prometheusscraper.SimplePrometheusScraper
 	neuronMonitorScraper     *prometheusscraper.SimplePrometheusScraper
 	efaSysfsScraper          *efa.Scraper
+	kubeletScraper           *kubelet.Scraper
 }
 
 // newAWSContainerInsightReceiver creates the aws container insight receiver with the given parameters.
@@ -228,6 +230,7 @@ func (acir *awsContainerInsightReceiver) initEKS(ctx context.Context, host compo
 		if err != nil {
 			acir.settings.Logger.Debug("Unable to start EFA scraper", zap.Error(err))
 		}
+		acir.initKubeletScraper(kubeletClient, hostInfo)
 	}
 
 	return nil
@@ -419,6 +422,10 @@ func (acir *awsContainerInsightReceiver) initEfaSysfsScraper(localNodeDecorator 
 	return nil
 }
 
+func (acir *awsContainerInsightReceiver) initKubeletScraper(kubeletClient *kubeletutil.KubeletClient, hostInfo *hostinfo.Info) {
+	acir.kubeletScraper = kubelet.NewKubeletScraper(kubeletClient, hostInfo, acir.settings.Logger)
+}
+
 // Shutdown stops the awsContainerInsightReceiver receiver.
 func (acir *awsContainerInsightReceiver) Shutdown(context.Context) error {
 	if acir.prometheusScraper != nil {
@@ -450,6 +457,9 @@ func (acir *awsContainerInsightReceiver) Shutdown(context.Context) error {
 	}
 	if acir.efaSysfsScraper != nil {
 		acir.efaSysfsScraper.Shutdown()
+	}
+	if acir.kubeletScraper != nil {
+		acir.kubeletScraper.Shutdown()
 	}
 	if acir.decorators != nil {
 		for i := len(acir.decorators) - 1; i >= 0; i-- {
@@ -501,6 +511,10 @@ func (acir *awsContainerInsightReceiver) collectData(ctx context.Context) error 
 
 	if acir.efaSysfsScraper != nil {
 		mds = append(mds, acir.efaSysfsScraper.GetMetrics()...)
+	}
+
+	if acir.kubeletScraper != nil {
+		mds = append(mds, acir.kubeletScraper.GetMetrics()...)
 	}
 
 	for _, md := range mds {


### PR DESCRIPTION
---
### Disclaimer: This PR is built on top of my other [PR](https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/339) that introduced PVs and PVCs
---
## Summary

This PR enhances the AWS Container Insights receiver by adding a new kubelet scraper that collects detailed persistent volume (PV) usage metrics directly from the kubeletclient. 

## Changes Made

### New Features

- __New Kubelet Scraper__: Added `kubelet_scraper.go` that collects volume usage statistics from kubelet's `/stats/summary` endpoint

- __Enhanced PV Metrics__: Extended persistent volume monitoring to include:

  - `persistent_volume_capacity` (bytes)
  - `persistent_volume_used` (bytes)
  - `persistent_volume_available` (bytes)
  - `persistent_volume_utilization` (percentage)

### Refactoring & Improvements

- __Metric Constants Reorganization__: Refactored PV/PVC metric constants in `const.go` for better clarity:

- __Volume Aggregation Logic__: Implemented intelligent volume aggregation that:

  - Prevents double-counting of volumes across multiple pods
  - Sums used bytes across pods sharing the same volume
  - Takes maximum values for capacity/available bytes (consistent per volume)
  - Filters out non-PVC volumes (config maps, secrets, etc.)

### Architecture Changes

- __Receiver Integration__: Integrated kubelet scraper into the main receiver lifecycle:

  - The `kubeletclient` was already being initialized in the receiver
  - Now we are passing it to the scraper that calls `.Summary()` and filters for volume metrics

---
## EMF Logs
```
{
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName"
                ],
                [
                    "ClusterName",
                    "VolumeName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "persistent_volume_capacity",
                    "Unit": "",
                    "StorageResolution": 60
                },
                {
                    "Name": "persistent_volume_used",
                    "Unit": "",
                    "StorageResolution": 60
                },
                {
                    "Name": "persistent_volume_available",
                    "Unit": "",
                    "StorageResolution": 60
                }
            ]
        }
    ],
    "ClusterName": "basic-cluster",
    "PlatformType": "AWS::EKS",
    "Timestamp": "1756308270694",
    "Type": "PersistentVolume",
    "Version": "0",
    "VolumeName": "ebs-volume",
    "persistent_volume_utilization": 0.032474352104147154,
    "persistent_volume_available": 10447220736,
    "persistent_volume_capacity": 10464022528,
    "persistent_volume_used": 339812352
}
```
---
## Graphs
<img width="719" height="411" alt="image" src="https://github.com/user-attachments/assets/6c0669de-bfcc-4138-8d07-6e60e3b66682" />
<img width="564" height="398" alt="image" src="https://github.com/user-attachments/assets/842e29c6-6f3e-419e-8166-d054011f45f2" />
<img width="643" height="427" alt="image" src="https://github.com/user-attachments/assets/19bbef80-a614-469c-8700-0d2f0b20a480" />
<img width="680" height="418" alt="image" src="https://github.com/user-attachments/assets/0497663c-72fa-4647-a664-9d008e8ff982" />
