### PR TITLE
Otel kedakarpenter

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -197,7 +197,9 @@ const (
 	TypeContainer          = "Container"
 	TypeContainerFS        = "ContainerFS"
 	TypeContainerDiskIO    = "ContainerDiskIO"
-
+	
+	TypeContainerKeda 	   = "ContainerKeda"
+	TypeContainerKarpenter = "ContainerKarpenter"
 	// kueue metric types
 	TypeClusterQueue = "ClusterQueue"
 

--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -197,8 +197,8 @@ const (
 	TypeContainer          = "Container"
 	TypeContainerFS        = "ContainerFS"
 	TypeContainerDiskIO    = "ContainerDiskIO"
-	
-	TypeContainerKeda 	   = "ContainerKeda"
+
+	TypeContainerKeda      = "ContainerKeda"
 	TypeContainerKarpenter = "ContainerKarpenter"
 	// kueue metric types
 	TypeClusterQueue = "ClusterQueue"

--- a/receiver/awscontainerinsightreceiver/internal/karpenter/karpenter_empty_metric_decorator.go
+++ b/receiver/awscontainerinsightreceiver/internal/karpenter/karpenter_empty_metric_decorator.go
@@ -1,0 +1,97 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package karpenter
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+const (
+	nodePool     = "nodepool"
+	provisioner  = "provisioner"
+	nodeState    = "state"
+	actionType   = "action"
+	DefaultValue = "DEFAULT"
+)
+
+var attributeConfig = map[string][]string{
+	KarpenterNodesTotal:           {nodePool, nodeState},
+	KarpenterNodesClaimed:         {nodePool},
+	KarpenterPodsUnschedulable:    {nodePool},
+	KarpenterNodeClaimsCreated:    {nodePool},
+	KarpenterNodeClaimsTerminated: {nodePool},
+}
+
+var defaultAttributeValues = map[string]string{
+	nodePool:    "default",
+	provisioner: "default",
+	nodeState:   "ready",
+	actionType:  "terminate",
+}
+
+type EmptyMetricDecorator struct {
+	NextConsumer consumer.Metrics
+	Logger       *zap.Logger
+}
+
+func (ed *EmptyMetricDecorator) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{
+		MutatesData: true,
+	}
+}
+
+func (ed *EmptyMetricDecorator) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	rms := md.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		rs := rms.At(i)
+		ilms := rs.ScopeMetrics()
+		for j := 0; j < ilms.Len(); j++ {
+			ils := ilms.At(j)
+			metrics := ils.Metrics()
+			ed.addEmptyMetrics(metrics)
+		}
+	}
+	return ed.NextConsumer.ConsumeMetrics(ctx, md)
+}
+
+func (ed *EmptyMetricDecorator) addEmptyMetrics(metrics pmetric.MetricSlice) {
+	metricFoundMap := make(map[string]bool)
+	for k := range attributeConfig {
+		metricFoundMap[k] = false
+	}
+
+	for i := 0; i < metrics.Len(); i++ {
+		m := metrics.At(i)
+		if _, ok := metricFoundMap[m.Name()]; ok {
+			metricFoundMap[m.Name()] = true
+		}
+	}
+
+	for k, v := range metricFoundMap {
+		if !v {
+			populateEmptyMetric(metrics, k, attributeConfig[k])
+		}
+	}
+}
+
+func populateEmptyMetric(metrics pmetric.MetricSlice, metricName string, attributesToAdd []string) {
+	metricToAdd := pmetric.NewMetric()
+	metricToAdd.SetEmptyGauge()
+	metricToAdd.SetName(metricName)
+	
+	datapoint := metricToAdd.Gauge().DataPoints().AppendEmpty()
+	datapoint.SetDoubleValue(0)
+	
+	for _, attribute := range attributesToAdd {
+		if value, exists := defaultAttributeValues[attribute]; exists {
+			datapoint.Attributes().PutStr(attribute, value)
+		}
+	}
+	
+	metricToAdd.CopyTo(metrics.AppendEmpty())
+}

--- a/receiver/awscontainerinsightreceiver/internal/karpenter/karpenter_empty_metric_decorator.go
+++ b/receiver/awscontainerinsightreceiver/internal/karpenter/karpenter_empty_metric_decorator.go
@@ -5,11 +5,28 @@ package karpenter
 
 import (
 	"context"
+	"os"
 
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
 )
+
+// IsKarpenterMetric checks if a metric name belongs to Karpenter
+func IsKarpenterMetric(metricName string, metricType string) bool {
+	// Direct karpenter metrics
+	if len(metricName) >= 9 && metricName[:9] == "karpenter" {
+		return true
+	}
+	// controller_runtime metrics are considered Karpenter metrics for cluster type
+	if len(metricName) >= 18 && metricName[:18] == "controller_runtime" && metricType == ci.TypeCluster {
+		return true
+	}
+	return false
+}
 
 const (
 	nodePool     = "nodepool"
@@ -20,11 +37,14 @@ const (
 )
 
 var attributeConfig = map[string][]string{
-	KarpenterNodesTotal:           {nodePool, nodeState},
-	KarpenterNodesClaimed:         {nodePool},
-	KarpenterPodsUnschedulable:    {nodePool},
-	KarpenterNodeClaimsCreated:    {nodePool},
-	KarpenterNodeClaimsTerminated: {nodePool},
+	KarpenterPodsStartupTime:                  {},
+	KarpenterDeprovisioningReplacementMachine: {},
+	KarpenterDisruptionReplacementNodeclaim:   {},
+	KarpenterCloudproviderDuration:            {},
+	KarpenterNodepoolLimit:                    {nodePool},
+	KarpenterNodepoolUsage:                    {nodePool},
+	KarpenterProvisionerLimit:                 {provisioner},
+	KarpenterProvisionerUsage:                 {provisioner},
 }
 
 var defaultAttributeValues = map[string]string{
@@ -37,6 +57,7 @@ var defaultAttributeValues = map[string]string{
 type EmptyMetricDecorator struct {
 	NextConsumer consumer.Metrics
 	Logger       *zap.Logger
+	MetricType   string
 }
 
 func (ed *EmptyMetricDecorator) Capabilities() consumer.Capabilities {
@@ -49,11 +70,26 @@ func (ed *EmptyMetricDecorator) ConsumeMetrics(ctx context.Context, md pmetric.M
 	rms := md.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
 		rs := rms.At(i)
+
+		// Ensure resource attributes for EMF exporter
+		resourceTags := make(map[string]string)
+		ras := rs.Resource().Attributes()
+		ras.Range(func(k string, v pcommon.Value) bool {
+			resourceTags[k] = v.AsString()
+			return true
+		})
+		ed.ensureResourceAttributes(ras, resourceTags)
+
 		ilms := rs.ScopeMetrics()
 		for j := 0; j < ilms.Len(); j++ {
 			ils := ilms.At(j)
 			metrics := ils.Metrics()
+
+			// Filter out problematic metrics before processing
+			ed.filterUnsupportedMetrics(metrics)
+
 			ed.addEmptyMetrics(metrics)
+			ed.addServiceTypeLabels(metrics)
 		}
 	}
 	return ed.NextConsumer.ConsumeMetrics(ctx, md)
@@ -83,15 +119,118 @@ func populateEmptyMetric(metrics pmetric.MetricSlice, metricName string, attribu
 	metricToAdd := pmetric.NewMetric()
 	metricToAdd.SetEmptyGauge()
 	metricToAdd.SetName(metricName)
-	
+
 	datapoint := metricToAdd.Gauge().DataPoints().AppendEmpty()
 	datapoint.SetDoubleValue(0)
-	
+
 	for _, attribute := range attributesToAdd {
 		if value, exists := defaultAttributeValues[attribute]; exists {
 			datapoint.Attributes().PutStr(attribute, value)
 		}
 	}
-	
+
 	metricToAdd.CopyTo(metrics.AppendEmpty())
+}
+
+// addServiceTypeLabels adds ServiceType label to Karpenter metrics
+func (ed *EmptyMetricDecorator) addServiceTypeLabels(metrics pmetric.MetricSlice) {
+	for i := 0; i < metrics.Len(); i++ {
+		m := metrics.At(i)
+		if IsKarpenterMetric(m.Name(), ed.MetricType) {
+			ed.addServiceTypeLabel(m, "Karpenter")
+			ed.Logger.Debug("Added ServiceType label to Karpenter metric", zap.String("name", m.Name()))
+		}
+	}
+}
+
+// addServiceTypeLabel adds ServiceType label to a specific metric
+func (ed *EmptyMetricDecorator) addServiceTypeLabel(m pmetric.Metric, serviceType string) {
+	var dps pmetric.NumberDataPointSlice
+	switch m.Type() {
+	case pmetric.MetricTypeGauge:
+		dps = m.Gauge().DataPoints()
+	case pmetric.MetricTypeSum:
+		dps = m.Sum().DataPoints()
+	default:
+		return
+	}
+
+	for i := 0; i < dps.Len(); i++ {
+		attrs := dps.At(i).Attributes()
+		attrs.PutStr("ServiceType", serviceType)
+	}
+}
+
+// filterUnsupportedMetrics removes histogram and other unsupported metric types that cause panics
+func (ed *EmptyMetricDecorator) filterUnsupportedMetrics(metrics pmetric.MetricSlice) {
+	// Create a new slice to hold only supported metrics
+	originalLen := metrics.Len()
+	writeIndex := 0
+
+	for i := 0; i < originalLen; i++ {
+		m := metrics.At(i)
+		metricType := m.Type()
+
+		// Only allow Gauge and Sum metrics, drop everything else (Histogram, Summary, etc.)
+		if metricType == pmetric.MetricTypeGauge || metricType == pmetric.MetricTypeSum {
+			// Keep this metric - move it to the write position if needed
+			if writeIndex != i {
+				m.CopyTo(metrics.At(writeIndex))
+			}
+			writeIndex++
+		} else {
+			ed.Logger.Debug("Filtering out unsupported metric type",
+				zap.String("name", m.Name()),
+				zap.String("type", metricType.String()))
+		}
+	}
+
+	// Remove the extra metrics at the end
+	for i := originalLen - 1; i >= writeIndex; i-- {
+		metrics.RemoveIf(func(pmetric.Metric) bool { return true })
+	}
+}
+
+// ensureResourceAttributes ensures essential resource attributes are present for EMF exporter compatibility
+func (ed *EmptyMetricDecorator) ensureResourceAttributes(ras pcommon.Map, resourceTags map[string]string) {
+	// Ensure ClusterName is present - this is critical for EMF exporter
+	if _, exists := resourceTags[ci.ClusterNameKey]; !exists {
+		if clusterName, exists := resourceTags["ClusterName"]; exists {
+			ras.PutStr(ci.ClusterNameKey, clusterName)
+			ed.Logger.Info("Added ClusterName resource attribute", zap.String("cluster", clusterName))
+		} else {
+			// Try to get cluster name from environment variables as fallback
+			clusterName := ""
+
+			// Check K8S_CLUSTER_NAME environment variable first
+			if envClusterName := os.Getenv("K8S_CLUSTER_NAME"); envClusterName != "" {
+				clusterName = envClusterName
+				ed.Logger.Info("Using cluster name from K8S_CLUSTER_NAME environment variable", zap.String("cluster", clusterName))
+			} else if envClusterName := os.Getenv("CLUSTER_NAME"); envClusterName != "" {
+				clusterName = envClusterName
+				ed.Logger.Info("Using cluster name from CLUSTER_NAME environment variable", zap.String("cluster", clusterName))
+			}
+
+			if clusterName != "" {
+				ras.PutStr(ci.ClusterNameKey, clusterName)
+				resourceTags[ci.ClusterNameKey] = clusterName
+			}
+		}
+	}
+
+	// Ensure other essential attributes are present
+	if _, exists := resourceTags[ci.NodeNameKey]; !exists {
+		if nodeName, exists := resourceTags["NodeName"]; exists {
+			ras.PutStr(ci.NodeNameKey, nodeName)
+		} else if nodeName := os.Getenv("HOST_NAME"); nodeName != "" {
+			ras.PutStr(ci.NodeNameKey, nodeName)
+			resourceTags[ci.NodeNameKey] = nodeName
+		}
+	}
+
+	// Ensure Type is set for Container Insights
+	if _, exists := resourceTags[ci.MetricType]; !exists {
+		ras.PutStr(ci.MetricType, ed.MetricType)
+		resourceTags[ci.MetricType] = ed.MetricType
+	}
 }

--- a/receiver/awscontainerinsightreceiver/internal/karpenter/karpenter_scraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/karpenter/karpenter_scraper_config.go
@@ -1,0 +1,106 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package karpenter
+import (
+	"os"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/kubernetes"
+	"github.com/prometheus/prometheus/model/relabel"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/prometheusscraper"
+)
+
+const (
+    caFile                    = "/etc/amazon-cloudwatch-observability-agent-cert/tls-ca.crt"
+	collectionInterval        = 60 * time.Second
+	jobName                   = "containerInsightsKarpenterScraper"
+	scraperMetricsPath        = "/metrics"
+	scraperK8sServiceSelector = "app.kubernetes.io/name=karpenter"
+)
+
+func GetKarpenterScrapeConfig(hostinfo prometheusscraper.HostInfoProvider) *config.ScrapeConfig {
+	return &config.ScrapeConfig{
+		ScrapeProtocols:        config.DefaultScrapeProtocols,
+		ScrapeFallbackProtocol: config.PrometheusText0_0_4,
+		ScrapeInterval:         model.Duration(collectionInterval),
+		ScrapeTimeout:          model.Duration(collectionInterval),
+		JobName:                jobName,
+		Scheme:                 "http",
+		MetricsPath:            scraperMetricsPath,
+		ServiceDiscoveryConfigs: discovery.Configs{
+			&kubernetes.SDConfig{
+				Role: kubernetes.RoleService,
+				NamespaceDiscovery: kubernetes.NamespaceDiscovery{
+					Names: []string{"karpenter"},
+				},
+				Selectors: []kubernetes.SelectorConfig{
+					{
+						Role:  kubernetes.RoleService,
+						Label: scraperK8sServiceSelector,
+					},
+				},
+			},
+		},
+		RelabelConfigs: []*relabel.Config{
+			{
+				SourceLabels: model.LabelNames{"__address__"},
+				TargetLabel:  "__address__",
+				Regex:        relabel.MustNewRegexp("([^:]+)(?::\\d+)?"),
+				Replacement:  "${1}:8000",
+				Action:       relabel.Replace,
+			},
+		},
+		MetricRelabelConfigs: GetKarpenterMetricRelabelConfigs(hostinfo),
+	}
+}
+
+func GetKarpenterMetricRelabelConfigs(hostinfo prometheusscraper.HostInfoProvider) []*relabel.Config {
+	return []*relabel.Config{
+		{
+			SourceLabels: model.LabelNames{"__name__"},
+			Regex:        relabel.MustNewRegexp("karpenter_.*"),
+			Action:       relabel.Keep,
+		},
+		{
+			SourceLabels: model.LabelNames{"node"},
+			TargetLabel:  "Node",
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  "${1}",
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"__name__"},
+			TargetLabel:  ci.NodeNameKey,
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  os.Getenv("HOST_NAME"),
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"__name__"},
+			TargetLabel:  ci.ClusterNameKey,
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  hostinfo.GetClusterName(),
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"__name__"},
+			TargetLabel:  ci.InstanceID,
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  hostinfo.GetInstanceID(),
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"__name__"},
+			TargetLabel:  ci.InstanceType,
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  hostinfo.GetInstanceType(),
+			Action:       relabel.Replace,
+		},
+	}
+}

--- a/receiver/awscontainerinsightreceiver/internal/karpenter/karpenter_scraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/karpenter/karpenter_scraper_config.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package karpenter
+
 import (
 	"os"
 	"time"
@@ -17,7 +18,7 @@ import (
 )
 
 const (
-    caFile                    = "/etc/amazon-cloudwatch-observability-agent-cert/tls-ca.crt"
+	caFile                    = "/etc/amazon-cloudwatch-observability-agent-cert/tls-ca.crt"
 	collectionInterval        = 60 * time.Second
 	jobName                   = "containerInsightsKarpenterScraper"
 	scraperMetricsPath        = "/metrics"
@@ -25,7 +26,7 @@ const (
 )
 
 func GetKarpenterScrapeConfig(hostinfo prometheusscraper.HostInfoProvider) *config.ScrapeConfig {
-	return &config.ScrapeConfig{
+	scrapeConfig := &config.ScrapeConfig{
 		ScrapeProtocols:        config.DefaultScrapeProtocols,
 		ScrapeFallbackProtocol: config.PrometheusText0_0_4,
 		ScrapeInterval:         model.Duration(collectionInterval),
@@ -58,18 +59,65 @@ func GetKarpenterScrapeConfig(hostinfo prometheusscraper.HostInfoProvider) *conf
 		},
 		MetricRelabelConfigs: GetKarpenterMetricRelabelConfigs(hostinfo),
 	}
+
+	return scrapeConfig
 }
 
 func GetKarpenterMetricRelabelConfigs(hostinfo prometheusscraper.HostInfoProvider) []*relabel.Config {
 	return []*relabel.Config{
 		{
+			// Drop Go runtime metrics that are often histograms
 			SourceLabels: model.LabelNames{"__name__"},
-			Regex:        relabel.MustNewRegexp("karpenter_.*"),
+			Regex:        relabel.MustNewRegexp("go_.*"),
+			Action:       relabel.Drop,
+		},
+		{
+			// Drop Prometheus client metrics that are often histograms
+			SourceLabels: model.LabelNames{"__name__"},
+			Regex:        relabel.MustNewRegexp("promhttp_.*"),
+			Action:       relabel.Drop,
+		},
+		{
+			// Drop controller runtime metrics that can be problematic
+			SourceLabels: model.LabelNames{"__name__"},
+			Regex:        relabel.MustNewRegexp("controller_runtime_.*_bucket$|workqueue_.*_bucket$"),
+			Action:       relabel.Drop,
+		},
+		{
+			// Drop problematic histogram bucket metrics but keep _total and summary metrics
+			SourceLabels: model.LabelNames{"__name__"},
+			Regex:        relabel.MustNewRegexp(".*_bucket$|.*_seconds_bucket$|.*_duration_seconds_bucket$"),
+			Action:       relabel.Drop,
+		},
+		{
+			// Drop specific summary metrics that cause panics in the containerinsight utils
+			SourceLabels: model.LabelNames{"__name__"},
+			Regex:        relabel.MustNewRegexp("karpenter_nodes_termination_time_seconds$"),
+			Action:       relabel.Drop,
+		},
+		{
+			// Keep all Karpenter metrics AND controller_runtime metrics (after dropping problematic ones above)
+			SourceLabels: model.LabelNames{"__name__"},
+			Regex:        relabel.MustNewRegexp("karpenter_nodes_leases_deleted|karpenter_interruption_deleted_messages|karpenter_deprovisioning_replacement_machine_initialized_seconds_sum|karpenter_deprovisioning_replacement_machine_initialized_seconds_count|karpenter_disruption_replacement_nodeclaim_initialized_seconds_sum|karpenter_disruption_replacement_nodeclaim_initialized_seconds_count|karpenter_interruption_message_latency_time_seconds_sum|karpenter_interruption_message_latency_time_seconds_count|karpenter_pods_startup_time_seconds_sum|karpenter_pods_startup_time_seconds_count|controller_runtime_reconcile_total|controller_runtime_active_workers|controller_runtime_reconcile_errors_total"),
 			Action:       relabel.Keep,
 		},
 		{
 			SourceLabels: model.LabelNames{"node"},
 			TargetLabel:  "Node",
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  "${1}",
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"nodepool"},
+			TargetLabel:  "NodePool",
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  "${1}",
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"provisioner"},
+			TargetLabel:  "Provisioner",
 			Regex:        relabel.MustNewRegexp("(.*)"),
 			Replacement:  "${1}",
 			Action:       relabel.Replace,

--- a/receiver/awscontainerinsightreceiver/internal/karpenter/metric_name.go
+++ b/receiver/awscontainerinsightreceiver/internal/karpenter/metric_name.go
@@ -1,0 +1,12 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package karpenter
+
+const (
+	KarpenterNodesTotal              = "karpenter_nodes_total"
+	KarpenterNodesClaimed            = "karpenter_nodes_claimed"
+	KarpenterPodsUnschedulable       = "karpenter_pods_unschedulable"
+	KarpenterNodeClaimsCreated       = "karpenter_nodeclaims_created_total"
+	KarpenterNodeClaimsTerminated    = "karpenter_nodeclaims_terminated_total"
+)

--- a/receiver/awscontainerinsightreceiver/internal/karpenter/metric_name.go
+++ b/receiver/awscontainerinsightreceiver/internal/karpenter/metric_name.go
@@ -4,9 +4,12 @@
 package karpenter
 
 const (
-	KarpenterNodesTotal              = "karpenter_nodes_total"
-	KarpenterNodesClaimed            = "karpenter_nodes_claimed"
-	KarpenterPodsUnschedulable       = "karpenter_pods_unschedulable"
-	KarpenterNodeClaimsCreated       = "karpenter_nodeclaims_created_total"
-	KarpenterNodeClaimsTerminated    = "karpenter_nodeclaims_terminated_total"
+	KarpenterPodsStartupTime                  = "karpenter_pods_startup_time_seconds"
+	KarpenterDeprovisioningReplacementMachine = "karpenter_deprovisioning_replacement_machine_initialized_seconds"
+	KarpenterDisruptionReplacementNodeclaim   = "karpenter_disruption_replacement_nodeclaim_initialized_seconds"
+	KarpenterCloudproviderDuration            = "karpenter_cloudprovider_duration_seconds"
+	KarpenterNodepoolLimit                    = "karpenter_nodepool_limit"
+	KarpenterNodepoolUsage                    = "karpenter_nodepool_usage"
+	KarpenterProvisionerLimit                 = "karpenter_provisioner_limit"
+	KarpenterProvisionerUsage                 = "karpenter_provisioner_usage"
 )

--- a/receiver/awscontainerinsightreceiver/internal/keda/keda_empty_metric_decorator.go
+++ b/receiver/awscontainerinsightreceiver/internal/keda/keda_empty_metric_decorator.go
@@ -1,0 +1,92 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package keda
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+const (
+	scalerType    = "scaler_type"
+	scaledObject  = "scaled_object"
+	errorType     = "error_type"
+	DefaultValue  = "DEFAULT"
+)
+
+var attributeConfig = map[string][]string{
+	KedaScalerActive:        {scalerType, scaledObject},
+	KedaScalerErrors:        {scalerType, scaledObject, errorType},
+	KedaScaledObjectErrors:  {scaledObject, errorType},
+}
+
+var defaultAttributeValues = map[string]string{
+	scalerType:   "prometheus",
+	scaledObject: "default",
+	errorType:    "generic",
+}
+
+type EmptyMetricDecorator struct {
+	NextConsumer consumer.Metrics
+	Logger       *zap.Logger
+}
+
+func (ed *EmptyMetricDecorator) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{
+		MutatesData: true,
+	}
+}
+
+func (ed *EmptyMetricDecorator) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	rms := md.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		rs := rms.At(i)
+		ilms := rs.ScopeMetrics()
+		for j := 0; j < ilms.Len(); j++ {
+			ils := ilms.At(j)
+			metrics := ils.Metrics()
+			ed.addEmptyMetrics(metrics)
+		}
+	}
+	return ed.NextConsumer.ConsumeMetrics(ctx, md)
+}
+
+func (ed *EmptyMetricDecorator) addEmptyMetrics(metrics pmetric.MetricSlice) {
+	metricFoundMap := make(map[string]bool)
+	for k := range attributeConfig {
+		metricFoundMap[k] = false
+	}
+
+	for i := 0; i < metrics.Len(); i++ {
+		m := metrics.At(i)
+		if _, ok := metricFoundMap[m.Name()]; ok {
+			metricFoundMap[m.Name()] = true
+		}
+	}
+
+	for k, v := range metricFoundMap {
+		if !v {
+			populateEmptyMetric(metrics, k, attributeConfig[k])
+		}
+	}
+}
+
+func populateEmptyMetric(metrics pmetric.MetricSlice, metricName string, attributesToAdd []string) {
+	metricToAdd := pmetric.NewMetric()
+	metricToAdd.SetEmptyGauge()
+	metricToAdd.SetName(metricName)
+	
+	datapoint := metricToAdd.Gauge().DataPoints().AppendEmpty()
+	datapoint.SetDoubleValue(0)
+	
+	for _, attribute := range attributesToAdd {
+		if value, exists := defaultAttributeValues[attribute]; exists {
+			datapoint.Attributes().PutStr(attribute, value)
+		}
+	}
+	
+	metricToAdd.CopyTo(metrics.AppendEmpty())
+}

--- a/receiver/awscontainerinsightreceiver/internal/keda/keda_empty_metric_decorator.go
+++ b/receiver/awscontainerinsightreceiver/internal/keda/keda_empty_metric_decorator.go
@@ -2,25 +2,35 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package keda
+
 import (
 	"context"
+	"os"
 
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
 )
 
+// IsKedaMetric checks if a metric name belongs to KEDA
+func IsKedaMetric(metricName string) bool {
+	return len(metricName) >= 4 && metricName[:4] == "keda"
+}
+
 const (
-	scalerType    = "scaler_type"
-	scaledObject  = "scaled_object"
-	errorType     = "error_type"
-	DefaultValue  = "DEFAULT"
+	scalerType   = "scaler_type"
+	scaledObject = "scaled_object"
+	errorType    = "error_type"
+	DefaultValue = "DEFAULT"
 )
 
 var attributeConfig = map[string][]string{
-	KedaScalerActive:        {scalerType, scaledObject},
-	KedaScalerErrors:        {scalerType, scaledObject, errorType},
-	KedaScaledObjectErrors:  {scaledObject, errorType},
+	KedaScalerActive:       {scalerType, scaledObject},
+	KedaScalerErrors:       {scalerType, scaledObject, errorType},
+	KedaScaledObjectErrors: {scaledObject, errorType},
 }
 
 var defaultAttributeValues = map[string]string{
@@ -32,6 +42,7 @@ var defaultAttributeValues = map[string]string{
 type EmptyMetricDecorator struct {
 	NextConsumer consumer.Metrics
 	Logger       *zap.Logger
+	MetricType   string
 }
 
 func (ed *EmptyMetricDecorator) Capabilities() consumer.Capabilities {
@@ -44,11 +55,26 @@ func (ed *EmptyMetricDecorator) ConsumeMetrics(ctx context.Context, md pmetric.M
 	rms := md.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
 		rs := rms.At(i)
+
+		// Ensure resource attributes for EMF exporter
+		resourceTags := make(map[string]string)
+		ras := rs.Resource().Attributes()
+		ras.Range(func(k string, v pcommon.Value) bool {
+			resourceTags[k] = v.AsString()
+			return true
+		})
+		ed.ensureResourceAttributes(ras, resourceTags)
+
 		ilms := rs.ScopeMetrics()
 		for j := 0; j < ilms.Len(); j++ {
 			ils := ilms.At(j)
 			metrics := ils.Metrics()
+
+			// Filter out problematic metrics before processing
+			ed.filterUnsupportedMetrics(metrics)
+
 			ed.addEmptyMetrics(metrics)
+			ed.addServiceTypeLabels(metrics)
 		}
 	}
 	return ed.NextConsumer.ConsumeMetrics(ctx, md)
@@ -78,15 +104,118 @@ func populateEmptyMetric(metrics pmetric.MetricSlice, metricName string, attribu
 	metricToAdd := pmetric.NewMetric()
 	metricToAdd.SetEmptyGauge()
 	metricToAdd.SetName(metricName)
-	
+
 	datapoint := metricToAdd.Gauge().DataPoints().AppendEmpty()
 	datapoint.SetDoubleValue(0)
-	
+
 	for _, attribute := range attributesToAdd {
 		if value, exists := defaultAttributeValues[attribute]; exists {
 			datapoint.Attributes().PutStr(attribute, value)
 		}
 	}
-	
+
 	metricToAdd.CopyTo(metrics.AppendEmpty())
+}
+
+// addServiceTypeLabels adds ServiceType label to KEDA metrics
+func (ed *EmptyMetricDecorator) addServiceTypeLabels(metrics pmetric.MetricSlice) {
+	for i := 0; i < metrics.Len(); i++ {
+		m := metrics.At(i)
+		if IsKedaMetric(m.Name()) {
+			ed.addServiceTypeLabel(m, "KEDA")
+			ed.Logger.Debug("Added ServiceType label to KEDA metric", zap.String("name", m.Name()))
+		}
+	}
+}
+
+// addServiceTypeLabel adds ServiceType label to a specific metric
+func (ed *EmptyMetricDecorator) addServiceTypeLabel(m pmetric.Metric, serviceType string) {
+	var dps pmetric.NumberDataPointSlice
+	switch m.Type() {
+	case pmetric.MetricTypeGauge:
+		dps = m.Gauge().DataPoints()
+	case pmetric.MetricTypeSum:
+		dps = m.Sum().DataPoints()
+	default:
+		return
+	}
+
+	for i := 0; i < dps.Len(); i++ {
+		attrs := dps.At(i).Attributes()
+		attrs.PutStr("ServiceType", serviceType)
+	}
+}
+
+// filterUnsupportedMetrics removes histogram and other unsupported metric types that cause panics
+func (ed *EmptyMetricDecorator) filterUnsupportedMetrics(metrics pmetric.MetricSlice) {
+	// Create a new slice to hold only supported metrics
+	originalLen := metrics.Len()
+	writeIndex := 0
+
+	for i := 0; i < originalLen; i++ {
+		m := metrics.At(i)
+		metricType := m.Type()
+
+		// Only allow Gauge and Sum metrics, drop everything else (Histogram, Summary, etc.)
+		if metricType == pmetric.MetricTypeGauge || metricType == pmetric.MetricTypeSum {
+			// Keep this metric - move it to the write position if needed
+			if writeIndex != i {
+				m.CopyTo(metrics.At(writeIndex))
+			}
+			writeIndex++
+		} else {
+			ed.Logger.Debug("Filtering out unsupported metric type",
+				zap.String("name", m.Name()),
+				zap.String("type", metricType.String()))
+		}
+	}
+
+	// Remove the extra metrics at the end
+	for i := originalLen - 1; i >= writeIndex; i-- {
+		metrics.RemoveIf(func(pmetric.Metric) bool { return true })
+	}
+}
+
+// ensureResourceAttributes ensures essential resource attributes are present for EMF exporter compatibility
+func (ed *EmptyMetricDecorator) ensureResourceAttributes(ras pcommon.Map, resourceTags map[string]string) {
+	// Ensure ClusterName is present - this is critical for EMF exporter
+	if _, exists := resourceTags[ci.ClusterNameKey]; !exists {
+		if clusterName, exists := resourceTags["ClusterName"]; exists {
+			ras.PutStr(ci.ClusterNameKey, clusterName)
+			ed.Logger.Info("Added ClusterName resource attribute", zap.String("cluster", clusterName))
+		} else {
+			// Try to get cluster name from environment variables as fallback
+			clusterName := ""
+
+			// Check K8S_CLUSTER_NAME environment variable first
+			if envClusterName := os.Getenv("K8S_CLUSTER_NAME"); envClusterName != "" {
+				clusterName = envClusterName
+				ed.Logger.Info("Using cluster name from K8S_CLUSTER_NAME environment variable", zap.String("cluster", clusterName))
+			} else if envClusterName := os.Getenv("CLUSTER_NAME"); envClusterName != "" {
+				clusterName = envClusterName
+				ed.Logger.Info("Using cluster name from CLUSTER_NAME environment variable", zap.String("cluster", clusterName))
+			}
+
+			if clusterName != "" {
+				ras.PutStr(ci.ClusterNameKey, clusterName)
+				resourceTags[ci.ClusterNameKey] = clusterName
+			}
+		}
+	}
+
+	// Ensure other essential attributes are present
+	if _, exists := resourceTags[ci.NodeNameKey]; !exists {
+		if nodeName, exists := resourceTags["NodeName"]; exists {
+			ras.PutStr(ci.NodeNameKey, nodeName)
+		} else if nodeName := os.Getenv("HOST_NAME"); nodeName != "" {
+			ras.PutStr(ci.NodeNameKey, nodeName)
+			resourceTags[ci.NodeNameKey] = nodeName
+		}
+	}
+
+	// Ensure Type is set for Container Insights
+	if _, exists := resourceTags[ci.MetricType]; !exists {
+		ras.PutStr(ci.MetricType, ed.MetricType)
+		resourceTags[ci.MetricType] = ed.MetricType
+	}
 }

--- a/receiver/awscontainerinsightreceiver/internal/keda/keda_scraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/keda/keda_scraper_config.go
@@ -1,0 +1,122 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package keda // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/keda"
+
+import (
+	"os"
+	"time"
+
+	// configutil "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/kubernetes"
+	"github.com/prometheus/prometheus/model/relabel"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/prometheusscraper"
+)
+
+const (
+	caFile                    = "/etc/amazon-cloudwatch-observability-agent-cert/tls-ca.crt"
+	collectionInterval        = 60 * time.Second
+	jobName                   = "containerInsightsKedaScraper"
+	scraperMetricsPath        = "/metrics"
+	scraperK8sServiceSelector = "app.kubernetes.io/name=keda-operator-metrics-apiserver"
+)
+
+func GetKedaScrapeConfig(hostinfo prometheusscraper.HostInfoProvider) *config.ScrapeConfig {
+	return &config.ScrapeConfig{
+		ScrapeProtocols:        config.DefaultScrapeProtocols,
+		ScrapeFallbackProtocol: config.PrometheusText0_0_4,
+		ScrapeInterval:         model.Duration(collectionInterval),
+		ScrapeTimeout:          model.Duration(collectionInterval),
+		JobName:                jobName,
+		Scheme:                 "http",
+		MetricsPath:            scraperMetricsPath,
+		ServiceDiscoveryConfigs: discovery.Configs{
+			&kubernetes.SDConfig{
+				Role: kubernetes.RoleService,
+				NamespaceDiscovery: kubernetes.NamespaceDiscovery{
+					Names: []string{"keda"},
+				},
+				Selectors: []kubernetes.SelectorConfig{
+					{
+						Role:  kubernetes.RoleService,
+						Label: scraperK8sServiceSelector,
+					},
+				},
+			},
+		},
+		RelabelConfigs: []*relabel.Config{
+			{
+				SourceLabels: model.LabelNames{"__address__"},
+				TargetLabel:  "__address__",
+				Regex:        relabel.MustNewRegexp("([^:]+)(?::\\d+)?"),
+				Replacement:  "${1}:9022",
+				Action:       relabel.Replace,
+			},
+		},
+		MetricRelabelConfigs: GetKedaMetricRelabelConfigs(hostinfo),
+	}
+}
+
+func GetKedaMetricRelabelConfigs(hostinfo prometheusscraper.HostInfoProvider) []*relabel.Config {
+	return []*relabel.Config{
+		{
+			SourceLabels: model.LabelNames{"__name__"},
+			Regex:        relabel.MustNewRegexp("keda_.*"),
+			Action:       relabel.Keep,
+		},
+		{
+			SourceLabels: model.LabelNames{"scaledObject"},
+			TargetLabel:  "ScaledObject",
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  "${1}",
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"scaler"},
+			TargetLabel:  "Scaler",
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  "${1}",
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"namespace"},
+			TargetLabel:  ci.K8sNamespace,
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  "${1}",
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"__name__"},
+			TargetLabel:  ci.NodeNameKey,
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  os.Getenv("HOST_NAME"),
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"__name__"},
+			TargetLabel:  ci.ClusterNameKey,
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  hostinfo.GetClusterName(),
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"__name__"},
+			TargetLabel:  ci.InstanceID,
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  hostinfo.GetInstanceID(),
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"__name__"},
+			TargetLabel:  ci.InstanceType,
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  hostinfo.GetInstanceType(),
+			Action:       relabel.Replace,
+		},
+	}
+}

--- a/receiver/awscontainerinsightreceiver/internal/keda/keda_scraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/keda/keda_scraper_config.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"time"
 
-	// configutil "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
@@ -23,11 +22,11 @@ const (
 	collectionInterval        = 60 * time.Second
 	jobName                   = "containerInsightsKedaScraper"
 	scraperMetricsPath        = "/metrics"
-	scraperK8sServiceSelector = "app.kubernetes.io/name=keda-operator-metrics-apiserver"
+	scraperK8sServiceSelector = "app.kubernetes.io/name=keda-operator"
 )
 
 func GetKedaScrapeConfig(hostinfo prometheusscraper.HostInfoProvider) *config.ScrapeConfig {
-	return &config.ScrapeConfig{
+	scrapeConfig := &config.ScrapeConfig{
 		ScrapeProtocols:        config.DefaultScrapeProtocols,
 		ScrapeFallbackProtocol: config.PrometheusText0_0_4,
 		ScrapeInterval:         model.Duration(collectionInterval),
@@ -53,20 +52,21 @@ func GetKedaScrapeConfig(hostinfo prometheusscraper.HostInfoProvider) *config.Sc
 			{
 				SourceLabels: model.LabelNames{"__address__"},
 				TargetLabel:  "__address__",
-				Regex:        relabel.MustNewRegexp("([^:]+)(?::\\d+)?"),
-				Replacement:  "${1}:9022",
+				Regex:        relabel.MustNewRegexp("([^:]+)(?:\\d+)?"),
+				Replacement:  "${1}:8080",
 				Action:       relabel.Replace,
 			},
 		},
 		MetricRelabelConfigs: GetKedaMetricRelabelConfigs(hostinfo),
 	}
+	return scrapeConfig
 }
 
 func GetKedaMetricRelabelConfigs(hostinfo prometheusscraper.HostInfoProvider) []*relabel.Config {
 	return []*relabel.Config{
 		{
 			SourceLabels: model.LabelNames{"__name__"},
-			Regex:        relabel.MustNewRegexp("keda_.*"),
+			Regex:        relabel.MustNewRegexp("keda_scaler_.*|keda_scaled_object_.*|keda_internal_scale_loop_latency_seconds|keda_internal_metricsservice_grpc_server_handled_total"),
 			Action:       relabel.Keep,
 		},
 		{
@@ -79,6 +79,13 @@ func GetKedaMetricRelabelConfigs(hostinfo prometheusscraper.HostInfoProvider) []
 		{
 			SourceLabels: model.LabelNames{"scaler"},
 			TargetLabel:  "Scaler",
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  "${1}",
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"metric"},
+			TargetLabel:  "Metric",
 			Regex:        relabel.MustNewRegexp("(.*)"),
 			Replacement:  "${1}",
 			Action:       relabel.Replace,

--- a/receiver/awscontainerinsightreceiver/internal/keda/metric_name.go
+++ b/receiver/awscontainerinsightreceiver/internal/keda/metric_name.go
@@ -1,0 +1,10 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package keda
+
+const (
+	KedaScalerActive           = "keda_scaler_active"
+	KedaScalerErrors           = "keda_scaler_errors_total"
+	KedaScaledObjectErrors     = "keda_scaled_object_errors_total"
+)

--- a/receiver/awscontainerinsightreceiver/internal/keda/metric_name.go
+++ b/receiver/awscontainerinsightreceiver/internal/keda/metric_name.go
@@ -4,7 +4,16 @@
 package keda
 
 const (
-	KedaScalerActive           = "keda_scaler_active"
-	KedaScalerErrors           = "keda_scaler_errors_total"
-	KedaScaledObjectErrors     = "keda_scaled_object_errors_total"
+	KedaScalerMetricsValue = "keda_scaler_metrics_value"
+	KedaScalerActive       = "keda_scaler_active"
+	KedaScaledObjectErrors = "keda_scaled_object_errors_total"
+
+	KedaScalerMetricsLatency = "keda_scaler_metrics_latency_seconds"
+	KedaScaleLoopLatency     = "keda_internal_scale_loop_latency_seconds"
+
+	KedaScalerDetailsErrorsTotal = "keda_scaler_detail_errors_total"
+	KedaScaledObjectPaused       = "keda_scaled_object_paused"
+	KedaResourceRegisteredTotal  = "keda_resource_registered_total"
+	KedaTriggerRegisteredTotal   = "keda_trigger_registered_total"
+	KedaScalerErrors             = "keda_scaler_errors_total"
 )

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -28,6 +28,8 @@ import (
 	hostinfo "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/host"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8sapiserver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/karpenter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/keda"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/neuron"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/nvme"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/prometheusscraper"
@@ -63,6 +65,8 @@ type awsContainerInsightReceiver struct {
 	nvmeScraper              *prometheusscraper.SimplePrometheusScraper
 	neuronMonitorScraper     *prometheusscraper.SimplePrometheusScraper
 	efaSysfsScraper          *efa.Scraper
+	kedaScraper              *prometheusscraper.SimplePrometheusScraper
+	karpenterScraper         *prometheusscraper.SimplePrometheusScraper
 }
 
 // newAWSContainerInsightReceiver creates the aws container insight receiver with the given parameters.
@@ -228,8 +232,24 @@ func (acir *awsContainerInsightReceiver) initEKS(ctx context.Context, host compo
 		if err != nil {
 			acir.settings.Logger.Debug("Unable to start EFA scraper", zap.Error(err))
 		}
-	}
+		acir.settings.Logger.Info("test0")
+		acir.settings.Logger.Info("Initializing KEEEEDA and Karpenter scrapers")
+		err = acir.initKedaScraper(ctx, host, hostInfo, localNodeDecorator)
+		acir.settings.Logger.Info("KEDA scraper initialization result", zap.Error(err))
+		if err != nil {
+			acir.settings.Logger.Info("Unable to start KEDA scraper", zap.Error(err))
+		}else {
+			acir.settings.Logger.Info("KEDA scraper initialized successfully")
+		}
+		err = acir.initKarpenterScraper(ctx, host, hostInfo, localNodeDecorator)
+		acir.settings.Logger.Info("KARPENTER scraper initialization result", zap.Error(err))
+		if err != nil {
+			acir.settings.Logger.Info("Unable to start Karpenter scraper", zap.Error(err))
+		} else {
+			acir.settings.Logger.Info("Karpenter scraper initialized successfully")
+		}
 
+	}
 	return nil
 }
 
@@ -419,6 +439,54 @@ func (acir *awsContainerInsightReceiver) initEfaSysfsScraper(localNodeDecorator 
 	return nil
 }
 
+func (acir *awsContainerInsightReceiver) initKedaScraper(ctx context.Context, host component.Host, hostInfo *hostinfo.Info, localNodeDecorator stores.Decorator) error {
+        decoConsumer := decoratorconsumer.DecorateConsumer{
+                ContainerOrchestrator: ci.EKS,
+                NextConsumer:          acir.nextConsumer,
+                MetricType:            ci.TypeCluster,
+                K8sDecorator:          localNodeDecorator,
+                Logger:                acir.settings.Logger,
+        }
+
+        scraperOpts := prometheusscraper.SimplePrometheusScraperOpts{
+                Ctx:               ctx,
+                TelemetrySettings: acir.settings,
+                Consumer:          &decoConsumer,
+                Host:              host,
+                ScraperConfigs:    keda.GetKedaScrapeConfig(hostInfo),
+                HostInfoProvider:  hostInfo,
+                Logger:            acir.settings.Logger,
+        }
+
+        var err error
+        acir.kedaScraper, err = prometheusscraper.NewSimplePrometheusScraper(scraperOpts)
+        return err
+}
+
+func (acir *awsContainerInsightReceiver) initKarpenterScraper(ctx context.Context, host component.Host, hostInfo *hostinfo.Info, localNodeDecorator stores.Decorator) error {
+        decoConsumer := decoratorconsumer.DecorateConsumer{
+                ContainerOrchestrator: ci.EKS,
+                NextConsumer:          acir.nextConsumer,
+                MetricType:            ci.TypeCluster,
+                K8sDecorator:          localNodeDecorator,
+                Logger:                acir.settings.Logger,
+        }
+
+        scraperOpts := prometheusscraper.SimplePrometheusScraperOpts{
+                Ctx:               ctx,
+                TelemetrySettings: acir.settings,
+                Consumer:          &decoConsumer,
+                Host:              host,
+                ScraperConfigs:    karpenter.GetKarpenterScrapeConfig(hostInfo),
+                HostInfoProvider:  hostInfo,
+                Logger:            acir.settings.Logger,
+        }
+
+        var err error
+        acir.karpenterScraper, err = prometheusscraper.NewSimplePrometheusScraper(scraperOpts)
+        return err
+}
+
 // Shutdown stops the awsContainerInsightReceiver receiver.
 func (acir *awsContainerInsightReceiver) Shutdown(context.Context) error {
 	if acir.prometheusScraper != nil {
@@ -450,6 +518,12 @@ func (acir *awsContainerInsightReceiver) Shutdown(context.Context) error {
 	}
 	if acir.efaSysfsScraper != nil {
 		acir.efaSysfsScraper.Shutdown()
+	}
+	if acir.kedaScraper != nil {
+		acir.kedaScraper.Shutdown()
+	}
+	if acir.karpenterScraper != nil {
+		acir.karpenterScraper.Shutdown()
 	}
 	if acir.decorators != nil {
 		for i := len(acir.decorators) - 1; i >= 0; i-- {
@@ -501,6 +575,16 @@ func (acir *awsContainerInsightReceiver) collectData(ctx context.Context) error 
 
 	if acir.efaSysfsScraper != nil {
 		mds = append(mds, acir.efaSysfsScraper.GetMetrics()...)
+	}
+
+	if acir.kedaScraper != nil {
+		acir.settings.Logger.Info("KEDA scraper trying to get metrics")
+		acir.kedaScraper.GetMetrics()
+	}
+
+	if acir.karpenterScraper != nil {
+			acir.settings.Logger.Info("Karpenter scraper trying to get metrics")
+			acir.karpenterScraper.GetMetrics()
 	}
 
 	for _, md := range mds {

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -232,23 +232,15 @@ func (acir *awsContainerInsightReceiver) initEKS(ctx context.Context, host compo
 		if err != nil {
 			acir.settings.Logger.Debug("Unable to start EFA scraper", zap.Error(err))
 		}
-		acir.settings.Logger.Info("test0")
-		acir.settings.Logger.Info("Initializing KEEEEDA and Karpenter scrapers")
+
 		err = acir.initKedaScraper(ctx, host, hostInfo, localNodeDecorator)
-		acir.settings.Logger.Info("KEDA scraper initialization result", zap.Error(err))
 		if err != nil {
 			acir.settings.Logger.Info("Unable to start KEDA scraper", zap.Error(err))
-		}else {
-			acir.settings.Logger.Info("KEDA scraper initialized successfully")
 		}
 		err = acir.initKarpenterScraper(ctx, host, hostInfo, localNodeDecorator)
-		acir.settings.Logger.Info("KARPENTER scraper initialization result", zap.Error(err))
 		if err != nil {
 			acir.settings.Logger.Info("Unable to start Karpenter scraper", zap.Error(err))
-		} else {
-			acir.settings.Logger.Info("Karpenter scraper initialized successfully")
 		}
-
 	}
 	return nil
 }
@@ -440,51 +432,63 @@ func (acir *awsContainerInsightReceiver) initEfaSysfsScraper(localNodeDecorator 
 }
 
 func (acir *awsContainerInsightReceiver) initKedaScraper(ctx context.Context, host component.Host, hostInfo *hostinfo.Info, localNodeDecorator stores.Decorator) error {
-        decoConsumer := decoratorconsumer.DecorateConsumer{
-                ContainerOrchestrator: ci.EKS,
-                NextConsumer:          acir.nextConsumer,
-                MetricType:            ci.TypeCluster,
-                K8sDecorator:          localNodeDecorator,
-                Logger:                acir.settings.Logger,
-        }
+	decoConsumer := decoratorconsumer.DecorateConsumer{
+		ContainerOrchestrator: ci.EKS,
+		NextConsumer:          acir.nextConsumer,
+		MetricType:            ci.TypeCluster,
+		K8sDecorator:          localNodeDecorator,
+		Logger:                acir.settings.Logger,
+	}
 
-        scraperOpts := prometheusscraper.SimplePrometheusScraperOpts{
-                Ctx:               ctx,
-                TelemetrySettings: acir.settings,
-                Consumer:          &decoConsumer,
-                Host:              host,
-                ScraperConfigs:    keda.GetKedaScrapeConfig(hostInfo),
-                HostInfoProvider:  hostInfo,
-                Logger:            acir.settings.Logger,
-        }
+	kedaEmptyMetricDecorator := keda.EmptyMetricDecorator{
+		NextConsumer: &decoConsumer,
+		Logger:       acir.settings.Logger,
+		MetricType:   ci.TypeCluster,
+	}
 
-        var err error
-        acir.kedaScraper, err = prometheusscraper.NewSimplePrometheusScraper(scraperOpts)
-        return err
+	scraperOpts := prometheusscraper.SimplePrometheusScraperOpts{
+		Ctx:               ctx,
+		TelemetrySettings: acir.settings,
+		Consumer:          &kedaEmptyMetricDecorator,
+		Host:              host,
+		ScraperConfigs:    keda.GetKedaScrapeConfig(hostInfo),
+		HostInfoProvider:  hostInfo,
+		Logger:            acir.settings.Logger,
+	}
+
+	var err error
+	acir.kedaScraper, err = prometheusscraper.NewSimplePrometheusScraper(scraperOpts)
+	return err
 }
 
 func (acir *awsContainerInsightReceiver) initKarpenterScraper(ctx context.Context, host component.Host, hostInfo *hostinfo.Info, localNodeDecorator stores.Decorator) error {
-        decoConsumer := decoratorconsumer.DecorateConsumer{
-                ContainerOrchestrator: ci.EKS,
-                NextConsumer:          acir.nextConsumer,
-                MetricType:            ci.TypeCluster,
-                K8sDecorator:          localNodeDecorator,
-                Logger:                acir.settings.Logger,
-        }
+	decoConsumer := decoratorconsumer.DecorateConsumer{
+		ContainerOrchestrator: ci.EKS,
+		NextConsumer:          acir.nextConsumer,
+		MetricType:            ci.TypeCluster,
+		K8sDecorator:          localNodeDecorator,
+		Logger:                acir.settings.Logger,
+	}
 
-        scraperOpts := prometheusscraper.SimplePrometheusScraperOpts{
-                Ctx:               ctx,
-                TelemetrySettings: acir.settings,
-                Consumer:          &decoConsumer,
-                Host:              host,
-                ScraperConfigs:    karpenter.GetKarpenterScrapeConfig(hostInfo),
-                HostInfoProvider:  hostInfo,
-                Logger:            acir.settings.Logger,
-        }
+	karpenterEmptyMetricDecorator := karpenter.EmptyMetricDecorator{
+		NextConsumer: &decoConsumer,
+		Logger:       acir.settings.Logger,
+		MetricType:   ci.TypeCluster,
+	}
 
-        var err error
-        acir.karpenterScraper, err = prometheusscraper.NewSimplePrometheusScraper(scraperOpts)
-        return err
+	scraperOpts := prometheusscraper.SimplePrometheusScraperOpts{
+		Ctx:               ctx,
+		TelemetrySettings: acir.settings,
+		Consumer:          &karpenterEmptyMetricDecorator,
+		Host:              host,
+		ScraperConfigs:    karpenter.GetKarpenterScrapeConfig(hostInfo),
+		HostInfoProvider:  hostInfo,
+		Logger:            acir.settings.Logger,
+	}
+
+	var err error
+	acir.karpenterScraper, err = prometheusscraper.NewSimplePrometheusScraper(scraperOpts)
+	return err
 }
 
 // Shutdown stops the awsContainerInsightReceiver receiver.
@@ -549,7 +553,9 @@ func (acir *awsContainerInsightReceiver) collectData(ctx context.Context) error 
 	}
 
 	if acir.containerMetricsProvider != nil {
-		mds = append(mds, acir.containerMetricsProvider.GetMetrics()...)
+		containerMetrics := acir.containerMetricsProvider.GetMetrics()
+		mds = append(mds, containerMetrics...)
+		acir.settings.Logger.Info("Container metrics collected", zap.Int("count", len(containerMetrics)))
 	}
 
 	if acir.k8sapiserver != nil {
@@ -578,16 +584,17 @@ func (acir *awsContainerInsightReceiver) collectData(ctx context.Context) error 
 	}
 
 	if acir.kedaScraper != nil {
-		acir.settings.Logger.Info("KEDA scraper trying to get metrics")
-		acir.kedaScraper.GetMetrics()
+		kedaMetrics := acir.kedaScraper.GetMetrics()
+		mds = append(mds, kedaMetrics...)
 	}
 
 	if acir.karpenterScraper != nil {
-			acir.settings.Logger.Info("Karpenter scraper trying to get metrics")
-			acir.karpenterScraper.GetMetrics()
+		karpenterMetrics := acir.karpenterScraper.GetMetrics()
+		mds = append(mds, karpenterMetrics...)
 	}
 
-	for _, md := range mds {
+	for i, md := range mds {
+		acir.settings.Logger.Info("Sending metric batch to next consumer", zap.Int("batch_index", i), zap.Int("resource_metrics", md.ResourceMetrics().Len()))
 		err := acir.nextConsumer.ConsumeMetrics(ctx, md)
 		if err != nil {
 			return err


### PR DESCRIPTION
# KEDA and Karpenter Metrics Integration for AWS Container Insights

## Overview

Added KEDA (Kubernetes Event-driven Autoscaling) and Karpenter (Node Autoscaling) metrics collection to the AWS Container Insights receiver, enabling automatic discovery and emission of scaling metrics to CloudWatch.

## Implementation

### New Components
- **`internal/keda/`** - KEDA metrics collection and processing
- **`internal/karpenter/`** - Karpenter metrics collection and processing
- **Receiver Integration** - Automatic scraper initialization in EKS environments

### Key Files
```
internal/keda/
├── metric_name.go                    # KEDA metric constants
├── keda_empty_metric_decorator.go    # Metric processing & decoration
└── scrape_config.go                  # Prometheus scraping config

internal/karpenter/
├── metric_name.go                    # Karpenter metric constants  
├── karpenter_empty_metric_decorator.go  # Metric processing & decoration
└── scrape_config.go                  # Prometheus scraping config
```

## Collected Metrics

### KEDA Metrics
- `keda_scaler_metrics_value` - Current scaler metric values
- `keda_scaler_active` - Active scaler status
- `keda_scaled_object_errors_total` - ScaledObject errors
- `keda_scaler_metrics_latency_seconds` - Scaler latency
- `keda_internal_scale_loop_latency_seconds` - Scale loop performance
- Additional error and registration metrics

### Karpenter Metrics
- `karpenter_pods_startup_time_seconds` - Pod startup timing
- `karpenter_nodepool_limit/usage` - NodePool resource metrics
- `karpenter_provisioner_limit/usage` - Provisioner resource metrics (legacy)
- `karpenter_cloudprovider_duration_seconds` - Cloud provider API timing
- Node replacement and disruption timing metrics



<img width="1483" height="661" alt="Screenshot 2025-08-29 at 17 34 56" src="https://github.com/user-attachments/assets/667de819-e5a0-4464-8c8a-44f3a6d01841" />
<img width="1492" height="257" alt="Screenshot 2025-08-29 at 17 48 35" src="https://github.com/user-attachments/assets/2fba6839-c709-4b4f-96e9-f7275afa862e" />


<!--Please delete paragraphs that you did not use before submitting.-->
