### PR TITLE
ocb collector for AgentCore Runtime

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -525,6 +525,9 @@ jobs:
         run: make genotelcontribcol
       - name: Build Collector ${{ matrix.binary }}
         run: make GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} GOARM=${{ matrix.arm }} otelcontribcol
+      - name: Build AgentCore Collector
+        if: matrix.os == 'linux' && matrix.arch == 'arm64'
+        run: make GOOS=linux GOARCH=arm64 otelcol-agentcore
       - name: Upload Collector Binaries
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
       - run: ./.github/workflows/scripts/free-disk-space.sh
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.24.13"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -87,7 +87,7 @@ jobs:
       - run: ./.github/workflows/scripts/free-disk-space.sh
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.24.13"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -158,7 +158,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.24.13"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -182,7 +182,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.24.13"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -363,7 +363,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.24.13"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -402,7 +402,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.24.13"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -429,7 +429,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.24.13"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -503,7 +503,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.24.13"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -556,7 +556,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.11"
+          go-version: "1.24.13"
           cache: false
       - name: Mkdir bin and dist
         run: |

--- a/Makefile
+++ b/Makefile
@@ -403,6 +403,17 @@ otelcontribcollite: genotelcontribcol
 	cd ./cmd/otelcontribcol && GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -trimpath -o ../../bin/otelcontribcol_$(GOOS)_$(GOARCH)$(EXTENSION) \
 		-tags $(GO_BUILD_TAGS) -ldflags $(GO_BUILD_LDFLAGS) .
 
+.PHONY: genotelcolagentcore
+genotelcolagentcore: $(BUILDER)
+	./internal/buildscripts/ocb-add-replaces.sh otelcol-agentcore
+	$(BUILDER) --skip-compilation --config cmd/otelcol-agentcore/builder-config-replaced.yaml
+
+# Build the AgentCore Collector executable.
+.PHONY: otelcol-agentcore
+otelcol-agentcore: genotelcolagentcore
+	cd ./cmd/otelcol-agentcore && GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -trimpath -o ../../bin/otelcol-agentcore_$(GOOS)_$(GOARCH)$(EXTENSION) \
+		-tags $(GO_BUILD_TAGS) -ldflags $(GO_BUILD_LDFLAGS) .
+
 .PHONY: genoteltestbedcol
 genoteltestbedcol: $(BUILDER)
 	./internal/buildscripts/ocb-add-replaces.sh oteltestbedcol

--- a/Makefile
+++ b/Makefile
@@ -406,7 +406,10 @@ otelcontribcollite: genotelcontribcol
 .PHONY: genotelcolagentcore
 genotelcolagentcore: $(BUILDER)
 	./internal/buildscripts/ocb-add-replaces.sh otelcol-agentcore
-	$(BUILDER) --skip-compilation --config cmd/otelcol-agentcore/builder-config-replaced.yaml
+	$(BUILDER) --skip-compilation --skip-get-modules --config cmd/otelcol-agentcore/builder-config-replaced.yaml
+	cd ./cmd/otelcol-agentcore && \
+		$(GOCMD) get go.opentelemetry.io/otel/sdk/log@v0.17.0 go.opentelemetry.io/otel/exporters/stdout/stdoutlog@v0.17.0 go.opentelemetry.io/otel/log@v0.17.0 go.opentelemetry.io/otel/log/logtest@v0.17.0 && \
+		$(GOCMD) mod tidy -compat=1.23
 
 # Build the AgentCore Collector executable.
 .PHONY: otelcol-agentcore

--- a/cmd/otelcol-agentcore/builder-config.yaml
+++ b/cmd/otelcol-agentcore/builder-config.yaml
@@ -1,0 +1,33 @@
+dist:
+  module: github.com/open-telemetry/opentelemetry-collector-contrib/cmd/otelcol-agentcore
+  name: otelcol-agentcore
+  description: OTel Collector for AgentCore Runtime
+  version: 0.124.1-dev
+  output_path: ./cmd/otelcol-agentcore
+
+exporters:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.124.1
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.124.0
+
+
+processors:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.124.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.124.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.124.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/awscwotlpbatchsplitprocessor v0.124.1
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.124.0
+
+connectors:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/genaiadapterconnector v0.124.1
+
+receivers:
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.124.0
+
+extensions:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy v0.124.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.124.1
+
+# When using `make genotelcolagentcore`, the `replaces` content is appended to
+# this file before passing it to OCB, to ensure that local versions are used
+# for all Contrib modules.
+replaces:

--- a/cmd/otelcol-agentcore/config.yaml
+++ b/cmd/otelcol-agentcore/config.yaml
@@ -1,0 +1,72 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+  awscwotlpbatchsplit:
+
+connectors:
+  genaiadapterconnector:
+
+exporters:
+
+  otlphttp/xray:
+    compression: gzip
+    traces_endpoint: https://xray.${env:AWS_REGION:-us-east-1}.amazonaws.com/v1/traces
+    auth:
+      authenticator: sigv4auth/traces
+
+  otlphttp/logs:
+    compression: gzip
+    logs_endpoint: https://logs.${env:AWS_REGION:-us-east-1}.amazonaws.com/v1/logs
+    headers:
+      x-aws-log-group: ${env:AWS_APP_LOG_GROUP:-AgentCoreRuntimeLogs}
+      x-aws-log-stream: ${env:AWS_APP_LOG_STREAM:-default}
+    auth:
+      authenticator: sigv4auth/logs
+
+  awsemf:
+    region: ${env:AWS_REGION:-us-east-1}
+    namespace: ${env:AWS_EMF_NAMESPACE:-AgentCoreRuntime}
+    log_group_name: ${env:AWS_EMF_LOG_GROUP:-AgentCoreRuntimeEMF}
+    log_stream_name: ${env:AWS_EMF_LOG_STREAM:-default}
+    resource_to_telemetry_conversion:
+      enabled: true
+    dimension_rollup_option: "NoDimensionRollup"
+
+extensions:
+  sigv4auth/traces:
+    region: ${env:AWS_REGION:-us-east-1}
+    service: xray
+
+  sigv4auth/logs:
+    region: ${env:AWS_REGION:-us-east-1}
+    service: logs
+
+service:
+  extensions: [sigv4auth/traces, sigv4auth/logs]
+  pipelines:
+    logs/cloudwatch:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/logs]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [awsemf]
+    traces/input:
+      receivers: [otlp]
+      exporters: [genaiadapterconnector]
+    traces/output:
+      receivers: [genaiadapterconnector]
+      processors: [batch]
+      exporters: [otlphttp/xray]
+    logs/genai:
+      receivers: [genaiadapterconnector]
+      processors: [batch, awscwotlpbatchsplit]
+      exporters: [otlphttp/logs]

--- a/cmd/otelcol-agentcore/metadata.yaml
+++ b/cmd/otelcol-agentcore/metadata.yaml
@@ -1,0 +1,6 @@
+type: otelcol-agentcore
+
+status:
+  class: cmd
+  codeowners:
+    active: []


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

- Add OpenTelemetry Collector Builder (OCB) configuration for AgentCore Runtime (`otelcol-agentcore`)
- Include default collector config with OTLP receiver, GenAI adapter connector, AWS EMF exporter, and CloudWatch logs exporter
- Add Makefile targets and CI build step for `otelcol-agentcore`

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Feature

<!--Describe what testing was performed and which tests were added.-->
#### Testing

E2E testing in:
- https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/23065535865/job/67008221153
- https://github.com/aws-observability/aws-otel-python-instrumentation/actions/workflows/build-agentcore-collector.yml

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
