### PR TITLE
[awscontainerinsightreceiver] Add accelerated_compute_gpu_metrics_collection_interval config to support gpu metrics collection interval customization

### DIFF
--- a/receiver/awscontainerinsightreceiver/config.go
+++ b/receiver/awscontainerinsightreceiver/config.go
@@ -74,6 +74,9 @@ type Config struct {
 	// EnableAcceleratedComputeMetrics enables features with accelerated compute resources where metrics are scraped from vendor specific sources
 	EnableAcceleratedComputeMetrics bool `mapstructure:"accelerated_compute_metrics"`
 
+	// AcceleratedComputeGPUMetricsCollectionInterval is the interval at which gpu metrics should be collected. The default is 60 second.
+	AcceleratedComputeGPUMetricsCollectionInterval time.Duration `mapstructure:"accelerated_compute_gpu_metrics_collection_interval"`
+
 	// KubeConfigPath is an optional attribute to override the default kube config path in an EC2 environment
 	KubeConfigPath string `mapstructure:"kube_config_path"`
 

--- a/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_config.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	caFile                    = "/etc/amazon-cloudwatch-observability-agent-cert/tls-ca.crt"
-	collectionInterval        = 60 * time.Second
 	jobName                   = "containerInsightsDCGMExporterScraper"
 	scraperMetricsPath        = "/metrics"
 	scraperK8sServiceSelector = "k8s-app=dcgm-exporter-service"
@@ -30,7 +29,7 @@ type hostInfoProvider interface {
 	GetInstanceType() string
 }
 
-func GetScraperConfig(hostInfoProvider hostInfoProvider) *config.ScrapeConfig {
+func GetScraperConfig(hostInfoProvider hostInfoProvider, collectionInterval time.Duration) *config.ScrapeConfig {
 	return &config.ScrapeConfig{
 		HTTPClientConfig: configutil.HTTPClientConfig{
 			TLSConfig: configutil.TLSConfig{

--- a/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/gpu/dcgmscraper_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	configutil "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -165,7 +166,7 @@ func TestNewDcgmScraperEndToEnd(t *testing.T) {
 		Consumer:          mConsumer,
 		Host:              componenttest.NewNopHost(),
 		HostInfoProvider:  mockHostInfoProvider{},
-		ScraperConfigs:    GetScraperConfig(mockHostInfoProvider{}),
+		ScraperConfigs:    GetScraperConfig(mockHostInfoProvider{}, 30*time.Second),
 		Logger:            settings.Logger,
 	})
 	assert.NoError(t, err)
@@ -243,4 +244,14 @@ func TestNewDcgmScraperEndToEnd(t *testing.T) {
 func TestDcgmScraperJobName(t *testing.T) {
 	// needs to start with containerInsights
 	assert.True(t, strings.HasPrefix(jobName, "containerInsightsDCGMExporterScraper"))
+}
+
+func TestGetScraperConfig(t *testing.T) {
+	hostInfoProvider := mockHostInfoProvider{}
+	customInterval := 30 * time.Second
+	config := GetScraperConfig(hostInfoProvider, customInterval)
+
+	// Verify the custom collection interval is used
+	assert.Equal(t, model.Duration(customInterval), config.ScrapeInterval)
+	assert.Equal(t, model.Duration(customInterval), config.ScrapeTimeout)
 }

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -319,7 +319,7 @@ func (acir *awsContainerInsightReceiver) initDcgmScraper(ctx context.Context, ho
 		TelemetrySettings: acir.settings,
 		Consumer:          &decoConsumer,
 		Host:              host,
-		ScraperConfigs:    gpu.GetScraperConfig(hostInfo),
+		ScraperConfigs:    gpu.GetScraperConfig(hostInfo, acir.config.AcceleratedComputeGPUMetricsCollectionInterval),
 		HostInfoProvider:  hostInfo,
 		Logger:            acir.settings.Logger,
 	}


### PR DESCRIPTION
#### Note
This PR is part of enabling high frequency gpu metrics, other related PRs are [ 371](https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/371) and [1893](https://github.com/aws/amazon-cloudwatch-agent/pull/1893). 

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR introduces a new config field - `accelerated_compute_gpu_metrics_collection_interval` to let customer configure gpu metrics collection interval based on their own use case. For example, setting this value to `1` would denote cloudwatch agent to scrape gpu metrics every second.


<!--Describe what testing was performed and which tests were added.-->
#### Testing
1. set up this field in helm-chat configuration as follows:

```
agents:
  - name: cloudwatch-agent
agent:
  name:
  mode: daemonset # Represents the mode the AmazonCloudWatchAgent workload will run in (deployment, daemonset or statefulset)
  replicas: 1
  defaultConfig:
    {
      "logs": {
        "metrics_collected": {
          "kubernetes": {
            "enhanced_container_insights": true,
            "accelerated_compute_gpu_metrics_collection_interval": 1

          },
        }
      },
      "traces": {
        "traces_collected": {
          "application_signals": { }
        }
      }
    }
   ```
2. deploy agent code and helm chart and verified there were 60 datapoints each min.
  ```
{
    "CloudWatchMetrics": [
        {
            "Namespace": "ContainerInsights",
            "Dimensions": [
                [
                    "ClusterName"
                ],
                [
                    "ClusterName",
                    "ContainerName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName",
                    "ContainerName",
                    "FullPodName",
                    "Namespace",
                    "PodName"
                ],
                [
                    "ClusterName",
                    "ContainerName",
                    "FullPodName",
                    "GpuDevice",
                    "Namespace",
                    "PodName"
                ]
            ],
            "Metrics": [
                {
                    "Name": "container_gpu_temperature",
                    "Unit": "None",
                    "StorageResolution": 60
                },
                {
                    "Name": "container_gpu_power_draw",
                    "Unit": "None",
                    "StorageResolution": 60
                },
                {
                    "Name": "container_gpu_utilization",
                    "Unit": "Percent",
                    "StorageResolution": 60
                },
                {
                    "Name": "container_gpu_memory_utilization",
                    "Unit": "Percent",
                    "StorageResolution": 60
                },
                {
                    "Name": "container_gpu_memory_used",
                    "Unit": "Bytes",
                    "StorageResolution": 60
                },
                {
                    "Name": "container_gpu_memory_total",
                    "Unit": "Bytes",
                    "StorageResolution": 60
                }
            ]
        }
    ],
    "ClusterName": "cpipeline",
    "ContainerName": "main",
    "FullPodName": "gpu-burn-577f5d7468-4j54s",
    "GpuDevice": "nvidia0",
    "InstanceId": "i-0f01fff8faa360227",
    "InstanceType": "g4dn.xlarge",
    "Namespace": "kube-system",
    "NodeName": "ip-192-168-6-219.ec2.internal",
    "PodName": "gpu-burn",
    "Sources": [
        "dcgm",
        "pod",
        "calculated"
    ],
    "Timestamp": "1760375344178",
    "Type": "ContainerGPU",
    "UUID": "GPU-60efa417-4d26-c4ba-9e62-66249559952d",
    "Version": "0",
    "kubernetes": {
        "container_name": "main",
        "containerd": {
            "container_id": "5bfc51b6805d8bdc96e34f262394ae2702cc5d55ad186c660acbef414aa86223"
        },
        "host": "ip-192-168-6-219.ec2.internal",
        "labels": {
            "app": "gpu-burn",
            "pod-template-hash": "577f5d7468"
        },
        "pod_name": "gpu-burn-577f5d7468-4j54s",
        "pod_owners": [
            {
                "owner_kind": "Deployment",
                "owner_name": "gpu-burn"
            }
        ]
    },
    "container_gpu_memory_total": {
        "Values": [
            16006027360
        ],
        "Counts": [
            60
        ],
        "Max": 16006027360,
        "Min": 16006027360,
        "Count": 60,
        "Sum": 982473768960
    },
    "container_gpu_memory_used": {
        "Values": [
            0,
            176060768,
            245366784,
            14254342144,
            253755392,
            111149056,
            207608048,
            251658240
        ],
        "Counts": [
            8,
            1,
            1,
            46,
            1,
            1,
            1,
            1
        ],
        "Max": 14254342144,
        "Min": 0,
        "Count": 60,
        "Sum": 656945446912
    },
    "container_gpu_memory_utilization": {
        "Values": [
            1.185,
            0.9862,
            90.0607,
            1.609,
            0.6948,
            1.3572000000000002,
            1.5559999999999998,
            0
        ],
        "Counts": [
            1,
            1,
            46,
            1,
            1,
            1,
            1,
            8
        ],
        "Max": 90.0607,
        "Min": 0,
        "Count": 60,
        "Sum": 4150.226400000004
    },
    "container_gpu_power_draw": {
        "Values": [
            32.662,
            70.563,
            69.099,
            32.760,
            69.49,
            33.549,
            69.978,
            69.197,
            33.844,
            63.907,
            65.919,
            70.368,
            70.27,
            38.921,
            69.435,
            68.360,
            69.88,
            70.173,
            68.318,
            70.119,
            67.872,
            70.466,
            65.626,
            67.97,
            69.826,
            32.859,
            33.352,
            70.660,
            70.075,
            33.253,
            69.294,
            69.587,
            68.904,
            38.429,
            82.459,
            69.685,
            69.392,
            68.849,
            69.782,
            68.458
        ],
        "Counts": [
            2,
            2,
            1,
            1,
            1,
            1,
            4,
            1,
            1,
            1,
            1,
            1,
            3,
            1,
            1,
            1,
            3,
            1,
            1,
            1,
            1,
            1,
            1,
            1,
            1,
            4,
            1,
            3,
            2,
            2,
            1,
            1,
            1,
            1,
            1,
            4,
            1,
            1,
            2,
            1
        ],
        "Max": 82.459,
        "Min": 32.662,
        "Count": 60,
        "Sum": 3748.8209999999995
    },
    "container_gpu_temperature": {
        "Values": [
            42,
            43,
            44
        ],
        "Counts": [
            12,
            32,
            16
        ],
        "Max": 44,
        "Min": 42,
        "Count": 60,
        "Sum": 2628
    },
    "container_gpu_utilization": {
        "Values": [
            96,
            6,
            8,
            14,
            58,
            0,
            64,
            9,
            89,
            7,
            100
        ],
        "Counts": [
            1,
            1,
            1,
            1,
            1,
            6,
            1,
            1,
            1,
            2,
            44
        ],
        "Max": 100,
        "Min": 0,
        "Count": 60,
        "Sum": 4858
    }
}
   ```




<!--Please delete paragraphs that you did not use before submitting.-->
