### PR TITLE
[internal/useragent] Add user agent string when EBS metrics exist

### DIFF
--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -231,7 +231,7 @@ func (emf *emfExporter) start(_ context.Context, host component.Host) error {
 	// Below are optimizatons to minimize amoount of
 	// metrics processing. We have two scearios
 	// 1. AppSignal - Only run Process function for AppSignal related useragent
-	// 2. Enhanced Container Insights - Only run ProcessMetrics function for CI EBS related useragent
+	// 2. Enhanced Container Insights - Only run ProcessMetrics function for CI related useragent
 	if emf.config.IsAppSignalsEnabled() || emf.config.IsEnhancedContainerInsights() {
 		userAgent := useragent.NewUserAgent()
 		emf.svcStructuredLog.Handlers().Build.PushFrontNamed(userAgent.Handler())

--- a/exporter/awsemfexporter/internal/useragent/useragent.go
+++ b/exporter/awsemfexporter/internal/useragent/useragent.go
@@ -28,9 +28,16 @@ const (
 
 	// TODO: Available in semconv/v1.21.0+. Replace after collector dependency is v0.91.0+.
 	attributeTelemetryDistroVersion = "telemetry.distro.version"
+	attributeEBS                    = "ci_ebs"
+	attributeLocalInstanceStore     = "ci_lis"
+)
 
-	attributeEBS    = "ci_ebs"
-	ebsMetricPrefix = "node_diskio_ebs"
+var (
+	// Map of NVMe feature attributes to their corresponding metric prefixes
+	featureMetricPrefixes = map[string]string{
+		attributeEBS:                "node_diskio_ebs",
+		attributeLocalInstanceStore: "node_diskio_instance_store",
+	}
 )
 
 type UserAgent struct {
@@ -95,8 +102,15 @@ func (ua *UserAgent) Process(labels map[string]string) {
 
 // ProcessMetrics checks metric names for specific patterns and updates user agent accordingly
 func (ua *UserAgent) ProcessMetrics(metrics pmetric.Metrics) {
-	// Check if we've already detected NVME
-	if _, exists := ua.featureList[attributeEBS]; exists {
+	// Check if all NVME features are already detected
+	allFeaturesFound := true
+	for feature := range featureMetricPrefixes {
+		if _, exists := ua.featureList[feature]; !exists {
+			allFeaturesFound = false
+			break
+		}
+	}
+	if allFeaturesFound {
 		return
 	}
 
@@ -107,14 +121,17 @@ func (ua *UserAgent) ProcessMetrics(metrics pmetric.Metrics) {
 			ms := ilms.At(j).Metrics()
 			for k := 0; k < ms.Len(); k++ {
 				metric := ms.At(k)
-				if strings.HasPrefix(metric.Name(), ebsMetricPrefix) {
-					ua.featureList[attributeEBS] = struct{}{}
-					ua.build()
-					return
+				for feature, prefix := range featureMetricPrefixes {
+					if strings.HasPrefix(metric.Name(), prefix) {
+						if _, exists := ua.featureList[feature]; !exists {
+							ua.featureList[feature] = struct{}{}
+						}
+					}
 				}
 			}
 		}
 	}
+	ua.build()
 }
 
 // build the user agent string from the items in the cache. Format is telemetry-sdk (<lang1>/<ver1>;<lang2>/<ver2>).

--- a/exporter/awsemfexporter/internal/useragent/useragent.go
+++ b/exporter/awsemfexporter/internal/useragent/useragent.go
@@ -32,13 +32,11 @@ const (
 	attributeLocalInstanceStore     = "ci_lis"
 )
 
-var (
-	// Map of NVMe feature attributes to their corresponding metric prefixes
-	featureMetricPrefixes = map[string]string{
-		attributeEBS:                "node_diskio_ebs",
-		attributeLocalInstanceStore: "node_diskio_instance_store",
-	}
-)
+// Map of NVMe feature attributes to their corresponding metric prefixes
+var featureMetricPrefixes = map[string]string{
+	attributeEBS:                "node_diskio_ebs",
+	attributeLocalInstanceStore: "node_diskio_instance_store",
+}
 
 type UserAgent struct {
 	mu          sync.RWMutex

--- a/exporter/awsemfexporter/internal/useragent/useragent_test.go
+++ b/exporter/awsemfexporter/internal/useragent/useragent_test.go
@@ -75,6 +75,10 @@ func TestUserAgent(t *testing.T) {
 			metrics: []string{"node_diskio_ebs_something"},
 			want:    "feature:(ci_ebs)",
 		},
+		"WithLocalInstanceStoreMetrics": {
+			metrics: []string{"node_diskio_instance_store_something"},
+			want:    "feature:(ci_lis)",
+		},
 		"WithBothTelemetryAndEBS": {
 			labelSets: []map[string]string{
 				{
@@ -85,13 +89,31 @@ func TestUserAgent(t *testing.T) {
 			metrics: []string{"node_diskio_ebs_something"},
 			want:    "telemetry-sdk (test/1.0) feature:(ci_ebs)",
 		},
+		"WithBothTelemetryAndLocalInstanceStore": {
+			labelSets: []map[string]string{
+				{
+					semconv.AttributeTelemetrySDKLanguage: "test",
+					attributeTelemetryDistroVersion:       "1.0",
+				},
+			},
+			metrics: []string{"node_diskio_instance_store_something"},
+			want:    "telemetry-sdk (test/1.0) feature:(ci_lis)",
+		},
 		"WithNonEBSMetrics": {
 			metrics: []string{"some_other_metric"},
 			want:    "",
 		},
-		"WithMultipleFeatures": {
+		"WithMultipleEBSMetrics": {
 			metrics: []string{"node_diskio_ebs_something", "node_diskio_ebs_something_else"},
 			want:    "feature:(ci_ebs)",
+		},
+		"WithMultipleLocalInstanceStoreMetrics": {
+			metrics: []string{"node_diskio_instance_store_something", "node_diskio_instance_store_something_else"},
+			want:    "feature:(ci_lis)",
+		},
+		"WithMixedEBSAndInstanceStoreMetrics": {
+			metrics: []string{"node_diskio_ebs_something", "node_diskio_ebs_something", "node_diskio_instance_store_something", "node_diskio_instance_store_something"},
+			want:    "feature:(ci_ebs ci_lis)", // Both features should be detected and sorted alphabetically
 		},
 	}
 	for name, testCase := range testCases {


### PR DESCRIPTION
#### Description
When Local Instance Store (lis) metrics are detected, add ci_lis string to User Agent

#### Testing
Unit tests

Manual testing verifies that `ci_lis` is present in the useragent field when the LIS NVME metrics are detected.

See User Agent value:
```
User-Agent: CWAgent/Unknown (go1.24.2; linux; amd64) ID/33abf24a-63f4-4695-8cdb-67e7d868349b inputs:(awscontainerinsightreceiver otlp) processors:(awsapplicationsignals awsentity batch filter gpuattributes metricstransform resourcedetection) outputs:(application_signals awsemf awsxray cloudwatchlogs debug enhanced_container_insights) feature:(ci_ebs ci_lis) / (awsemf; EnhancedEKSContainerInsights; ContainerInsights) aws-sdk-go/1.48.6 (go1.24.2; linux; amd64)
```