### PR TITLE
Cherry-pick: [exporter/awscloudwatchlogsexporter] added placeholder names for loggroup and logstream (open-telemetry#37297)

### DIFF
--- a/.chloggen/dynamic-loggroup-logstream-names-cloudwatch.yaml
+++ b/.chloggen/dynamic-loggroup-logstream-names-cloudwatch.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awscloudwatchlogsexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add dynamic log_group_name and log_group_stream naming, based on awsemfexporter
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31382]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/awscloudwatchlogsexporter/README.md
+++ b/exporter/awscloudwatchlogsexporter/README.md
@@ -22,8 +22,21 @@ NOTE: OpenTelemetry Logging support is experimental, hence this exporter is subj
 
 The following settings are required:
 
-- `log_group_name`: The group name of the CloudWatch Logs. If it does not exist it will be created automatically.
-- `log_stream_name`: The stream name of the CloudWatch Logs. If it does not exist it will be created automatically.
+
+- `log_group_name`: The group name of the CloudWatch Logs. If it does not exist it will be created automatically. It supports several placeholder names. One valid example is `/aws/metrics/{ClusterName}`. It will search for ClusterName (or aws.ecs.cluster.name) resource attribute in the metrics data and replace with the actual cluster name. If none of them are found in the resource attribute map, {ClusterName} will be replaced by undefined. Similar way, for the {TaskId}, it searches for TaskId (or aws.ecs.task.id) key in the resource attribute map. For {NodeName}, it searches for NodeName (or k8s.node.name)
+  - List of valid placeholders:
+    - `{ClusterName}`: `aws.ecs.cluster.name`
+    - `{TaskId}`:               `aws.ecs.task.id`
+    - `{NodeName}`:             `k8s.node.name`
+    - `{PodName}`:              `pod`
+    - `{ServiceName}`:          `service.name`
+    - `{ContainerInstanceId}`:  `aws.ecs.container.instance.id`
+    - `{TaskDefinitionFamily}`: `aws.ecs.task.family`
+    - `{InstanceId}`:           `service.instance.id`
+    - `{FaasName}`:             `faas.name`
+    - `{FaasVersion}`:          `faas.version`
+- `log_stream_name`: The stream name of the CloudWatch Logs. If it does not exist it will be created automatically. It supports the same placeholders as `log_group_name`
+
 
 The following settings can be optionally configured:
 

--- a/exporter/awscloudwatchlogsexporter/config.go
+++ b/exporter/awscloudwatchlogsexporter/config.go
@@ -69,6 +69,13 @@ func (config *Config) Validate() error {
 		return errors.New("'log_stream_name' must be set")
 	}
 
+	if isPatternValid, invalidPattern := (isPatternValid(config.LogGroupName)); !isPatternValid {
+		return errors.New("'log_group_name' has an invalid pattern between curly brackets: " + invalidPattern)
+	}
+	if isPatternValid, invalidPattern := (isPatternValid(config.LogStreamName)); !isPatternValid {
+		return errors.New("'log_stream_name'  has an invalid pattern between curly brackets: " + invalidPattern)
+	}
+
 	if err := config.QueueSettings.Validate(); err != nil {
 		return err
 	}

--- a/exporter/awscloudwatchlogsexporter/config_test.go
+++ b/exporter/awscloudwatchlogsexporter/config_test.go
@@ -237,6 +237,22 @@ func TestValidateTags(t *testing.T) {
 	}
 }
 
+func TestValidateWithEnvVarSyntax(t *testing.T) {
+	defaultBackOffConfig := configretry.NewDefaultBackOffConfig()
+	cfg := &Config{
+		BackOffConfig: defaultBackOffConfig,
+		LogGroupName:  "${ENV_LOG_GROUP}",
+		LogStreamName: "${ENV_LOG_STREAM}",
+		QueueSettings: exporterhelper.QueueBatchConfig{
+			Enabled:      true,
+			NumConsumers: 1,
+			QueueSize:    exporterhelper.NewDefaultQueueConfig().QueueSize,
+		},
+		AWSSessionSettings: awsutil.CreateDefaultSessionConfig(),
+	}
+	assert.NoError(t, xconfmap.Validate(cfg))
+}
+
 func TestRawLogEmfOnlyCombination(t *testing.T) {
 	tests := []struct {
 		RawLog    bool

--- a/exporter/awscloudwatchlogsexporter/exporter.go
+++ b/exporter/awscloudwatchlogsexporter/exporter.go
@@ -151,7 +151,7 @@ func pushLogsToCWLogs(logger *zap.Logger, ld plog.Logs, config *Config, pusher c
 			logs := sl.LogRecords()
 			for k := 0; k < logs.Len(); k++ {
 				log := logs.At(k)
-				event, err := logToCWLog(resourceAttrs, scope, log, config)
+				event, err := logToCWLog(logger, resourceAttrs, scope, log, config)
 				if err != nil {
 					logger.Debug("Failed to convert to CloudWatch Log", zap.Error(err))
 				} else {
@@ -186,11 +186,11 @@ type cwLogBody struct {
 	Resource               map[string]any  `json:"resource,omitempty"`
 }
 
-func logToCWLog(resourceAttrs map[string]any, scope pcommon.InstrumentationScope, log plog.LogRecord, config *Config) (*cwlogs.Event, error) {
+func logToCWLog(logger *zap.Logger, resourceAttrs map[string]any, scope pcommon.InstrumentationScope, log plog.LogRecord, config *Config) (*cwlogs.Event, error) {
 	// TODO(jbd): Benchmark and improve the allocations.
 	// Evaluate go.elastic.co/fastjson as a replacement for encoding/json.
 	// Replace loggroup and logstream with resource attribute
-	logGroupName, logStreamName, _ := getLogInfo(resourceAttrs, config)
+	logGroupName, logStreamName, _ := getLogInfo(resourceAttrs, config, logger)
 
 	var bodyJSON []byte
 	var err error

--- a/exporter/awscloudwatchlogsexporter/exporter.go
+++ b/exporter/awscloudwatchlogsexporter/exporter.go
@@ -189,8 +189,8 @@ type cwLogBody struct {
 func logToCWLog(resourceAttrs map[string]any, scope pcommon.InstrumentationScope, log plog.LogRecord, config *Config) (*cwlogs.Event, error) {
 	// TODO(jbd): Benchmark and improve the allocations.
 	// Evaluate go.elastic.co/fastjson as a replacement for encoding/json.
-	logGroupName := config.LogGroupName
-	logStreamName := config.LogStreamName
+	// Replace loggroup and logstream with resource attribute
+	logGroupName, logStreamName, _ := getLogInfo(resourceAttrs, config)
 
 	var bodyJSON []byte
 	var err error

--- a/exporter/awscloudwatchlogsexporter/exporter.go
+++ b/exporter/awscloudwatchlogsexporter/exporter.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware"
-	"github.com/aws/aws-sdk-go/aws"                    //nolint:staticcheck // AWS SDK v1 migration tracked separately
-	"github.com/aws/aws-sdk-go/service/cloudwatchlogs" //nolint:staticcheck // AWS SDK v1 migration tracked separately
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"

--- a/exporter/awscloudwatchlogsexporter/exporter.go
+++ b/exporter/awscloudwatchlogsexporter/exporter.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go/aws"                    //nolint:staticcheck // AWS SDK v1 migration tracked separately
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs" //nolint:staticcheck // AWS SDK v1 migration tracked separately
 	"github.com/google/uuid"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -126,7 +126,7 @@ func (e *cwlExporter) start(_ context.Context, host component.Host) error {
 	return nil
 }
 
-func (e *cwlExporter) shutdown(_ context.Context) error {
+func (*cwlExporter) shutdown(_ context.Context) error {
 	return nil
 }
 
@@ -151,7 +151,7 @@ func pushLogsToCWLogs(logger *zap.Logger, ld plog.Logs, config *Config, pusher c
 			logs := sl.LogRecords()
 			for k := 0; k < logs.Len(); k++ {
 				log := logs.At(k)
-				event, err := logToCWLog(logger, resourceAttrs, scope, log, config)
+				event, err := logToCWLog(resourceAttrs, scope, log, config, logger)
 				if err != nil {
 					logger.Debug("Failed to convert to CloudWatch Log", zap.Error(err))
 				} else {
@@ -186,7 +186,7 @@ type cwLogBody struct {
 	Resource               map[string]any  `json:"resource,omitempty"`
 }
 
-func logToCWLog(logger *zap.Logger, resourceAttrs map[string]any, scope pcommon.InstrumentationScope, log plog.LogRecord, config *Config) (*cwlogs.Event, error) {
+func logToCWLog(resourceAttrs map[string]any, scope pcommon.InstrumentationScope, log plog.LogRecord, config *Config, logger *zap.Logger) (*cwlogs.Event, error) {
 	// TODO(jbd): Benchmark and improve the allocations.
 	// Evaluate go.elastic.co/fastjson as a replacement for encoding/json.
 	// Replace loggroup and logstream with resource attribute

--- a/exporter/awscloudwatchlogsexporter/exporter_test.go
+++ b/exporter/awscloudwatchlogsexporter/exporter_test.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go/aws"                    //nolint:staticcheck // AWS SDK v1 migration tracked separately
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs" //nolint:staticcheck // AWS SDK v1 migration tracked separately
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -38,7 +38,7 @@ type mockHost struct {
 	component.Host
 }
 
-func (m *mockHost) GetExtensions() map[component.ID]component.Component {
+func (*mockHost) GetExtensions() map[component.ID]component.Component {
 	return nil
 }
 
@@ -306,13 +306,16 @@ func TestLogToCWLog(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resourceAttrs := attrsValue(tt.resource.Attributes())
-			got, err := logToCWLog(zap.NewNop(), resourceAttrs, tt.scope, tt.log, tt.config)
+			got, err := logToCWLog(resourceAttrs, tt.scope, tt.log, tt.config, zap.NewNop())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("logToCWLog() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+			if tt.wantErr {
+				return
+			}
 			// Do not test generated time since it is time.Now()
-			assert.Equal(t, tt.want.InputLogEvent, got.InputLogEvent)
+			assert.Equal(t, *tt.want.InputLogEvent, *got.InputLogEvent)
 			assert.Equal(t, tt.want.LogStreamName, got.LogStreamName)
 			assert.Equal(t, tt.want.LogGroupName, got.LogGroupName)
 		})
@@ -325,8 +328,8 @@ func BenchmarkLogToCWLog(b *testing.B) {
 	resource := testResource()
 	log := testLogRecord()
 	scope := testScope()
-	for i := 0; i < b.N; i++ {
-		_, err := logToCWLog(zap.NewNop(), attrsValue(resource.Attributes()), scope, log, &Config{})
+	for b.Loop() {
+		_, err := logToCWLog(attrsValue(resource.Attributes()), scope, log, &Config{}, zap.NewNop())
 		if err != nil {
 			b.Errorf("logToCWLog() failed %v", err)
 			return

--- a/exporter/awscloudwatchlogsexporter/exporter_test.go
+++ b/exporter/awscloudwatchlogsexporter/exporter_test.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs"
@@ -305,7 +306,7 @@ func TestLogToCWLog(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resourceAttrs := attrsValue(tt.resource.Attributes())
-			got, err := logToCWLog(resourceAttrs, tt.scope, tt.log, tt.config)
+			got, err := logToCWLog(zap.NewNop(), resourceAttrs, tt.scope, tt.log, tt.config)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("logToCWLog() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -325,7 +326,7 @@ func BenchmarkLogToCWLog(b *testing.B) {
 	log := testLogRecord()
 	scope := testScope()
 	for i := 0; i < b.N; i++ {
-		_, err := logToCWLog(attrsValue(resource.Attributes()), scope, log, &Config{})
+		_, err := logToCWLog(zap.NewNop(), attrsValue(resource.Attributes()), scope, log, &Config{})
 		if err != nil {
 			b.Errorf("logToCWLog() failed %v", err)
 			return

--- a/exporter/awscloudwatchlogsexporter/exporter_test.go
+++ b/exporter/awscloudwatchlogsexporter/exporter_test.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware"
-	"github.com/aws/aws-sdk-go/aws"                    //nolint:staticcheck // AWS SDK v1 migration tracked separately
-	"github.com/aws/aws-sdk-go/service/cloudwatchlogs" //nolint:staticcheck // AWS SDK v1 migration tracked separately
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/exporter/awscloudwatchlogsexporter/util.go
+++ b/exporter/awscloudwatchlogsexporter/util.go
@@ -1,0 +1,114 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package awscloudwatchlogsexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter"
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+var patternKeyToAttributeMap = map[string]string{
+	"ClusterName":          "aws.ecs.cluster.name",
+	"TaskId":               "aws.ecs.task.id",
+	"NodeName":             "k8s.node.name",
+	"PodName":              "pod",
+	"ServiceName":          "service.name",
+	"ContainerInstanceId":  "aws.ecs.container.instance.id",
+	"TaskDefinitionFamily": "aws.ecs.task.family",
+	"InstanceId":           "service.instance.id",
+	"FaasName":             "faas.name",
+	"FaasVersion":          "faas.version",
+}
+
+func isPatternValid(s string) (bool, string) {
+	if !strings.Contains(s, "{") && !strings.Contains(s, "}") {
+		return true, ""
+	}
+
+	re := regexp.MustCompile(`\{([^{}]*)\}`)
+	matches := re.FindAllStringSubmatch(s, -1)
+
+	for _, match := range matches {
+		if len(match) > 1 {
+			key := match[1]
+			if _, exists := patternKeyToAttributeMap[key]; !exists {
+				return false, key
+			}
+		}
+	}
+	return true, ""
+}
+
+func replacePatterns(s string, attrMap map[string]string, logger *zap.Logger) (string, bool) {
+	success := true
+	var foundAndReplaced bool
+	for key := range patternKeyToAttributeMap {
+		s, foundAndReplaced = replacePatternWithAttrValue(s, key, attrMap, logger)
+		success = success && foundAndReplaced
+	}
+	return s, success
+}
+
+func replacePatternWithAttrValue(s, patternKey string, attrMap map[string]string, logger *zap.Logger) (string, bool) {
+	pattern := "{" + patternKey + "}"
+	if strings.Contains(s, pattern) {
+		if value, ok := attrMap[patternKey]; ok {
+			return replace(s, pattern, value, logger)
+		} else if value, ok := attrMap[patternKeyToAttributeMap[patternKey]]; ok {
+			return replace(s, pattern, value, logger)
+		}
+		logger.Debug("No resource attribute found for pattern " + pattern)
+		return strings.ReplaceAll(s, pattern, "undefined"), false
+	}
+	return s, true
+}
+
+func replace(s, pattern string, value string, logger *zap.Logger) (string, bool) {
+	if value == "" {
+		logger.Debug("Empty resource attribute value found for pattern " + pattern)
+		return strings.ReplaceAll(s, pattern, "undefined"), false
+	}
+	return strings.ReplaceAll(s, pattern, value), true
+}
+
+// getLogInfo retrieves the log group and log stream names from a given set of metrics.
+func getLogInfo(resourceAttrs map[string]any, config *Config) (string, string, bool) {
+	var logGroup, logStream string
+	groupReplaced := true
+	streamReplaced := true
+
+	// Convert to map[string]string
+	strAttributeMap := anyMapToStringMap(resourceAttrs)
+
+	// Override log group/stream if specified in config. However, in this case, customer won't have correlation experience
+	if len(config.LogGroupName) > 0 {
+		logGroup, groupReplaced = replacePatterns(config.LogGroupName, strAttributeMap, config.logger)
+	}
+	if len(config.LogStreamName) > 0 {
+		logStream, streamReplaced = replacePatterns(config.LogStreamName, strAttributeMap, config.logger)
+	}
+
+	return logGroup, logStream, (groupReplaced && streamReplaced)
+}
+
+func anyMapToStringMap(resourceAttrs map[string]any) map[string]string {
+	strMap := make(map[string]string)
+	for key, value := range resourceAttrs {
+		switch v := value.(type) {
+		case string:
+			strMap[key] = v
+		case int:
+			strMap[key] = strconv.Itoa(v)
+		case bool:
+			strMap[key] = strconv.FormatBool(v)
+		default:
+			strMap[key] = fmt.Sprintf("%v", v)
+		}
+	}
+	return strMap
+}

--- a/exporter/awscloudwatchlogsexporter/util.go
+++ b/exporter/awscloudwatchlogsexporter/util.go
@@ -31,14 +31,17 @@ func isPatternValid(s string) (bool, string) {
 	}
 
 	re := regexp.MustCompile(`\{([^{}]*)\}`)
-	matches := re.FindAllStringSubmatch(s, -1)
+	matches := re.FindAllStringSubmatchIndex(s, -1)
 
 	for _, match := range matches {
-		if len(match) > 1 {
-			key := match[1]
-			if _, exists := patternKeyToAttributeMap[key]; !exists {
-				return false, key
-			}
+		// match[0] is the start index of the full match `{...}`
+		// Skip if preceded by '$' as env vars should not be considered as placeholders
+		if match[0] > 0 && s[match[0]-1] == '$' {
+			continue
+		}
+		key := s[match[2]:match[3]]
+		if _, exists := patternKeyToAttributeMap[key]; !exists {
+			return false, key
 		}
 	}
 	return true, ""

--- a/exporter/awscloudwatchlogsexporter/util.go
+++ b/exporter/awscloudwatchlogsexporter/util.go
@@ -68,7 +68,7 @@ func replacePatternWithAttrValue(s, patternKey string, attrMap map[string]string
 	return s, true
 }
 
-func replace(s, pattern string, value string, logger *zap.Logger) (string, bool) {
+func replace(s, pattern, value string, logger *zap.Logger) (string, bool) {
 	if value == "" {
 		logger.Debug("Empty resource attribute value found for pattern " + pattern)
 		return strings.ReplaceAll(s, pattern, "undefined"), false
@@ -86,10 +86,10 @@ func getLogInfo(resourceAttrs map[string]any, config *Config, logger *zap.Logger
 	strAttributeMap := anyMapToStringMap(resourceAttrs)
 
 	// Override log group/stream if specified in config. However, in this case, customer won't have correlation experience
-	if len(config.LogGroupName) > 0 {
+	if config.LogGroupName != "" {
 		logGroup, groupReplaced = replacePatterns(config.LogGroupName, strAttributeMap, logger)
 	}
-	if len(config.LogStreamName) > 0 {
+	if config.LogStreamName != "" {
 		logStream, streamReplaced = replacePatterns(config.LogStreamName, strAttributeMap, logger)
 	}
 

--- a/exporter/awscloudwatchlogsexporter/util.go
+++ b/exporter/awscloudwatchlogsexporter/util.go
@@ -77,7 +77,7 @@ func replace(s, pattern string, value string, logger *zap.Logger) (string, bool)
 }
 
 // getLogInfo retrieves the log group and log stream names from a given set of metrics.
-func getLogInfo(resourceAttrs map[string]any, config *Config) (string, string, bool) {
+func getLogInfo(resourceAttrs map[string]any, config *Config, logger *zap.Logger) (string, string, bool) {
 	var logGroup, logStream string
 	groupReplaced := true
 	streamReplaced := true
@@ -87,10 +87,10 @@ func getLogInfo(resourceAttrs map[string]any, config *Config) (string, string, b
 
 	// Override log group/stream if specified in config. However, in this case, customer won't have correlation experience
 	if len(config.LogGroupName) > 0 {
-		logGroup, groupReplaced = replacePatterns(config.LogGroupName, strAttributeMap, config.logger)
+		logGroup, groupReplaced = replacePatterns(config.LogGroupName, strAttributeMap, logger)
 	}
 	if len(config.LogStreamName) > 0 {
-		logStream, streamReplaced = replacePatterns(config.LogStreamName, strAttributeMap, config.logger)
+		logStream, streamReplaced = replacePatterns(config.LogStreamName, strAttributeMap, logger)
 	}
 
 	return logGroup, logStream, (groupReplaced && streamReplaced)

--- a/exporter/awscloudwatchlogsexporter/util_test.go
+++ b/exporter/awscloudwatchlogsexporter/util_test.go
@@ -1,0 +1,227 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package awscloudwatchlogsexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestReplacePatternValidTaskId(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "{TaskId}"
+
+	attrMap := map[string]any{
+		"aws.ecs.cluster.name": "test-cluster-name",
+		"aws.ecs.task.id":      "test-task-id",
+	}
+
+	s, success := replacePatterns(input, anyMapToStringMap(attrMap), logger)
+
+	assert.Equal(t, "test-task-id", s)
+	assert.True(t, success)
+}
+
+func TestReplacePatternValidServiceName(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "{ServiceName}"
+
+	attrMap := map[string]any{
+		"service.name": "some-test-service",
+	}
+
+	s, success := replacePatterns(input, anyMapToStringMap(attrMap), logger)
+
+	assert.Equal(t, "some-test-service", s)
+	assert.True(t, success)
+}
+
+func TestReplacePatternValidClusterName(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "/aws/ecs/containerinsights/{ClusterName}/performance"
+
+	attrMap := map[string]any{
+		"aws.ecs.cluster.name": "test-cluster-name",
+		"aws.ecs.task.id":      "test-task-id",
+	}
+
+	s, success := replacePatterns(input, anyMapToStringMap(attrMap), logger)
+
+	assert.Equal(t, "/aws/ecs/containerinsights/test-cluster-name/performance", s)
+	assert.True(t, success)
+}
+
+func TestReplacePatternMissingAttribute(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "/aws/ecs/containerinsights/{ClusterName}/performance"
+
+	attrMap := map[string]any{
+		"aws.ecs.task.id": "test-task-id",
+	}
+
+	s, success := replacePatterns(input, anyMapToStringMap(attrMap), logger)
+
+	assert.Equal(t, "/aws/ecs/containerinsights/undefined/performance", s)
+	assert.False(t, success)
+}
+
+func TestReplacePatternValidPodName(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "/aws/eks/containerinsights/{PodName}/performance"
+
+	attrMap := map[string]any{
+		"aws.eks.cluster.name": "test-cluster-name",
+		"PodName":              "test-pod-001",
+	}
+
+	s, success := replacePatterns(input, anyMapToStringMap(attrMap), logger)
+
+	assert.Equal(t, "/aws/eks/containerinsights/test-pod-001/performance", s)
+	assert.True(t, success)
+}
+
+func TestReplacePatternValidPod(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "/aws/eks/containerinsights/{PodName}/performance"
+
+	attrMap := map[string]any{
+		"aws.eks.cluster.name": "test-cluster-name",
+		"PodName":              "test-pod-001",
+	}
+
+	s, success := replacePatterns(input, anyMapToStringMap(attrMap), logger)
+
+	assert.Equal(t, "/aws/eks/containerinsights/test-pod-001/performance", s)
+	assert.True(t, success)
+}
+
+func TestReplacePatternMissingPodName(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "/aws/eks/containerinsights/{PodName}/performance"
+
+	attrMap := map[string]any{
+		"aws.eks.cluster.name": "test-cluster-name",
+	}
+
+	s, success := replacePatterns(input, anyMapToStringMap(attrMap), logger)
+
+	assert.Equal(t, "/aws/eks/containerinsights/undefined/performance", s)
+	assert.False(t, success)
+}
+
+func TestReplacePatternAttrPlaceholderClusterName(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "/aws/ecs/containerinsights/{ClusterName}/performance"
+
+	attrMap := map[string]any{
+		"ClusterName": "test-cluster-name",
+	}
+
+	s, success := replacePatterns(input, anyMapToStringMap(attrMap), logger)
+
+	assert.Equal(t, "/aws/ecs/containerinsights/test-cluster-name/performance", s)
+	assert.True(t, success)
+}
+
+func TestReplacePatternWrongKey(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "/aws/ecs/containerinsights/{WrongKey}/performance"
+
+	attrMap := map[string]any{
+		"ClusterName": "test-task-id",
+	}
+
+	s, success := replacePatterns(input, anyMapToStringMap(attrMap), logger)
+
+	assert.Equal(t, "/aws/ecs/containerinsights/{WrongKey}/performance", s)
+	assert.True(t, success)
+}
+
+func TestReplacePatternNilAttrValue(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "/aws/ecs/containerinsights/{ClusterName}/performance"
+
+	attrMap := map[string]any{
+		"ClusterName": "",
+	}
+
+	s, success := replacePatterns(input, anyMapToStringMap(attrMap), logger)
+
+	assert.Equal(t, "/aws/ecs/containerinsights/undefined/performance", s)
+	assert.False(t, success)
+}
+
+func TestReplacePatternValidTaskDefinitionFamily(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "{TaskDefinitionFamily}"
+
+	attrMap := map[string]any{
+		"aws.ecs.cluster.name": "test-cluster-name",
+		"aws.ecs.task.family":  "test-task-definition-family",
+	}
+
+	s, success := replacePatterns(input, anyMapToStringMap(attrMap), logger)
+
+	assert.Equal(t, "test-task-definition-family", s)
+	assert.True(t, success)
+}
+
+func TestIsPatternValid(t *testing.T) {
+	tests := []struct {
+		name     string
+		pattern  string
+		expected bool
+	}{
+		{
+			name:     "no curly brackets",
+			pattern:  "example-string",
+			expected: true,
+		},
+		{
+			name:     "valid single pattern",
+			pattern:  "prefix-{ClusterName}-suffix",
+			expected: true,
+		},
+		{
+			name:     "valid multiple patterns",
+			pattern:  "{ServiceName}-{TaskId}-{FaasName}",
+			expected: true,
+		},
+		{
+			name:     "invalid pattern key",
+			pattern:  "prefix-{RandomName}-suffix",
+			expected: false,
+		},
+		{
+			name:     "mixed valid and invalid",
+			pattern:  "{ClusterName}-{RandomName}",
+			expected: false,
+		},
+		{
+			name:     "empty curly brackets",
+			pattern:  "prefix-{}-suffix",
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, _ := isPatternValid(tc.pattern)
+			assert.Equal(t, tc.expected, result, "Pattern: %s", tc.pattern)
+		})
+	}
+}

--- a/exporter/awscloudwatchlogsexporter/util_test.go
+++ b/exporter/awscloudwatchlogsexporter/util_test.go
@@ -216,6 +216,36 @@ func TestIsPatternValid(t *testing.T) {
 			pattern:  "prefix-{}-suffix",
 			expected: false,
 		},
+		{
+			name:     "env var syntax ${FOO} should be valid",
+			pattern:  "${ENV_LOG_STREAM_NAME}",
+			expected: true,
+		},
+		{
+			name:     "env var with scheme syntax ${env:FOO} should be valid",
+			pattern:  "${env:LOG_STREAM_NAME}",
+			expected: true,
+		},
+		{
+			name:     "mixed env var and valid placeholder",
+			pattern:  "${ENV_PREFIX}-{ClusterName}",
+			expected: true,
+		},
+		{
+			name:     "mixed env var and invalid placeholder",
+			pattern:  "${ENV_PREFIX}-{RandomName}",
+			expected: false,
+		},
+		{
+			name:     "multiple env vars should be valid",
+			pattern:  "${ENV_ONE}/${ENV_TWO}",
+			expected: true,
+		},
+		{
+			name:     "env var in path context",
+			pattern:  "/aws/logs/${ENV_LOG_STREAM_NAME}/stream",
+			expected: true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

1) Cherry-picks upstream commit open-telemetry#37297
2) Adapt cherry-pick to AWS codebase (https://github.com/amazon-contributing/opentelemetry-collector-contrib/commit/cd62b7c40deb480aef022eb2446b846436e531cf) to use logger from `logsExporter.logger` instead of `logsExporter.Config.logger` since `logsExporter.Config.logger` was removed in this fork in https://github.com/amazon-contributing/opentelemetry-collector-contrib/commit/0e8671f4af966e8efcfdc7f4f46325412ba683d3#diff-873cdea6d638b2c0051d12dc22a05367629476144ba20e0a5e119303c0703626.

    - `logsExporter.Config.logger` and `logsExporter.logger` are the same logger anyways

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

1) built CWAgent ECR image and patched CW EKS add-on to use it.
2) Used OTel Config like the following for patched CW EKS add-on:
```
      otelConfig = {
        receivers = {
          "filelog/testing" = {
            include = [
              "/rootfs/var/lib/kubelet/pods/*/volumes/kubernetes.io~empty-dir/testing-logs/testing.log*"
            ]
            start_at  = "beginning"
            operators = [
              {
                type       = "json_parser"
                parse_from = "body"
              },
              {
                type = "move"
                from = "attributes.service_name"
                to   = "resource[\"service.name\"]"
              }
            ]
          }
        }
        exporters = {
          "awscloudwatchlogs/testing" = {
            log_group_name  = "/testing/{ServiceName}"
            log_stream_name = "testing"
            region          = var.region
            raw_log         = true
          }
        }
        service = {
          pipelines = {
            "logs/testing" = {
              receivers = ["filelog/testing"]
              exporters = ["awscloudwatchlogs/testing"]
            }
          }
        }
      }
```

3) Result: I get log group created & populated: `/testing/billing-service-python`.


<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
