### PR TITLE
Add support for AggregateAcrossMBeans field.

### DIFF
--- a/receiver/jmxreceiver/config.go
+++ b/receiver/jmxreceiver/config.go
@@ -66,6 +66,9 @@ type Config struct {
 	RemoteProfile string `mapstructure:"remote_profile,omitempty"`
 	// The SASL/DIGEST-MD5 realm
 	Realm string `mapstructure:"realm,omitempty"`
+	// AggregateAcrossMBeans for cases where the MBean query returns multiple MBeans (e.g. one of the attributes is *).
+	// When enabled, aggregates the values of the returned beans. Returns the value for the first bean if not enabled.
+	AggregateAcrossMBeans bool `mapstructure:"aggregate_across_mbeans,omitempty"`
 	// Array of additional JARs to be added to the class path when launching the JMX Metric Gatherer JAR
 	AdditionalJars []string `mapstructure:"additional_jars,omitempty"`
 	// Map of resource attributes used by the Java SDK Autoconfigure to set resource attributes

--- a/receiver/jmxreceiver/receiver.go
+++ b/receiver/jmxreceiver/receiver.go
@@ -216,6 +216,7 @@ func (jmx *jmxMetricReceiver) buildJMXMetricGathererConfig() (string, error) {
 		config["otel.exporter.otlp.headers"] = jmx.config.OTLPExporterConfig.headersToString()
 	}
 	config["otel.jmx.remote.registry.ssl"] = strconv.FormatBool(jmx.config.JMXRegistrySSLEnabled)
+	config["otel.jmx.aggregate.across.mbeans"] = strconv.FormatBool(jmx.config.AggregateAcrossMBeans)
 
 	var passwordMap map[string]string
 	if jmx.config.PasswordFile != "" {

--- a/receiver/jmxreceiver/receiver_test.go
+++ b/receiver/jmxreceiver/receiver_test.go
@@ -84,6 +84,7 @@ truststore = trustpass
 					"abc": "123",
 					"one": "two",
 				},
+				AggregateAcrossMBeans: true,
 			},
 			`javax.net.ssl.keyStore = /my/keystore
 javax.net.ssl.keyStorePassword = keypass
@@ -94,6 +95,7 @@ javax.net.ssl.trustStoreType = ASCII
 otel.exporter.otlp.endpoint = https://myotlpendpoint
 otel.exporter.otlp.headers = one=two,three=four
 otel.exporter.otlp.timeout = 234000
+otel.jmx.aggregate.across.mbeans = true
 otel.jmx.interval.milliseconds = 123000
 otel.jmx.password = mypass \nword
 otel.jmx.realm = myrealm
@@ -121,6 +123,7 @@ otel.resource.attributes = abc=123,one=two`,
 javax.net.ssl.trustStorePassword = trustpass
 otel.exporter.otlp.endpoint = https://myotlpendpoint
 otel.exporter.otlp.timeout = 0
+otel.jmx.aggregate.across.mbeans = false
 otel.jmx.interval.milliseconds = 0
 otel.jmx.password = mypassword
 otel.jmx.remote.registry.ssl = false

--- a/receiver/jmxreceiver/supported_jars.go
+++ b/receiver/jmxreceiver/supported_jars.go
@@ -31,10 +31,21 @@ func oldFormatProperties(c *Config, j supportedJar) error {
 // If you change this variable name, please open an issue in opentelemetry-java-contrib
 // so that repository's release automation can be updated
 var jmxMetricsGathererVersions = map[string]supportedJar{
-	// Remove once https://github.com/open-telemetry/opentelemetry-java-contrib/pull/1366 has been merged and released.
-	"14f28b1c45e6ad91faa7f25462bfd96e6ab3b6980afe5534f92b8a4973895cbb": {
-		version: "1.37.0-fix",
-		jar:     "JMX metrics gatherer w/ Tomcat metrics fix",
+	"0ef4abb0da557fc424867bcd55d73459cf9f6374842775fa2e64a9fcc0fe232c": {
+		version: "1.50.0-alpha",
+		jar:     "JMX metrics gatherer",
+	},
+	"914d590f31aa7fa8d0a8765eaea665fd15a345f3fce447949e09dd78c6e1d68c": {
+		version: "1.49.0-alpha",
+		jar:     "JMX metrics gatherer",
+	},
+	"dd1ab4cb7fd45c30cf4e8090f9289a42b2c7bc1e7377536eef2c40c51d8641ae": {
+		version: "1.48.0-alpha",
+		jar:     "JMX metrics gatherer",
+	},
+	"0344be738295602718934accd0557496b10464582681e69a251dc3b8d3f69b69": {
+		version: "1.47.0-alpha",
+		jar:     "JMX metrics gatherer",
 	},
 	"291c6071e6702ae8d81b712582f8e2f312e6b35633b603eada46e3984e5cd020": {
 		version: "1.46.0-alpha",


### PR DESCRIPTION
#### Description
Before https://github.com/open-telemetry/opentelemetry-java-contrib/pull/1366 was merged in and released, we relied on a custom build of the OpenTelemetry JMX Metrics Gatherer JAR. Now that it's been released, we can remove the custom build and integrate the changes.

The aggregation across MBeans was added to fix a bug in the JMX metrics (specifically Tomcat sessions), which resulted in inaccurate metric values. The `jmx-metrics` PR adds an opt-in `otel.jmx.aggregate.across.mbeans` flag, which needs to be added to the `jmxreceiver` as well.

Also updates the `supported_jars.go` based on https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/b0687d7f57944ce400438563304f4f934f59c4b9/receiver/jmxreceiver/supported_jars.go#L56-L71

#### Testing
Updated the unit test and ran the integration tests (https://github.com/aws/amazon-cloudwatch-agent/actions/runs/18475790845/job/52640228392) against the build.
