### PR TITLE
[awscontainerinsightreceiver] Set NodeName for PV and PVC metrics collected from leader node

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
@@ -287,7 +287,7 @@ func (k *K8sAPIServer) getServiceMetrics(clusterName, timestampNs string) []pmet
 			ci.Version:        "0",
 		}
 		if k.nodeName != "" {
-			attributes["NodeName"] = k.nodeName
+			attributes[ci.NodeNameKey] = k.nodeName
 		}
 		attributes[ci.SourcesKey] = "[\"apiserver\"]"
 		attributes[ci.Kubernetes] = fmt.Sprintf("{\"namespace_name\":\"%s\",\"service_name\":\"%s\"}",
@@ -518,7 +518,7 @@ func (k *K8sAPIServer) getPersistentVolumeClaimMetrics(clusterName, timestampNs 
 			continue
 		}
 		namespace, pvcName := parts[0], parts[1]
-		pvcFields := map[string]any{
+		fields := map[string]any{
 			ci.MetricName(ci.TypePersistentVolumeClaim, ci.Count):         1,
 			ci.MetricName(ci.TypePersistentVolumeClaim, ci.StatusPending): 0,
 			ci.MetricName(ci.TypePersistentVolumeClaim, ci.StatusBound):   0,
@@ -527,18 +527,18 @@ func (k *K8sAPIServer) getPersistentVolumeClaimMetrics(clusterName, timestampNs 
 
 		switch phase {
 		case v1.ClaimPending:
-			pvcFields[ci.MetricName(ci.TypePersistentVolumeClaim, ci.StatusPending)] = 1
+			fields[ci.MetricName(ci.TypePersistentVolumeClaim, ci.StatusPending)] = 1
 		case v1.ClaimBound:
-			pvcFields[ci.MetricName(ci.TypePersistentVolumeClaim, ci.StatusBound)] = 1
+			fields[ci.MetricName(ci.TypePersistentVolumeClaim, ci.StatusBound)] = 1
 		case v1.ClaimLost:
-			pvcFields[ci.MetricName(ci.TypePersistentVolumeClaim, ci.StatusLost)] = 1
+			fields[ci.MetricName(ci.TypePersistentVolumeClaim, ci.StatusLost)] = 1
 		default:
 			k.logger.Warn("Unexpected PVC phase", zap.String(ci.PersistentVolumeClaimName, pvcName),
 				zap.String("phase", string(phase)))
 			continue
 		}
 
-		pvcAttributes := map[string]string{
+		attributes := map[string]string{
 			ci.ClusterNameKey:            clusterName,
 			ci.MetricType:                ci.TypePersistentVolumeClaim,
 			ci.Timestamp:                 timestampNs,
@@ -547,8 +547,11 @@ func (k *K8sAPIServer) getPersistentVolumeClaimMetrics(clusterName, timestampNs 
 			ci.Version:                   "0",
 			ci.SourcesKey:                "[\"apiserver\"]",
 		}
-
-		md := ci.ConvertToOTLPMetrics(pvcFields, pvcAttributes, k.logger)
+		if k.nodeName != "" {
+			attributes[ci.NodeNameKey] = k.nodeName
+		}
+		attributes[ci.SourcesKey] = "[\"apiserver\"]"
+		md := ci.ConvertToOTLPMetrics(fields, attributes, k.logger)
 		metrics = append(metrics, md)
 	}
 
@@ -560,18 +563,21 @@ func (k *K8sAPIServer) getPersistentVolumeMetrics(clusterName, timestampNs strin
 
 	pvMetrics := k.leaderElection.persistentVolumeClient.GetPersistentVolumeMetrics()
 
-	clusterFields := map[string]any{
+	fields := map[string]any{
 		ci.MetricName(ci.TypePersistentVolume, ci.Count): pvMetrics.ClusterCount,
 	}
 
-	clusterAttributes := map[string]string{
+	attributes := map[string]string{
 		ci.ClusterNameKey: clusterName,
 		ci.MetricType:     ci.TypePersistentVolume,
 		ci.Timestamp:      timestampNs,
 		ci.Version:        "0",
 		ci.SourcesKey:     "[\"apiserver\"]",
 	}
-	md := ci.ConvertToOTLPMetrics(clusterFields, clusterAttributes, k.logger)
+	if k.nodeName != "" {
+		attributes[ci.NodeNameKey] = k.nodeName
+	}
+	md := ci.ConvertToOTLPMetrics(fields, attributes, k.logger)
 	metrics = append(metrics, md)
 
 	return metrics

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver.go
@@ -550,7 +550,6 @@ func (k *K8sAPIServer) getPersistentVolumeClaimMetrics(clusterName, timestampNs 
 		if k.nodeName != "" {
 			attributes[ci.NodeNameKey] = k.nodeName
 		}
-		attributes[ci.SourcesKey] = "[\"apiserver\"]"
 		md := ci.ConvertToOTLPMetrics(fields, attributes, k.logger)
 		metrics = append(metrics, md)
 	}

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
@@ -504,7 +504,9 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 			assertMetricValueEqual(t, metric, "hyperpod_node_health_status_unschedulable_pending_replacement", int64(0))
 		case ci.TypePersistentVolume:
 			assertMetricValueEqual(t, metric, "persistent_volume_count", int64(5))
+			assert.Equal(t, hostName, getStringAttrVal(metric, ci.NodeNameKey))
 		case ci.TypePersistentVolumeClaim:
+			assert.Equal(t, hostName, getStringAttrVal(metric, ci.NodeNameKey))
 			namespace := getStringAttrVal(metric, ci.K8sNamespace)
 			pvcName := getStringAttrVal(metric, ci.PersistentVolumeClaimName)
 			pvcKey := namespace + "/" + pvcName


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/339 introduced PersistentVolume and PersistentVolumeClaim metrics that are scraped from the leader node. Though these are not specific to the cluster, we typically set the `NodeName` attribute on these metrics to that of the leader node itself such that the EMF logs for these end up in a log stream for that node.
Without the `NodeName` attribute, the log stream defaults to `undefined`.

This change sets the `NodeName` for these new metrics, consistent with the other metrics in the same file. 

#### Testing
* Before change:
<img width="434" height="262" alt="image" src="https://github.com/user-attachments/assets/25690b98-eccc-4599-9506-7303a4107f73" />

* After change:
<img width="542" height="121" alt="image" src="https://github.com/user-attachments/assets/d8c0b245-3027-442d-9ac7-20fc5b6dd8a1" />

