### PR TITLE
feat: add transform and resource processors to AgentCore collector

### DIFF
--- a/cmd/otelcol-agentcore/builder-config.yaml
+++ b/cmd/otelcol-agentcore/builder-config.yaml
@@ -14,6 +14,8 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.124.1
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.124.1
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.124.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.124.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.124.1
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/awscwotlpbatchsplitprocessor v0.124.1
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.124.0
 


### PR DESCRIPTION
## Summary
- Add `transformprocessor` (OTTL-based general transformation) to AgentCore collector
- Add `resourceprocessor` (resource attribute manipulation) to AgentCore collector
- Binary size increase: ~2MB (44MB → 46MB)

## Test plan
- [x] Built successfully with Go 1.24.13
- [x] Verified both processors registered via `otelcol-agentcore components`