### PR TITLE
Add Nvme scrape configs for LIS CSI

### DIFF
--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -148,7 +148,7 @@ func (mt metricTranslator) translateOTelToGroupedMetric(rm pmetric.ResourceMetri
 			strings.HasPrefix(serviceName.Str(), "containerInsightsNeuronMonitorScraper") ||
 			strings.HasPrefix(serviceName.Str(), "containerInsightsKueueMetricsScraper") ||
 			strings.HasPrefix(serviceName.Str(), "containerInsightsNVMeEBSScraper") ||
-			strings.HasPrefix(serviceName.Str(), "containerInsightsNVMeLisExporterScraper") {
+			strings.HasPrefix(serviceName.Str(), "containerInsightsNVMeLISScraper") {
 			// the prometheus metrics that come from the container insight receiver need to be clearly tagged as coming from container insights
 			metricReceiver = containerInsightsReceiver
 		}

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -147,7 +147,8 @@ func (mt metricTranslator) translateOTelToGroupedMetric(rm pmetric.ResourceMetri
 			strings.HasPrefix(serviceName.Str(), "containerInsightsDCGMExporterScraper") ||
 			strings.HasPrefix(serviceName.Str(), "containerInsightsNeuronMonitorScraper") ||
 			strings.HasPrefix(serviceName.Str(), "containerInsightsKueueMetricsScraper") ||
-			strings.HasPrefix(serviceName.Str(), "containerInsightsNVMeEBSScraper") {
+			strings.HasPrefix(serviceName.Str(), "containerInsightsNVMeEBSScraper") ||
+			strings.HasPrefix(serviceName.Str(), "containerInsightsNVMeLisExporterScraper") {
 			// the prometheus metrics that come from the container insight receiver need to be clearly tagged as coming from container insights
 			metricReceiver = containerInsightsReceiver
 		}

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -281,7 +281,7 @@ func TestTranslateOtToGroupedMetric(t *testing.T) {
 	nvmeMetric := createTestResourceMetricsHelper(defaultNumberOfTestMetrics + 1)
 	nvmeMetric.Resource().Attributes().PutStr(conventions.AttributeServiceName, "containerInsightsNVMeEBSScraper")
 	nvmeLisMetric := createTestResourceMetricsHelper(defaultNumberOfTestMetrics + 1)
-	nvmeLisMetric.Resource().Attributes().PutStr(conventions.AttributeServiceName, "containerInsightsNVMeLisExporterScraper")
+	nvmeLisMetric.Resource().Attributes().PutStr(conventions.AttributeServiceName, "containerInsightsNVMeLISScraper")
 
 	counterSumMetrics := map[string]*metricInfo{
 		"spanCounter": {
@@ -422,7 +422,7 @@ func TestTranslateOtToGroupedMetric(t *testing.T) {
 			map[string]string{
 				"spanName": "testSpan",
 			},
-			"myServiceNS/containerInsightsNVMeLisExporterScraper",
+			"myServiceNS/containerInsightsNVMeLISScraper",
 			containerInsightsReceiver,
 		},
 	}

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -280,6 +280,8 @@ func TestTranslateOtToGroupedMetric(t *testing.T) {
 	kueueMetric.Resource().Attributes().PutStr(conventions.AttributeServiceName, "containerInsightsKueueMetricsScraper")
 	nvmeMetric := createTestResourceMetricsHelper(defaultNumberOfTestMetrics + 1)
 	nvmeMetric.Resource().Attributes().PutStr(conventions.AttributeServiceName, "containerInsightsNVMeEBSScraper")
+	nvmeLisMetric := createTestResourceMetricsHelper(defaultNumberOfTestMetrics + 1)
+	nvmeLisMetric.Resource().Attributes().PutStr(conventions.AttributeServiceName, "containerInsightsNVMeLisExporterScraper")
 
 	counterSumMetrics := map[string]*metricInfo{
 		"spanCounter": {
@@ -408,6 +410,19 @@ func TestTranslateOtToGroupedMetric(t *testing.T) {
 				"spanName": "testSpan",
 			},
 			"myServiceNS/containerInsightsNVMeEBSScraper",
+			containerInsightsReceiver,
+		},
+		{
+			"nvme lis receiver",
+			nvmeLisMetric,
+			map[string]string{
+				"isItAnError": "false",
+				"spanName":    "testSpan",
+			},
+			map[string]string{
+				"spanName": "testSpan",
+			},
+			"myServiceNS/containerInsightsNVMeLisExporterScraper",
 			containerInsightsReceiver,
 		},
 	}

--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -223,7 +223,6 @@ const (
 	TypeNodeEFA         = "NodeEFA"
 	TypeHyperPodNode    = "HyperPodNode"
 	TypeNodeNVME        = "NodeNVME"
-	TypeNodeLISNVME     = "NodeInstanceStore"
 
 	// unit
 	UnitBytes       = "Bytes"

--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -223,6 +223,7 @@ const (
 	TypeNodeEFA         = "NodeEFA"
 	TypeHyperPodNode    = "HyperPodNode"
 	TypeNodeNVME        = "NodeNVME"
+	TypeNodeLISNVME     = "NodeInstanceStore"
 
 	// unit
 	UnitBytes       = "Bytes"

--- a/receiver/awscontainerinsightreceiver/internal/nvme/metric_unit.go
+++ b/receiver/awscontainerinsightreceiver/internal/nvme/metric_unit.go
@@ -19,9 +19,21 @@ const (
 	ebsExceededEC2IOPSTime = "aws_ebs_csi_ec2_exceeded_iops_seconds_total"
 	ebsExceededEC2TPTime   = "aws_ebs_csi_ec2_exceeded_tp_seconds_total"
 	ebsVolumeQueueLength   = "aws_ebs_csi_volume_queue_length"
+
+	// LIS Original Metric Names
+	lisReadOpsTotal        = "aws_ec2_instance_store_csi_read_ops_total"
+	lisWriteOpsTotal       = "aws_ec2_instance_store_csi_write_ops_total"
+	lisReadBytesTotal      = "aws_ec2_instance_store_csi_read_bytes_total"
+	lisWriteBytesTotal     = "aws_ec2_instance_store_csi_write_bytes_total"
+	lisReadTime            = "aws_ec2_instance_store_csi_read_seconds_total"
+	lisWriteTime           = "aws_ec2_instance_store_csi_write_seconds_total"
+	lisExceededIOPSTime    = "aws_ec2_instance_store_csi_ec2_exceeded_iops_seconds_total"
+	lisExceededTPTime      = "aws_ec2_instance_store_csi_ec2_exceeded_tp_seconds_total"
+	lisVolumeQueueLength   = "aws_ec2_instance_store_csi_volume_queue_length"
 )
 
 var MetricToUnit = map[string]string{
+	// EBS metrics
 	ebsReadOpsTotal:        containerinsight.UnitCount,
 	ebsWriteOpsTotal:       containerinsight.UnitCount,
 	ebsReadBytesTotal:      containerinsight.UnitBytes,
@@ -33,4 +45,15 @@ var MetricToUnit = map[string]string{
 	ebsExceededEC2IOPSTime: containerinsight.UnitSecond,
 	ebsExceededEC2TPTime:   containerinsight.UnitSecond,
 	ebsVolumeQueueLength:   containerinsight.UnitCount,
+
+	// LIS metrics
+	lisReadOpsTotal:      containerinsight.UnitCount,
+	lisWriteOpsTotal:     containerinsight.UnitCount,
+	lisReadBytesTotal:    containerinsight.UnitBytes,
+	lisWriteBytesTotal:   containerinsight.UnitBytes,
+	lisReadTime:          containerinsight.UnitSecond,
+	lisWriteTime:         containerinsight.UnitSecond,
+	lisExceededIOPSTime:  containerinsight.UnitSecond,
+	lisExceededTPTime:    containerinsight.UnitSecond,
+	lisVolumeQueueLength: containerinsight.UnitCount,
 }

--- a/receiver/awscontainerinsightreceiver/internal/nvme/metric_unit.go
+++ b/receiver/awscontainerinsightreceiver/internal/nvme/metric_unit.go
@@ -21,15 +21,15 @@ const (
 	ebsVolumeQueueLength   = "aws_ebs_csi_volume_queue_length"
 
 	// LIS Original Metric Names
-	lisReadOpsTotal        = "aws_ec2_instance_store_csi_read_ops_total"
-	lisWriteOpsTotal       = "aws_ec2_instance_store_csi_write_ops_total"
-	lisReadBytesTotal      = "aws_ec2_instance_store_csi_read_bytes_total"
-	lisWriteBytesTotal     = "aws_ec2_instance_store_csi_write_bytes_total"
-	lisReadTime            = "aws_ec2_instance_store_csi_read_seconds_total"
-	lisWriteTime           = "aws_ec2_instance_store_csi_write_seconds_total"
-	lisExceededIOPSTime    = "aws_ec2_instance_store_csi_ec2_exceeded_iops_seconds_total"
-	lisExceededTPTime      = "aws_ec2_instance_store_csi_ec2_exceeded_tp_seconds_total"
-	lisVolumeQueueLength   = "aws_ec2_instance_store_csi_volume_queue_length"
+	lisReadOpsTotal      = "aws_ec2_instance_store_csi_read_ops_total"
+	lisWriteOpsTotal     = "aws_ec2_instance_store_csi_write_ops_total"
+	lisReadBytesTotal    = "aws_ec2_instance_store_csi_read_bytes_total"
+	lisWriteBytesTotal   = "aws_ec2_instance_store_csi_write_bytes_total"
+	lisReadTime          = "aws_ec2_instance_store_csi_read_seconds_total"
+	lisWriteTime         = "aws_ec2_instance_store_csi_write_seconds_total"
+	lisExceededIOPSTime  = "aws_ec2_instance_store_csi_ec2_exceeded_iops_seconds_total"
+	lisExceededTPTime    = "aws_ec2_instance_store_csi_ec2_exceeded_tp_seconds_total"
+	lisVolumeQueueLength = "aws_ec2_instance_store_csi_volume_queue_length"
 )
 
 var MetricToUnit = map[string]string{

--- a/receiver/awscontainerinsightreceiver/internal/nvme/nvme_ebs_scraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/nvme/nvme_ebs_scraper_config.go
@@ -29,7 +29,7 @@ type hostInfoProvider interface {
 	GetInstanceType() string
 }
 
-func GetScraperConfig(hostInfoProvider hostInfoProvider) *config.ScrapeConfig {
+func GetEbsScraperConfig(hostInfoProvider hostInfoProvider) *config.ScrapeConfig {
 	return &config.ScrapeConfig{
 		ScrapeInterval:         model.Duration(collectionInterval),
 		ScrapeTimeout:          model.Duration(collectionInterval),

--- a/receiver/awscontainerinsightreceiver/internal/nvme/nvme_ebs_scraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/nvme/nvme_ebs_scraper_test.go
@@ -141,7 +141,7 @@ func TestNewNVMEScraperEndToEnd(t *testing.T) {
 		Consumer:          mConsumer,
 		Host:              componenttest.NewNopHost(),
 		HostInfoProvider:  mockHostInfoProvider{},
-		ScraperConfigs:    GetScraperConfig(mockHostInfoProvider{}),
+		ScraperConfigs:    GetEbsScraperConfig(mockHostInfoProvider{}),
 		Logger:            settings.Logger,
 	})
 	assert.NoError(t, err)

--- a/receiver/awscontainerinsightreceiver/internal/nvme/nvme_lis_scraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/nvme/nvme_lis_scraper_config.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	lisCollectionInterval        = 60 * time.Second
-	lisJobName                   = "containerInsightsNVMeLisExporterScraper"
+	lisJobName                   = "containerInsightsNVMeLISScraper"
 	lisScraperMetricsPath        = "/metrics"
 	lisScraperK8sServiceSelector = "app=nvme-csi-plugin"
 	lisNamespaceDiscoveryName    = "kube-system"

--- a/receiver/awscontainerinsightreceiver/internal/nvme/nvme_lis_scraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/nvme/nvme_lis_scraper_config.go
@@ -1,0 +1,104 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nvme // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/nvme"
+
+import (
+	"os"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/kubernetes"
+	"github.com/prometheus/prometheus/model/relabel"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+)
+
+const (
+	lisCollectionInterval        = 60 * time.Second
+	lisJobName                   = "containerInsightsNVMeLisExporterScraper"
+	lisScraperMetricsPath        = "/metrics"
+	lisScraperK8sServiceSelector = "app=nvme-csi-plugin"
+	lisNamespaceDiscoveryName    = "kube-system"
+)
+
+func GetLisScraperConfig(hostInfoProvider hostInfoProvider) *config.ScrapeConfig {
+	return &config.ScrapeConfig{
+		ScrapeInterval:         model.Duration(lisCollectionInterval),
+		ScrapeTimeout:          model.Duration(lisCollectionInterval),
+		ScrapeProtocols:        config.DefaultScrapeProtocols,
+		JobName:                lisJobName,
+		Scheme:                 "http",
+		MetricsPath:            lisScraperMetricsPath,
+		ScrapeFallbackProtocol: config.PrometheusText0_0_4,
+		ServiceDiscoveryConfigs: discovery.Configs{
+			&kubernetes.SDConfig{
+				Role: kubernetes.RoleService,
+				NamespaceDiscovery: kubernetes.NamespaceDiscovery{
+					Names: []string{lisNamespaceDiscoveryName},
+				},
+				Selectors: []kubernetes.SelectorConfig{
+					{
+						Role:  kubernetes.RoleService,
+						Label: lisScraperK8sServiceSelector,
+					},
+				},
+			},
+		},
+		MetricRelabelConfigs: getLisMetricRelabelConfig(hostInfoProvider),
+	}
+}
+
+func getLisMetricRelabelConfig(hostInfoProvider hostInfoProvider) []*relabel.Config {
+	return []*relabel.Config{
+		{
+			SourceLabels: model.LabelNames{"__name__"},
+			Regex:        relabel.MustNewRegexp("aws_ec2_instance_store_csi_.*"),
+			Action:       relabel.Keep,
+		},
+
+		// Below metrics are histogram type which are not supported for container insights yet
+		{
+			SourceLabels: model.LabelNames{"__name__"},
+			Regex:        relabel.MustNewRegexp(".*_bucket|.*_sum|.*_count.*"),
+			Action:       relabel.Drop,
+		},
+		// Below metrics are NVMe data collection metrics which are not supported to maintain parity with EBS NVMe metrics
+		{
+			SourceLabels: model.LabelNames{"__name__"},
+			Regex:        relabel.MustNewRegexp(".*_nvme_collector_.*"),
+			Action:       relabel.Drop,
+		},
+		// Inject static values (clusterName/instanceId/nodeName/volumeID)
+		{
+			SourceLabels: model.LabelNames{"instance_id"},
+			TargetLabel:  ci.NodeNameKey,
+			Regex:        relabel.MustNewRegexp(".*"),
+			Replacement:  os.Getenv("HOST_NAME"),
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"instance_id"},
+			TargetLabel:  ci.ClusterNameKey,
+			Regex:        relabel.MustNewRegexp(".*"),
+			Replacement:  hostInfoProvider.GetClusterName(),
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"instance_id"},
+			TargetLabel:  ci.InstanceID,
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  "${1}",
+			Action:       relabel.Replace,
+		},
+		{
+			SourceLabels: model.LabelNames{"volume_id"},
+			TargetLabel:  ci.VolumeID,
+			Regex:        relabel.MustNewRegexp("(.*)"),
+			Replacement:  "${1}",
+			Action:       relabel.Replace,
+		},
+	}
+}

--- a/receiver/awscontainerinsightreceiver/internal/nvme/nvme_lis_scraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/nvme/nvme_lis_scraper_test.go
@@ -279,5 +279,5 @@ func TestLisNvmeScraperJobName(t *testing.T) {
 
 	mockProvider := mockHostInfoProvider{}
 	config := GetLisScraperConfig(mockProvider)
-	assert.Equal(t, "containerInsightsNVMeLisExporterScraper", config.JobName)
+	assert.Equal(t, "containerInsightsNVMeLISScraper", config.JobName)
 }

--- a/receiver/awscontainerinsightreceiver/internal/nvme/nvme_lis_scraper_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/nvme/nvme_lis_scraper_test.go
@@ -1,0 +1,283 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nvme
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	configutil "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/receiver"
+	"go.uber.org/zap"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/mocks"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/prometheusscraper"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+)
+
+const lisRenameMetric = `
+# HELP aws_ec2_instance_store_csi_read_ops_total Total number of read operations
+# TYPE aws_ec2_instance_store_csi_read_ops_total counter
+aws_ec2_instance_store_csi_read_ops_total{instance_id="i-0131bee5395cc4317",volume_id="vol-0281cf921f3dbb69b"} 55592
+# HELP aws_ec2_instance_store_csi_read_seconds_total Total time spent on read operations
+# TYPE aws_ec2_instance_store_csi_read_seconds_total counter
+aws_ec2_instance_store_csi_read_seconds_total{instance_id="i-0131bee5395cc4317",volume_id="vol-0281cf921f3dbb69b"} 34.52
+# HELP aws_ec2_instance_store_csi_write_ops_total Total number of write operations
+# TYPE aws_ec2_instance_store_csi_write_ops_total counter
+aws_ec2_instance_store_csi_write_ops_total{instance_id="i-0131bee5395cc4317",volume_id="vol-0281cf921f3dbb69b"} 12345
+# HELP aws_ec2_instance_store_csi_write_bytes_total Total bytes written
+# TYPE aws_ec2_instance_store_csi_write_bytes_total counter
+aws_ec2_instance_store_csi_write_bytes_total{instance_id="i-0131bee5395cc4317",volume_id="vol-0281cf921f3dbb69b"} 987654321
+`
+
+type mockLisConsumer struct {
+	t        *testing.T
+	called   *bool
+	expected map[string]struct {
+		value  float64
+		labels map[string]string
+	}
+}
+
+func (m mockLisConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{
+		MutatesData: false,
+	}
+}
+
+func (m mockLisConsumer) ConsumeMetrics(_ context.Context, md pmetric.Metrics) error {
+	assert.Equal(m.t, 1, md.ResourceMetrics().Len())
+
+	scrapedMetricCnt := 0
+	scopeMetrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	for i := 0; i < scopeMetrics.Len(); i++ {
+		metric := scopeMetrics.At(i)
+		// skip prometheus metadata metrics including "up"
+		if !strings.HasPrefix(metric.Name(), "aws_ec2_instance_store_csi") {
+			continue
+		}
+		metadata, ok := m.expected[metric.Name()]
+		assert.True(m.t, ok)
+		assert.Equal(m.t, metadata.value, metric.Sum().DataPoints().At(0).DoubleValue())
+		for k, v := range metadata.labels {
+			gauge := metric.Sum().DataPoints().At(0)
+			m.t.Logf("%v", gauge)
+			lv, found := metric.Sum().DataPoints().At(0).Attributes().Get(k)
+			assert.True(m.t, found)
+			assert.Equal(m.t, v, lv.AsString())
+		}
+		scrapedMetricCnt++
+	}
+	assert.Equal(m.t, len(m.expected), scrapedMetricCnt)
+	*m.called = true
+	return nil
+}
+
+func TestGetLisScraperConfig(t *testing.T) {
+	mockProvider := mockHostInfoProvider{}
+
+	config := GetLisScraperConfig(mockProvider)
+
+	assert.Equal(t, lisJobName, config.JobName)
+	assert.Equal(t, lisScraperMetricsPath, config.MetricsPath)
+	assert.Len(t, config.ServiceDiscoveryConfigs, 1)
+	assert.NotEmpty(t, config.MetricRelabelConfigs)
+
+	// Verify service discovery config
+	sdConfig := config.ServiceDiscoveryConfigs[0]
+	assert.NotNil(t, sdConfig)
+
+	// Verify metric relabel configs
+	relabelConfigs := config.MetricRelabelConfigs
+	assert.NotEmpty(t, relabelConfigs)
+
+	// Check that the first relabel config keeps LIS metrics
+	keepConfig := relabelConfigs[0]
+	assert.Equal(t, relabel.Keep, keepConfig.Action)
+	assert.Equal(t, "aws_ec2_instance_store_csi_.*", keepConfig.Regex.String())
+}
+
+func TestLisMetricRelabelConfig(t *testing.T) {
+	mockProvider := mockHostInfoProvider{}
+	relabelConfigs := getLisMetricRelabelConfig(mockProvider)
+
+	assert.NotEmpty(t, relabelConfigs)
+
+	// Test keep config for LIS metrics
+	keepConfig := relabelConfigs[0]
+	assert.Equal(t, relabel.Keep, keepConfig.Action)
+	assert.Equal(t, "aws_ec2_instance_store_csi_.*", keepConfig.Regex.String())
+
+	// Test drop config for histogram metrics
+	dropConfig := relabelConfigs[1]
+	assert.Equal(t, relabel.Drop, dropConfig.Action)
+	assert.Equal(t, ".*_bucket|.*_sum|.*_count.*", dropConfig.Regex.String())
+
+	// Test cluster name injection
+	found := false
+	for _, config := range relabelConfigs {
+		if config.TargetLabel == ci.ClusterNameKey {
+			assert.Equal(t, relabel.Replace, config.Action)
+			assert.Equal(t, dummyClusterName, config.Replacement)
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "ClusterName relabel config not found")
+}
+
+func TestNewLisNVMEScraperEndToEnd(t *testing.T) {
+	t.Setenv("HOST_NAME", dummyNodeName)
+	expected := map[string]struct {
+		value  float64
+		labels map[string]string
+	}{
+		"aws_ec2_instance_store_csi_read_seconds_total": {
+			value: 34.52,
+			labels: map[string]string{
+				ci.NodeNameKey:    "hostname",
+				ci.ClusterNameKey: dummyClusterName,
+				ci.InstanceID:     "i-0131bee5395cc4317",
+				ci.VolumeID:       "vol-0281cf921f3dbb69b",
+			},
+		},
+		"aws_ec2_instance_store_csi_read_ops_total": {
+			value: 55592,
+			labels: map[string]string{
+				ci.NodeNameKey:    "hostname",
+				ci.ClusterNameKey: dummyClusterName,
+				ci.InstanceID:     "i-0131bee5395cc4317",
+				ci.VolumeID:       "vol-0281cf921f3dbb69b",
+			},
+		},
+		"aws_ec2_instance_store_csi_write_ops_total": {
+			value: 12345,
+			labels: map[string]string{
+				ci.NodeNameKey:    "hostname",
+				ci.ClusterNameKey: dummyClusterName,
+				ci.InstanceID:     "i-0131bee5395cc4317",
+				ci.VolumeID:       "vol-0281cf921f3dbb69b",
+			},
+		},
+		"aws_ec2_instance_store_csi_write_bytes_total": {
+			value: 987654321,
+			labels: map[string]string{
+				ci.NodeNameKey:    "hostname",
+				ci.ClusterNameKey: dummyClusterName,
+				ci.InstanceID:     "i-0131bee5395cc4317",
+				ci.VolumeID:       "vol-0281cf921f3dbb69b",
+			},
+		},
+	}
+
+	consumerCalled := false
+	mConsumer := mockLisConsumer{
+		t:        t,
+		called:   &consumerCalled,
+		expected: expected,
+	}
+
+	settings := componenttest.NewNopTelemetrySettings()
+	settings.Logger, _ = zap.NewDevelopment()
+
+	scraper, err := prometheusscraper.NewSimplePrometheusScraper(prometheusscraper.SimplePrometheusScraperOpts{
+		Ctx:               t.Context(),
+		TelemetrySettings: settings,
+		Consumer:          mConsumer,
+		Host:              componenttest.NewNopHost(),
+		HostInfoProvider:  mockHostInfoProvider{},
+		ScraperConfigs:    GetLisScraperConfig(mockHostInfoProvider{}),
+		Logger:            settings.Logger,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, mockHostInfoProvider{}, scraper.HostInfoProvider)
+
+	// build up a new PR
+	promFactory := prometheusreceiver.NewFactory()
+
+	targets := []*mocks.TestData{
+		{
+			Name: "nvme-lis",
+			Pages: []mocks.MockPrometheusResponse{
+				{Code: 200, Data: lisRenameMetric},
+			},
+		},
+	}
+	mp, cfg, err := mocks.SetupMockPrometheus(targets...)
+	assert.NoError(t, err)
+
+	scrapeConfig := scraper.ScraperConfigs
+	scrapeConfig.ScrapeProtocols = cfg.ScrapeConfigs[0].ScrapeProtocols
+	scrapeConfig.ScrapeInterval = cfg.ScrapeConfigs[0].ScrapeInterval
+	scrapeConfig.ScrapeTimeout = cfg.ScrapeConfigs[0].ScrapeInterval
+	scrapeConfig.Scheme = "http"
+	scrapeConfig.MetricsPath = cfg.ScrapeConfigs[0].MetricsPath
+	scrapeConfig.HTTPClientConfig = configutil.HTTPClientConfig{
+		TLSConfig: configutil.TLSConfig{
+			InsecureSkipVerify: true,
+		},
+	}
+	scrapeConfig.ServiceDiscoveryConfigs = discovery.Configs{
+		// using dummy static config to avoid service discovery initialization
+		&discovery.StaticConfig{
+			{
+				Targets: []model.LabelSet{
+					{
+						model.AddressLabel: model.LabelValue(strings.Split(mp.Srv.URL, "http://")[1]),
+					},
+				},
+			},
+		},
+	}
+
+	promConfig := prometheusreceiver.Config{
+		PrometheusConfig: &prometheusreceiver.PromConfig{
+			ScrapeConfigs: []*config.ScrapeConfig{scrapeConfig},
+		},
+	}
+
+	// replace the prom receiver
+	params := receiver.Settings{
+		TelemetrySettings: scraper.Settings,
+		ID:                component.NewID(component.MustNewType("prometheus")),
+	}
+	scraper.PrometheusReceiver, err = promFactory.CreateMetrics(t.Context(), params, &promConfig, mConsumer)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, mp)
+	defer mp.Close()
+
+	// perform a single scrape, this will kick off the scraper process for additional scrapes
+	scraper.GetMetrics()
+
+	t.Cleanup(func() {
+		scraper.Shutdown()
+	})
+
+	// wait for 2 scrapes, one initiated by us, another by the new scraper process
+	mp.Wg.Wait()
+	mp.Wg.Wait()
+	// make sure the consumer is called at scraping interval
+	assert.True(t, consumerCalled)
+}
+
+func TestLisNvmeScraperJobName(t *testing.T) {
+	// needs to start with containerInsights
+	assert.True(t, strings.HasPrefix(lisJobName, "containerInsights"))
+
+	mockProvider := mockHostInfoProvider{}
+	config := GetLisScraperConfig(mockProvider)
+	assert.Equal(t, "containerInsightsNVMeLisExporterScraper", config.JobName)
+}

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -60,8 +60,8 @@ type awsContainerInsightReceiver struct {
 	prometheusScraper        *k8sapiserver.PrometheusScraper
 	podResourcesStore        *stores.PodResourcesStore
 	dcgmScraper              *prometheusscraper.SimplePrometheusScraper
-	nvmeEbsScraper           *prometheusscraper.SimplePrometheusScraper
-	nvmeLisScraper           *prometheusscraper.SimplePrometheusScraper
+	nvmeEBSScraper           *prometheusscraper.SimplePrometheusScraper
+	nvmeLISScraper           *prometheusscraper.SimplePrometheusScraper
 	neuronMonitorScraper     *prometheusscraper.SimplePrometheusScraper
 	efaSysfsScraper          *efa.Scraper
 }
@@ -213,11 +213,11 @@ func (acir *awsContainerInsightReceiver) initEKS(ctx context.Context, host compo
 		if err != nil {
 			acir.settings.Logger.Debug("Unable to start dcgm scraper", zap.Error(err))
 		}
-		err = acir.initNVMeEbsScraper(ctx, host, hostInfo, localNodeDecorator)
+		err = acir.initNVMeEBSScraper(ctx, host, hostInfo, localNodeDecorator)
 		if err != nil {
 			acir.settings.Logger.Debug("Unable to start NVME EBS scraper", zap.Error(err))
 		}
-		err = acir.initNVMeLisScraper(ctx, host, hostInfo, localNodeDecorator)
+		err = acir.initNVMeLISScraper(ctx, host, hostInfo, localNodeDecorator)
 		if err != nil {
 			acir.settings.Logger.Debug("Unable to start NVME LIS scraper", zap.Error(err))
 		}
@@ -334,7 +334,7 @@ func (acir *awsContainerInsightReceiver) initDcgmScraper(ctx context.Context, ho
 	return err
 }
 
-func (acir *awsContainerInsightReceiver) initNVMeEbsScraper(ctx context.Context, host component.Host, hostInfo *hostinfo.Info, localNodeDecorator stores.Decorator) error {
+func (acir *awsContainerInsightReceiver) initNVMeEBSScraper(ctx context.Context, host component.Host, hostInfo *hostinfo.Info, localNodeDecorator stores.Decorator) error {
 	decoConsumer := decoratorconsumer.DecorateConsumer{
 		ContainerOrchestrator: ci.EKS,
 		NextConsumer:          acir.nextConsumer,
@@ -349,17 +349,17 @@ func (acir *awsContainerInsightReceiver) initNVMeEbsScraper(ctx context.Context,
 		TelemetrySettings: acir.settings,
 		Consumer:          &decoConsumer,
 		Host:              host,
-		ScraperConfigs:    nvme.GetScraperConfig(hostInfo),
+		ScraperConfigs:    nvme.GetEbsScraperConfig(hostInfo),
 		HostInfoProvider:  hostInfo,
 		Logger:            acir.settings.Logger,
 	}
 
 	var err error
-	acir.nvmeEbsScraper, err = prometheusscraper.NewSimplePrometheusScraper(scraperOpts)
+	acir.nvmeEBSScraper, err = prometheusscraper.NewSimplePrometheusScraper(scraperOpts)
 	return err
 }
 
-func (acir *awsContainerInsightReceiver) initNVMeLisScraper(ctx context.Context, host component.Host, hostInfo *hostinfo.Info, localNodeDecorator stores.Decorator) error {
+func (acir *awsContainerInsightReceiver) initNVMeLISScraper(ctx context.Context, host component.Host, hostInfo *hostinfo.Info, localNodeDecorator stores.Decorator) error {
 	decoConsumer := decoratorconsumer.DecorateConsumer{
 		ContainerOrchestrator: ci.EKS,
 		NextConsumer:          acir.nextConsumer,
@@ -380,7 +380,7 @@ func (acir *awsContainerInsightReceiver) initNVMeLisScraper(ctx context.Context,
 	}
 
 	var err error
-	acir.nvmeLisScraper, err = prometheusscraper.NewSimplePrometheusScraper(scraperOpts)
+	acir.nvmeLISScraper, err = prometheusscraper.NewSimplePrometheusScraper(scraperOpts)
 	return err
 }
 
@@ -475,11 +475,11 @@ func (acir *awsContainerInsightReceiver) Shutdown(context.Context) error {
 	if acir.neuronMonitorScraper != nil {
 		acir.neuronMonitorScraper.Shutdown()
 	}
-	if acir.nvmeEbsScraper != nil {
-		acir.nvmeEbsScraper.Shutdown()
+	if acir.nvmeEBSScraper != nil {
+		acir.nvmeEBSScraper.Shutdown()
 	}
-	if acir.nvmeLisScraper != nil {
-		acir.nvmeLisScraper.Shutdown()
+	if acir.nvmeLISScraper != nil {
+		acir.nvmeLISScraper.Shutdown()
 	}
 	if acir.efaSysfsScraper != nil {
 		acir.efaSysfsScraper.Shutdown()
@@ -528,12 +528,12 @@ func (acir *awsContainerInsightReceiver) collectData(ctx context.Context) error 
 		acir.neuronMonitorScraper.GetMetrics()
 	}
 
-	if acir.nvmeEbsScraper != nil {
-		acir.nvmeEbsScraper.GetMetrics()
+	if acir.nvmeEBSScraper != nil {
+		acir.nvmeEBSScraper.GetMetrics()
 	}
 
-	if acir.nvmeLisScraper != nil {
-		acir.nvmeLisScraper.GetMetrics()
+	if acir.nvmeLISScraper != nil {
+		acir.nvmeLISScraper.GetMetrics()
 	}
 
 	if acir.efaSysfsScraper != nil {

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -60,7 +60,8 @@ type awsContainerInsightReceiver struct {
 	prometheusScraper        *k8sapiserver.PrometheusScraper
 	podResourcesStore        *stores.PodResourcesStore
 	dcgmScraper              *prometheusscraper.SimplePrometheusScraper
-	nvmeScraper              *prometheusscraper.SimplePrometheusScraper
+	nvmeEbsScraper           *prometheusscraper.SimplePrometheusScraper
+	nvmeLisScraper           *prometheusscraper.SimplePrometheusScraper
 	neuronMonitorScraper     *prometheusscraper.SimplePrometheusScraper
 	efaSysfsScraper          *efa.Scraper
 }
@@ -354,14 +355,15 @@ func (acir *awsContainerInsightReceiver) initNVMeEbsScraper(ctx context.Context,
 	}
 
 	var err error
-	acir.nvmeScraper, err = prometheusscraper.NewSimplePrometheusScraper(scraperOpts)
+	acir.nvmeEbsScraper, err = prometheusscraper.NewSimplePrometheusScraper(scraperOpts)
 	return err
 }
+
 func (acir *awsContainerInsightReceiver) initNVMeLisScraper(ctx context.Context, host component.Host, hostInfo *hostinfo.Info, localNodeDecorator stores.Decorator) error {
 	decoConsumer := decoratorconsumer.DecorateConsumer{
 		ContainerOrchestrator: ci.EKS,
 		NextConsumer:          acir.nextConsumer,
-		MetricType:            ci.TypeNodeNVME,
+		MetricType:            ci.TypeNodeLISNVME,
 		MetricToUnitMap:       nvme.MetricToUnit,
 		K8sDecorator:          localNodeDecorator,
 		Logger:                acir.settings.Logger,
@@ -378,7 +380,7 @@ func (acir *awsContainerInsightReceiver) initNVMeLisScraper(ctx context.Context,
 	}
 
 	var err error
-	acir.nvmeScraper, err = prometheusscraper.NewSimplePrometheusScraper(scraperOpts)
+	acir.nvmeLisScraper, err = prometheusscraper.NewSimplePrometheusScraper(scraperOpts)
 	return err
 }
 
@@ -473,8 +475,11 @@ func (acir *awsContainerInsightReceiver) Shutdown(context.Context) error {
 	if acir.neuronMonitorScraper != nil {
 		acir.neuronMonitorScraper.Shutdown()
 	}
-	if acir.nvmeScraper != nil {
-		acir.nvmeScraper.Shutdown()
+	if acir.nvmeEbsScraper != nil {
+		acir.nvmeEbsScraper.Shutdown()
+	}
+	if acir.nvmeLisScraper != nil {
+		acir.nvmeLisScraper.Shutdown()
 	}
 	if acir.efaSysfsScraper != nil {
 		acir.efaSysfsScraper.Shutdown()
@@ -523,8 +528,12 @@ func (acir *awsContainerInsightReceiver) collectData(ctx context.Context) error 
 		acir.neuronMonitorScraper.GetMetrics()
 	}
 
-	if acir.nvmeScraper != nil {
-		acir.nvmeScraper.GetMetrics()
+	if acir.nvmeEbsScraper != nil {
+		acir.nvmeEbsScraper.GetMetrics()
+	}
+
+	if acir.nvmeLisScraper != nil {
+		acir.nvmeLisScraper.GetMetrics()
 	}
 
 	if acir.efaSysfsScraper != nil {

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -363,7 +363,7 @@ func (acir *awsContainerInsightReceiver) initNVMeLisScraper(ctx context.Context,
 	decoConsumer := decoratorconsumer.DecorateConsumer{
 		ContainerOrchestrator: ci.EKS,
 		NextConsumer:          acir.nextConsumer,
-		MetricType:            ci.TypeNodeLISNVME,
+		MetricType:            ci.TypeNodeNVME,
 		MetricToUnitMap:       nvme.MetricToUnit,
 		K8sDecorator:          localNodeDecorator,
 		Logger:                acir.settings.Logger,

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -216,6 +216,10 @@ func (acir *awsContainerInsightReceiver) initEKS(ctx context.Context, host compo
 		if err != nil {
 			acir.settings.Logger.Debug("Unable to start NVME EBS scraper", zap.Error(err))
 		}
+		err = acir.initNVMeLisScraper(ctx, host, hostInfo, localNodeDecorator)
+		if err != nil {
+			acir.settings.Logger.Debug("Unable to start NVME LIS scraper", zap.Error(err))
+		}
 		err = acir.initPodResourcesStore()
 		if err != nil {
 			acir.settings.Logger.Debug("Unable to start pod resources store", zap.Error(err))
@@ -345,6 +349,30 @@ func (acir *awsContainerInsightReceiver) initNVMeEbsScraper(ctx context.Context,
 		Consumer:          &decoConsumer,
 		Host:              host,
 		ScraperConfigs:    nvme.GetScraperConfig(hostInfo),
+		HostInfoProvider:  hostInfo,
+		Logger:            acir.settings.Logger,
+	}
+
+	var err error
+	acir.nvmeScraper, err = prometheusscraper.NewSimplePrometheusScraper(scraperOpts)
+	return err
+}
+func (acir *awsContainerInsightReceiver) initNVMeLisScraper(ctx context.Context, host component.Host, hostInfo *hostinfo.Info, localNodeDecorator stores.Decorator) error {
+	decoConsumer := decoratorconsumer.DecorateConsumer{
+		ContainerOrchestrator: ci.EKS,
+		NextConsumer:          acir.nextConsumer,
+		MetricType:            ci.TypeNodeNVME,
+		MetricToUnitMap:       nvme.MetricToUnit,
+		K8sDecorator:          localNodeDecorator,
+		Logger:                acir.settings.Logger,
+	}
+
+	scraperOpts := prometheusscraper.SimplePrometheusScraperOpts{
+		Ctx:               ctx,
+		TelemetrySettings: acir.settings,
+		Consumer:          &decoConsumer,
+		Host:              host,
+		ScraperConfigs:    nvme.GetLisScraperConfig(hostInfo),
 		HostInfoProvider:  hostInfo,
 		Logger:            acir.settings.Logger,
 	}


### PR DESCRIPTION
#### Description
Adding Scrape Configs to collect NVMe metrics from Local Instance Store (LIS) CSI

#### Testing
Unit tests updated
Validated by building into CWA and running the agent on a test cluster