### PR TITLE
Update service selector for local instance store (lis) discovery

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/nvme/nvme_lis_scraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/nvme/nvme_lis_scraper_config.go
@@ -20,7 +20,7 @@ const (
 	lisCollectionInterval        = 60 * time.Second
 	lisJobName                   = "containerInsightsNVMeLISScraper"
 	lisScraperMetricsPath        = "/metrics"
-	lisScraperK8sServiceSelector = "app=instance-store-plugin"
+	lisScraperK8sServiceSelector = "app.kubernetes.io/name=instance-store-plugin"
 	lisNamespaceDiscoveryName    = "kube-system"
 )
 

--- a/receiver/awscontainerinsightreceiver/internal/nvme/nvme_lis_scraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/nvme/nvme_lis_scraper_config.go
@@ -20,7 +20,7 @@ const (
 	lisCollectionInterval        = 60 * time.Second
 	lisJobName                   = "containerInsightsNVMeLISScraper"
 	lisScraperMetricsPath        = "/metrics"
-	lisScraperK8sServiceSelector = "app=nvme-csi-plugin"
+	lisScraperK8sServiceSelector = "app=instance-store-plugin"
 	lisNamespaceDiscoveryName    = "kube-system"
 )
 


### PR DESCRIPTION
#### Description
Updates configuration to the latest service discovery config for local instance store. This change is needed to allow cloudwatch agent to discover and scrape nvme metrics for local instance store csi. This update is based on the latest changes shared for the actual lis csi driver, and will be needed for our upcoming integration tests against the actual driver.

#### Testing
Validated updated config will discover the applicable service on a test cluster with the lis csi installed 

See service selector from test cluster validation `app.kubernetes.io/name: instance-store-plugin`:
```
kubectl get service instance-store-plugin-metrics -n kube-system -o yaml

apiVersion: v1
kind: Service
metadata:
  creationTimestamp: "2025-12-20T04:09:01Z"
  labels:
    app.kubernetes.io/component: csi-driver
    app.kubernetes.io/instance: aws-ec2-local-instance-store-csi-driver
    app.kubernetes.io/managed-by: EKS
    app.kubernetes.io/name: instance-store-plugin
    app.kubernetes.io/version: 0.0.1-eksbuild.1
    helm.sh/chart: aws-ec2-local-instance-store-csi-driver-0.0.1-eksbuild.1
  name: instance-store-plugin-metrics
  namespace: kube-system
  resourceVersion: "2050"
  uid: b0952030-992d-4f6b-aa48-b3db474642a4
spec:
  clusterIP: 10.100.222.33
  clusterIPs:
  - 10.100.222.33
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv4
  ipFamilyPolicy: SingleStack
  ports:
  - name: metrics
    port: 8101
    protocol: TCP
    targetPort: metrics
  selector:
    app.kubernetes.io/instance: aws-ec2-local-instance-store-csi-driver
    app.kubernetes.io/name: instance-store-plugin
  sessionAffinity: None
  type: ClusterIP
status:
  loadBalancer: {}

```