### PR TITLE
feat(genaiadapterconnector): make prompt to log extraction from spans opt in feature

### DIFF
--- a/.chloggen/genaiadapter-prompt-extraction-config.yaml
+++ b/.chloggen/genaiadapter-prompt-extraction-config.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: genaiadapterconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add prompt_extraction_enabled configuration option to control LLO content extraction into Gen AI log events
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [423]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/connector/genaiadapterconnector/README.md
+++ b/connector/genaiadapterconnector/README.md
@@ -35,6 +35,7 @@ It supports two pipeline paths:
 ```yaml
 connectors:
   genaiadapterconnector:
+    prompt_extraction_enabled: true
 
 service:
   pipelines:
@@ -50,6 +51,10 @@ service:
 ```
 
 Either or both receiver pipelines (`traces/out`, `logs/out`) can be configured independently.
+
+| Setting | Type | Default | Description |
+| ------- | ---- | ------- | ----------- |
+| `prompt_extraction_enabled` | bool | `false` | When `true`, LLO content (input/output messages, prompts, completions) is extracted from spans and emitted as Gen AI log events. When `false`, traces pass through with LLO attributes intact and no logs are extracted. |
 
 ## How It Works
 

--- a/connector/genaiadapterconnector/config.go
+++ b/connector/genaiadapterconnector/config.go
@@ -4,7 +4,9 @@
 package genaiadapterconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/genaiadapterconnector"
 
 // Config defines configuration for the genaiadapterconnector.
-type Config struct{}
+type Config struct {
+	PromptExtractionEnabled bool `mapstructure:"prompt_extraction_enabled"`
+}
 
 // Validate checks the connector configuration for errors.
 func (cfg *Config) Validate() error {

--- a/connector/genaiadapterconnector/connector.go
+++ b/connector/genaiadapterconnector/connector.go
@@ -15,6 +15,7 @@ import (
 )
 
 type genAIAdapterConnector struct {
+	cfg            *Config
 	logger         *zap.Logger
 	tracesConsumer consumer.Traces
 	logsConsumer   consumer.Logs
@@ -36,16 +37,17 @@ func (c *genAIAdapterConnector) Shutdown(_ context.Context) error {
 func (c *genAIAdapterConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 	c.transformTraces(td)
 
-	logs := c.lloHandler.processSpans(td)
-
-	if c.tracesConsumer != nil {
-		if err := c.tracesConsumer.ConsumeTraces(ctx, td); err != nil {
-			return err
+	if c.cfg.PromptExtractionEnabled {
+		logs := c.lloHandler.processSpans(td)
+		if c.logsConsumer != nil && logs.LogRecordCount() > 0 {
+			if err := c.logsConsumer.ConsumeLogs(ctx, logs); err != nil {
+				return err
+			}
 		}
 	}
 
-	if c.logsConsumer != nil && logs.LogRecordCount() > 0 {
-		if err := c.logsConsumer.ConsumeLogs(ctx, logs); err != nil {
+	if c.tracesConsumer != nil {
+		if err := c.tracesConsumer.ConsumeTraces(ctx, td); err != nil {
 			return err
 		}
 	}

--- a/connector/genaiadapterconnector/connector_test.go
+++ b/connector/genaiadapterconnector/connector_test.go
@@ -33,8 +33,8 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestGetOrCreateConnector_Singleton(t *testing.T) {
 	connectors := &sync.Map{}
 	set := connectortest.NewNopSettings(metadata.Type)
-	c1 := getOrCreateConnector(connectors, set)
-	c2 := getOrCreateConnector(connectors, set)
+	c1 := getOrCreateConnector(connectors, set, &Config{PromptExtractionEnabled: true})
+	c2 := getOrCreateConnector(connectors, set, &Config{PromptExtractionEnabled: true})
 	assert.Same(t, c1, c2)
 }
 
@@ -44,8 +44,8 @@ func TestGetOrCreateConnector_DifferentIDs(t *testing.T) {
 	set2 := connectortest.NewNopSettings(metadata.Type)
 	set2.ID = component.MustNewIDWithName("genai_adapter", "other")
 
-	c1 := getOrCreateConnector(connectors, set1)
-	c2 := getOrCreateConnector(connectors, set2)
+	c1 := getOrCreateConnector(connectors, set1, &Config{PromptExtractionEnabled: true})
+	c2 := getOrCreateConnector(connectors, set2, &Config{PromptExtractionEnabled: true})
 	assert.NotSame(t, c1, c2)
 }
 
@@ -78,7 +78,7 @@ func TestCreateTracesToLogs(t *testing.T) {
 func TestStartShutdown(t *testing.T) {
 	connectors := &sync.Map{}
 	set := connectortest.NewNopSettings(metadata.Type)
-	c := getOrCreateConnector(connectors, set)
+	c := getOrCreateConnector(connectors, set, &Config{PromptExtractionEnabled: true})
 
 	assert.NoError(t, c.Start(t.Context(), componenttest.NewNopHost()))
 	assert.NoError(t, c.Shutdown(t.Context()))
@@ -88,7 +88,7 @@ func TestConsumeTraces_OISpanTransformed(t *testing.T) {
 	connectors := &sync.Map{}
 	tracesSink := &consumertest.TracesSink{}
 	set := connectortest.NewNopSettings(metadata.Type)
-	c := getOrCreateConnector(connectors, set)
+	c := getOrCreateConnector(connectors, set, &Config{PromptExtractionEnabled: true})
 	c.tracesConsumer = tracesSink
 
 	td := ptrace.NewTraces()
@@ -112,7 +112,7 @@ func TestConsumeTraces_NonOISpanPassthrough(t *testing.T) {
 	connectors := &sync.Map{}
 	tracesSink := &consumertest.TracesSink{}
 	set := connectortest.NewNopSettings(metadata.Type)
-	c := getOrCreateConnector(connectors, set)
+	c := getOrCreateConnector(connectors, set, &Config{PromptExtractionEnabled: true})
 	c.tracesConsumer = tracesSink
 
 	td := ptrace.NewTraces()
@@ -136,7 +136,7 @@ func TestConsumeTraces_LLOEmitsLogs(t *testing.T) {
 	connectors := &sync.Map{}
 	logsSink := &consumertest.LogsSink{}
 	set := connectortest.NewNopSettings(metadata.Type)
-	c := getOrCreateConnector(connectors, set)
+	c := getOrCreateConnector(connectors, set, &Config{PromptExtractionEnabled: true})
 	c.logsConsumer = logsSink
 
 	td := ptrace.NewTraces()
@@ -159,11 +159,51 @@ func TestConsumeTraces_LLOEmitsLogs(t *testing.T) {
 	assert.False(t, hasOutput)
 }
 
+func TestConsumeTraces_NoLogsWhenPromptExtractionDisabled(t *testing.T) {
+	connectors := &sync.Map{}
+	logsSink := &consumertest.LogsSink{}
+	set := connectortest.NewNopSettings(metadata.Type)
+	c := getOrCreateConnector(connectors, set, &Config{PromptExtractionEnabled: false})
+	c.logsConsumer = logsSink
+
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+	ss.Scope().SetName("test.scope")
+	span := ss.Spans().AppendEmpty()
+	span.Attributes().PutStr("input.value", "user prompt")
+	span.Attributes().PutStr("output.value", "assistant response")
+
+	err := c.ConsumeTraces(t.Context(), td)
+	require.NoError(t, err)
+	assert.Empty(t, logsSink.AllLogs())
+}
+
+func TestConsumeTraces_NoLogsWhenPromptExtractionDefault(t *testing.T) {
+	connectors := &sync.Map{}
+	logsSink := &consumertest.LogsSink{}
+	set := connectortest.NewNopSettings(metadata.Type)
+	c := getOrCreateConnector(connectors, set, &Config{})
+	c.logsConsumer = logsSink
+
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+	ss.Scope().SetName("test.scope")
+	span := ss.Spans().AppendEmpty()
+	span.Attributes().PutStr("input.value", "user prompt")
+	span.Attributes().PutStr("output.value", "assistant response")
+
+	err := c.ConsumeTraces(t.Context(), td)
+	require.NoError(t, err)
+	assert.Empty(t, logsSink.AllLogs())
+}
+
 func TestConsumeTraces_ForwardsToTracesConsumer(t *testing.T) {
 	connectors := &sync.Map{}
 	tracesSink := &consumertest.TracesSink{}
 	set := connectortest.NewNopSettings(metadata.Type)
-	c := getOrCreateConnector(connectors, set)
+	c := getOrCreateConnector(connectors, set, &Config{PromptExtractionEnabled: true})
 	c.tracesConsumer = tracesSink
 
 	td := ptrace.NewTraces()
@@ -178,7 +218,7 @@ func TestConsumeTraces_ForwardsToLogsConsumer(t *testing.T) {
 	connectors := &sync.Map{}
 	logsSink := &consumertest.LogsSink{}
 	set := connectortest.NewNopSettings(metadata.Type)
-	c := getOrCreateConnector(connectors, set)
+	c := getOrCreateConnector(connectors, set, &Config{PromptExtractionEnabled: true})
 	c.logsConsumer = logsSink
 
 	td := ptrace.NewTraces()
@@ -197,7 +237,7 @@ func TestConsumeTraces_NoLogsWhenNoLLO(t *testing.T) {
 	connectors := &sync.Map{}
 	logsSink := &consumertest.LogsSink{}
 	set := connectortest.NewNopSettings(metadata.Type)
-	c := getOrCreateConnector(connectors, set)
+	c := getOrCreateConnector(connectors, set, &Config{PromptExtractionEnabled: true})
 	c.logsConsumer = logsSink
 
 	td := ptrace.NewTraces()
@@ -213,7 +253,7 @@ func TestLogsOnlyConnector_ConsumeTracesNoOp(t *testing.T) {
 	connectors := &sync.Map{}
 	tracesSink := &consumertest.TracesSink{}
 	set := connectortest.NewNopSettings(metadata.Type)
-	c := getOrCreateConnector(connectors, set)
+	c := getOrCreateConnector(connectors, set, &Config{PromptExtractionEnabled: true})
 	c.tracesConsumer = tracesSink
 
 	wrapper := &logsOnlyConnector{c}

--- a/connector/genaiadapterconnector/factory.go
+++ b/connector/genaiadapterconnector/factory.go
@@ -28,11 +28,12 @@ func (l *logsOnlyConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces)
 
 	l.transformTraces(td)
 
-	logs := l.lloHandler.processSpans(td)
-
-	if l.logsConsumer != nil && logs.LogRecordCount() > 0 {
-		if err := l.logsConsumer.ConsumeLogs(ctx, logs); err != nil {
-			return err
+	if l.cfg.PromptExtractionEnabled {
+		logs := l.lloHandler.processSpans(td)
+		if l.logsConsumer != nil && logs.LogRecordCount() > 0 {
+			if err := l.logsConsumer.ConsumeLogs(ctx, logs); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -45,16 +46,16 @@ func NewFactory() connector.Factory {
 		metadata.Type,
 		createDefaultConfig,
 		connector.WithTracesToTraces(
-			func(_ context.Context, set connector.Settings, _ component.Config, tc consumer.Traces) (connector.Traces, error) {
-				c := getOrCreateConnector(connectors, set)
+			func(_ context.Context, set connector.Settings, cfg component.Config, tc consumer.Traces) (connector.Traces, error) {
+				c := getOrCreateConnector(connectors, set, cfg.(*Config))
 				c.tracesConsumer = tc
 				return c, nil
 			},
 			metadata.TracesToTracesStability,
 		),
 		connector.WithTracesToLogs(
-			func(_ context.Context, set connector.Settings, _ component.Config, lc consumer.Logs) (connector.Traces, error) {
-				c := getOrCreateConnector(connectors, set)
+			func(_ context.Context, set connector.Settings, cfg component.Config, lc consumer.Logs) (connector.Traces, error) {
+				c := getOrCreateConnector(connectors, set, cfg.(*Config))
 				c.logsConsumer = lc
 				return &logsOnlyConnector{c}, nil
 			},
@@ -64,12 +65,15 @@ func NewFactory() connector.Factory {
 }
 
 func createDefaultConfig() component.Config {
-	return &Config{}
+	return &Config{
+		PromptExtractionEnabled: false,
+	}
 }
 
-func getOrCreateConnector(connectors *sync.Map, set connector.Settings) *genAIAdapterConnector {
+func getOrCreateConnector(connectors *sync.Map, set connector.Settings, cfg *Config) *genAIAdapterConnector {
 	id := set.ID.String()
 	c := &genAIAdapterConnector{
+		cfg:        cfg,
 		logger:     set.Logger,
 		lloHandler: newLLOHandler(set.Logger),
 	}


### PR DESCRIPTION
#### Description

Add `prompt_extraction_enabled` configuration option to the genaiadapterconnector. By default or when set to false, prompt data will not be extracted from spans into logs.

#### Testing

Added additional unit tests:
- `TestConsumeTraces_NoLogsWhenPromptExtractionDisabled`
- `TestConsumeTraces_NoLogsWhenPromptExtractionDefault`
- Existing `TestConsumeTraces_LLOEmitsLogs` validates logs are extracted when `true`

#### Documentation

Updated `connector/genaiadapterconnector/README.md` with `prompt_extraction_enabled` configuration option and settings table.