### PR TITLE
Support setting `inProgress` segment-field in X-Ray Exporter

### DIFF
--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -334,8 +334,8 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 	attributes := span.Attributes()
 
 	var (
-		startTime                                          = timestampToFloatSeconds(span.StartTimestamp())
-		endTime, inProgress                                = makeEndTimeAndInProgress(span, attributes)
+		startTimePtr                                       = awsP.Float64(timestampToFloatSeconds(span.StartTimestamp()))
+		endTimePtr, inProgress                             = makeEndTimeAndInProgress(span, attributes)
 		httpfiltered, http                                 = makeHTTP(span)
 		isError, isFault, isThrottle, causefiltered, cause = makeCause(span, httpfiltered, resource)
 		origin                                             = determineAwsOrigin(resource)
@@ -456,8 +456,8 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 		ID:          awsxray.String(traceutil.SpanIDToHexOrEmptyString(span.SpanID())),
 		TraceID:     awsxray.String(traceID),
 		Name:        awsxray.String(name),
-		StartTime:   awsP.Float64(startTime),
-		EndTime:     endTime,
+		StartTime:   startTimePtr,
+		EndTime:     endTimePtr,
 		InProgress:  inProgress,
 		ParentID:    awsxray.String(traceutil.SpanIDToHexOrEmptyString(span.ParentSpanID())),
 		Fault:       awsP.Bool(isFault),
@@ -767,8 +767,7 @@ func makeEndTimeAndInProgress(span ptrace.Span, attributes pcommon.Map) (*float6
 			return nil, &inProgressVal
 		}
 	}
-	endTimeVal := timestampToFloatSeconds(span.EndTimestamp())
-	return &endTimeVal, nil
+	return awsP.Float64(timestampToFloatSeconds(span.EndTimestamp())), nil
 }
 
 func trimAwsSdkPrefix(name string, span ptrace.Span) string {

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -335,7 +335,7 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 
 	var (
 		startTime                                          = timestampToFloatSeconds(span.StartTimestamp())
-		endTime                                            = timestampToFloatSeconds(span.EndTimestamp())
+		endTime, inProgress                                = makeEndTimeAndInProgress(span, attributes)
 		httpfiltered, http                                 = makeHTTP(span)
 		isError, isFault, isThrottle, causefiltered, cause = makeCause(span, httpfiltered, resource)
 		origin                                             = determineAwsOrigin(resource)
@@ -457,7 +457,8 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 		TraceID:     awsxray.String(traceID),
 		Name:        awsxray.String(name),
 		StartTime:   awsP.Float64(startTime),
-		EndTime:     awsP.Float64(endTime),
+		EndTime:     endTime,
+		InProgress:  inProgress,
 		ParentID:    awsxray.String(traceutil.SpanIDToHexOrEmptyString(span.ParentSpanID())),
 		Fault:       awsP.Bool(isFault),
 		Error:       awsP.Bool(isError),
@@ -756,6 +757,18 @@ func fixAnnotationKey(key string) string {
 			return '_'
 		}
 	}, key)
+}
+
+func makeEndTimeAndInProgress(span ptrace.Span, attributes pcommon.Map) (*float64, *bool) {
+	if inProgressAttr, ok := attributes.Get(awsxray.AWSXRayInProgressAttribute); ok && inProgressAttr.Type() == pcommon.ValueTypeBool {
+		inProgressVal := inProgressAttr.Bool()
+		attributes.Remove(awsxray.AWSXRayInProgressAttribute)
+		if inProgressVal {
+			return nil, &inProgressVal
+		}
+	}
+	endTimeVal := timestampToFloatSeconds(span.EndTimestamp())
+	return &endTimeVal, nil
 }
 
 func trimAwsSdkPrefix(name string, span ptrace.Span) string {

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -1444,6 +1444,11 @@ func TestLocalRootConsumer(t *testing.T) {
 	// Checks these values are the same for both
 	assert.Equal(t, segments[0].StartTime, segments[1].StartTime)
 	assert.Equal(t, segments[0].EndTime, segments[1].EndTime)
+
+	// Check that segment EndTime matches span's EndTime
+	expectedEndTime := float64(span.EndTimestamp()) / float64(time.Second)
+	assert.Equal(t, expectedEndTime, *segments[0].EndTime)
+	assert.Equal(t, expectedEndTime, *segments[1].EndTime)
 }
 
 func TestNonLocalRootConsumerProcess(t *testing.T) {

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -1966,6 +1966,8 @@ func constructSpanAttributes(attributes map[string]any) pcommon.Map {
 			attrs.PutInt(key, int64(cast))
 		} else if cast, ok := value.(int64); ok {
 			attrs.PutInt(key, cast)
+		} else if cast, ok := value.(bool); ok {
+			attrs.PutBool(key, cast)
 		} else if cast, ok := value.([]string); ok {
 			slice := attrs.PutEmptySlice(key)
 			for _, v := range cast {
@@ -2041,6 +2043,40 @@ func constructTimedEventsWithSentMessageEvent(tm pcommon.Timestamp) ptrace.SpanE
 }
 
 // newTraceID generates a new valid X-Ray TraceID
+func TestSpanWithInProgressTrue(t *testing.T) {
+	spanName := "/api/test"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]any)
+	attributes[awsxray.AWSXRayInProgressAttribute] = true
+	resource := constructDefaultResource()
+	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeOk, "OK", attributes)
+
+	segment, _ := MakeSegment(span, resource, nil, false, nil, false)
+
+	assert.NotNil(t, segment)
+	assert.NotNil(t, segment.InProgress)
+	assert.True(t, *segment.InProgress)
+	assert.Nil(t, segment.EndTime)
+	assert.Nil(t, segment.Metadata["default"][awsxray.AWSXRayInProgressAttribute])
+}
+
+func TestSpanWithInProgressFalse(t *testing.T) {
+	spanName := "/api/test"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]any)
+	attributes[awsxray.AWSXRayInProgressAttribute] = false
+	resource := constructDefaultResource()
+	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeOk, "OK", attributes)
+
+	segment, _ := MakeSegment(span, resource, nil, false, nil, false)
+
+	assert.NotNil(t, segment)
+	assert.Nil(t, segment.InProgress)
+	assert.NotNil(t, segment.EndTime)
+	assert.Empty(t, segment.Annotations)
+	assert.Nil(t, segment.Metadata["default"][awsxray.AWSXRayInProgressAttribute])
+}
+
 func newTraceID() pcommon.TraceID {
 	var r [16]byte
 	epoch := time.Now().Unix()


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

When using OTel Collector with `X-Ray Receiver/Exporter`, X-Ray Segment gets converted into OpenTelemetry Span (via X-Ray Receiver) and then later gets converted into X-Ray Segment (via X-Ray Exporter).

In X-Ray Receiver, we explicitly convert the `in_progress` Segment field attribute into the `aws.xray.inprogress` attribute.

- https://github.com/amazon-contributing/opentelemetry-collector-contrib/blob/ae1729ad22c4c81735d883c1f8b2fa85c06e0f39/receiver/awsxrayreceiver/internal/translator/translator.go#L168

In X-Ray Exporter, we **don't** convert the `aws.xray.inprogress` attribute back into the `in_progress` Segment field:

- https://github.com/amazon-contributing/opentelemetry-collector-contrib/blob/ae1729ad22c4c81735d883c1f8b2fa85c06e0f39/exporter/awsxrayexporter/internal/translator/segment.go#L336-L350

Therefore the `in_progress` functionality does not function as it was intended as it is now part of metadata instead of being a Segment field. This PR fixes this issue by ensuring that `in_progress` is converted back into a Segment field if the original Segment ingested by X-Ray Receiver had `in_progress` set.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
N/A

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Tested with OCB:
`builder-config.yaml`:
```yaml
dist:
  name: otelcol-dev-0.138.0
  description: Basic OTel Collector distribution for Developers
  output_path: ./otelcol-dev-prod-0.138.0
  otelcol_version: 0.138.0

exporters:
  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.138.0

receivers:
  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.138.0
  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.138.0

extensions:
  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy v0.138.0

replaces:
  - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.138.0 => github.com/jj22ee/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.138.1
```

config.yaml
```yaml
extensions:
  awsproxy:
    local_mode: true
    region: 'us-west-2'
  #health_check:

receivers:
  awsxray:
    transport: udp
    proxy_server:
      tls:
        insecure: false
        server_name_override: ""
      region: 'us-west-2'
      role_arn: ""
      aws_endpoint: ""
      local_mode: true
  otlp:
    protocols:
      grpc:
        endpoint: 0.0.0.0:4315
      http:
        endpoint: 0.0.0.0:4316

exporters:
  awsxray:
    region: 'us-west-2'
    index_all_attributes: true

service:
  pipelines:
    traces:
      receivers: [awsxray, otlp]
      exporters: [awsxray]

  extensions: [awsproxy] #[health_check]
  telemetry:
    logs:
      level: debug
```

Send segment to OTel Collector:
> `cat sample-trace.json | nc -u 127.0.0.1 2000`

sample-trace.json:
```
{"format":"json","version":1}
{"type":"segment","trace_id":"1-64d8bfaf-fd72e26886b3fdd3a272224e","id":"6222467a3d841238","start_time":1759136781.313,"in_progress":true,"name":"testName","user":"213456","origin":"AWS::EC2::Instance","namespace":"aws","aws":{"account_id":"123456789012"}}
```
<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
