### PR TITLE
Ecs observer - Update task processing order

### DIFF
--- a/extension/observer/ecsobserver/filter_test.go
+++ b/extension/observer/ecsobserver/filter_test.go
@@ -190,4 +190,72 @@ func TestFilter(t *testing.T) {
 		require.Len(t, merr, 1)
 		assert.Len(t, res, 1)
 	})
+
+	t.Run("docker_label_precedence_over_task_definition", func(t *testing.T) {
+		cfgDockerLabelTaskDef := Config{
+			DockerLabels: []DockerLabelConfig{
+				{
+					PortLabel: "PROMETHEUS_PORT",
+					CommonExporterConfig: CommonExporterConfig{
+						JobName: "DOCKER_LABEL_JOB",
+					},
+				},
+			},
+			TaskDefinitions: []TaskDefinitionConfig{
+				{
+					ArnPattern: "arn:alike:nginx-.*",
+					CommonExporterConfig: CommonExporterConfig{
+						JobName:      "TASK_DEFINITION_JOB",
+						MetricsPorts: []int{2112},
+					},
+				},
+			},
+		}
+
+		f := newTestTaskFilter(t, cfgDockerLabelTaskDef)
+		res, err := f.filter(genTasksWithDockerLabels())
+		require.NoError(t, err)
+		assert.Len(t, res, 1)
+		assert.Equal(t, []matchedContainer{
+			{
+				TaskIndex:      0,
+				ContainerIndex: 0,
+				Targets: []matchedTarget{
+					{
+						MatcherType: matcherTypeDockerLabel,
+						Port:        2112,
+						Job:         "DOCKER_LABEL_JOB", // DockerLabel should win over TaskDefinition
+					},
+				},
+			},
+		}, res[0].Matched)
+	})
+}
+
+func genTasksWithDockerLabels() []*taskAnnotated {
+	return []*taskAnnotated{
+		{
+			Task: &ecs.Task{
+				TaskArn:           aws.String("arn:alike:nginx-task"),
+				TaskDefinitionArn: aws.String("arn:alike:nginx-def"),
+			},
+			Definition: &ecs.TaskDefinition{
+				TaskDefinitionArn: aws.String("arn:alike:nginx-def"),
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: aws.String("nginx"),
+						DockerLabels: map[string]*string{
+							"PROMETHEUS_PORT": aws.String("2112"),
+						},
+						PortMappings: []*ecs.PortMapping{
+							{
+								ContainerPort: aws.Int64(2112),
+								HostPort:      aws.Int64(2112),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 }

--- a/extension/observer/ecsobserver/matcher.go
+++ b/extension/observer/ecsobserver/matcher.go
@@ -104,8 +104,8 @@ type matchedTarget struct {
 func matcherOrders() []matcherType {
 	return []matcherType{
 		matcherTypeService,
-		matcherTypeTaskDefinition,
 		matcherTypeDockerLabel,
+		matcherTypeTaskDefinition,
 	}
 }
 


### PR DESCRIPTION
#### Description
Fixing a processing priority order issue in ecs_observer. In order to produce the same results as telegraf ecs_service_discovery, the processing order of which config matches the Task must match. 

ECS Service Discovery processing order:

1. ServiceNameList
2. DockerLabel
3. TaskDefinitionList

### Why does processing order matter

When all 3 configurations are provided and match a given service discovery target, then internally, a target is generated for each of the 3 configs, where the applicable metadata (such as JobName) will be picked up from the respective configuration (ie TargetA_serviceNameJob, TargetA_DockerLabelJob, TargetA_TaskDefJob) and the deduplication logic drops the first one. 

In ECS Observer, the processing order is currently different (ie TargetA_serviceNameJob, TargetA_TaskDefJob, TargetA_DockerLabelJob) so a different Target is kept during deduplication.

### Example of mismatch order behavior:

Customer configures DockerLabel and TaskDef to match the same target
Generated 2 targets internally, drops last dupe target according to processing order. 

**With ECS Service Discovery**: Drops TaskDef
**With ECS Observer**: Drops DockerLabel
Result: Different metadata from the retained target. 

#### Testing
Added test to validate the introduced scenario
All unit tests pass
Validated integration tests against cloudwatch agent using changes

#### Documentation
No change in docs
