### PR TITLE
fix(genaiadapterconnector): handle wrapped message format in parseChainOutput

### DIFF
--- a/.chloggen/fix-genai-adapter-wrapped-message.yaml
+++ b/.chloggen/fix-genai-adapter-wrapped-message.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: connector/genaiadapterconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Handle wrapped message format from openinference-instrumentation-langchain >= 0.1.62 in parseChainOutput
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [478]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/connector/genaiadapterconnector/adapters/openinference_to_cloudwatch.go
+++ b/connector/genaiadapterconnector/adapters/openinference_to_cloudwatch.go
@@ -346,7 +346,13 @@ func parseChainOutput(value string, attrs pcommon.Map) {
 			// always exactly a list of one, see:
 			// https://github.com/langchain-ai/langgraph/blob/8fbdb144876ec9ca75943c7addb452a2bb634304/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py#L661-L662
 			if msg, ok := messages[0].(map[string]any); ok {
-				if addlKwargs, ok := msg["additional_kwargs"].(map[string]any); ok {
+				addlKwargs, ok := msg["additional_kwargs"].(map[string]any)
+				if !ok {
+					if data, ok2 := msg["data"].(map[string]any); ok2 {
+						addlKwargs, ok = data["additional_kwargs"].(map[string]any)
+					}
+				}
+				if ok {
 					if usage, ok := addlKwargs["usage"].(map[string]any); ok {
 						if v, ok := common.ParseInt(usage["prompt_tokens"]); ok {
 							setIfAbsent(attrs, string(semconv.GenAIUsageInputTokensKey), pcommon.NewValueInt(v))
@@ -366,13 +372,18 @@ func parseChainOutput(value string, attrs pcommon.Map) {
 					}
 				}
 
+				msgBody := msg
+				if data, ok := msg["data"].(map[string]any); ok {
+					msgBody = data
+				}
+
 				if msgType, ok := msg["type"].(string); ok && msgType == "ai" {
 					otelMsg := map[string]any{"role": "assistant"}
 					var parts []map[string]any
-					if content, ok := msg["content"].(string); ok && content != "" {
+					if content, ok := msgBody["content"].(string); ok && content != "" {
 						parts = append(parts, map[string]any{"type": "text", "content": content})
 					}
-					if toolCalls, ok := msg["tool_calls"].([]any); ok {
+					if toolCalls, ok := msgBody["tool_calls"].([]any); ok {
 						for _, tc := range toolCalls {
 							if tcMap, ok := tc.(map[string]any); ok {
 								part := map[string]any{"type": "tool_call"}
@@ -404,7 +415,7 @@ func parseChainOutput(value string, attrs pcommon.Map) {
 						setIfAbsent(attrs, string(semconv.GenAIOutputMessagesKey), pcommon.NewValueStr(string(data)))
 					}
 				} else if msgType == "tool" {
-					if content, ok := msg["content"].(string); ok {
+					if content, ok := msgBody["content"].(string); ok {
 						setIfAbsent(attrs, string(semconv.GenAIToolCallResultKey), pcommon.NewValueStr(content))
 					}
 				}
@@ -421,6 +432,10 @@ func parseChainOutput(value string, attrs pcommon.Map) {
 	if err := json.Unmarshal([]byte(value), &messages); err == nil && len(messages) > 0 {
 		var converted []map[string]any
 		for _, msg := range messages {
+			msgBody := msg
+			if data, ok := msg["data"].(map[string]any); ok {
+				msgBody = data
+			}
 			otelMsg := make(map[string]any)
 			if msgType, ok := msg["type"].(string); ok {
 				if role, ok := roleMap[msgType]; ok {
@@ -430,10 +445,10 @@ func parseChainOutput(value string, attrs pcommon.Map) {
 				}
 			}
 			var parts []map[string]any
-			if content, ok := msg["content"].(string); ok && content != "" {
+			if content, ok := msgBody["content"].(string); ok && content != "" {
 				parts = append(parts, map[string]any{"type": "text", "content": content})
 			}
-			if toolCalls, ok := msg["tool_calls"].([]any); ok {
+			if toolCalls, ok := msgBody["tool_calls"].([]any); ok {
 				for _, tc := range toolCalls {
 					if tcMap, ok := tc.(map[string]any); ok {
 						part := map[string]any{"type": "tool_call"}

--- a/connector/genaiadapterconnector/adapters/openinference_to_cloudwatch_test.go
+++ b/connector/genaiadapterconnector/adapters/openinference_to_cloudwatch_test.go
@@ -192,6 +192,41 @@ func TestLangchain_ChainToolsNode(t *testing.T) {
 	assert.False(t, hasAttr(attrs, "output.value"))
 }
 
+func TestLangchain_ChainOutputWrappedFormat(t *testing.T) {
+	span := newSpan(langchainChainOutputWrappedFormatSpan)
+	TransformOpenInferenceSpan(span)
+	attrs := span.Attributes()
+
+	assert.Equal(t, int64(403), getAttr[int64](attrs, string(semconv.GenAIUsageInputTokensKey)))
+	assert.Equal(t, int64(15), getAttr[int64](attrs, string(semconv.GenAIUsageOutputTokensKey)))
+	assert.Equal(t, "anthropic.claude-3-haiku-20240307-v1:0", getAttr[string](attrs, string(semconv.GenAIRequestModelKey)))
+	assert.Equal(t, "end_turn", getAttr[string](attrs, string(semconv.GenAIResponseFinishReasonsKey)))
+
+	var outputMsgs []map[string]any
+	err := json.Unmarshal([]byte(getAttr[string](attrs, string(semconv.GenAIOutputMessagesKey))), &outputMsgs)
+	require.NoError(t, err)
+	require.Len(t, outputMsgs, 1)
+	assert.Equal(t, "assistant", outputMsgs[0]["role"])
+	assert.Equal(t, "The weather in Seattle is 72F and sunny.", getTextContent(t, outputMsgs[0]))
+}
+
+func TestLangchain_ChainOutputWrappedToolCall(t *testing.T) {
+	span := newSpan(langchainChainOutputWrappedToolCallSpan)
+	TransformOpenInferenceSpan(span)
+	attrs := span.Attributes()
+
+	assert.Equal(t, "tool_use", getAttr[string](attrs, string(semconv.GenAIResponseFinishReasonsKey)))
+
+	var outputMsgs []map[string]any
+	err := json.Unmarshal([]byte(getAttr[string](attrs, string(semconv.GenAIOutputMessagesKey))), &outputMsgs)
+	require.NoError(t, err)
+	require.Len(t, outputMsgs, 1)
+
+	toolCalls := getToolCallParts(t, outputMsgs[0])
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "get_weather", toolCalls[0]["name"])
+}
+
 func TestLangchain_ChainOutputArrayFormat(t *testing.T) {
 	span := newSpan(langchainChainOutputArrayFormatSpan)
 	TransformOpenInferenceSpan(span)

--- a/connector/genaiadapterconnector/adapters/spandata_test.go
+++ b/connector/genaiadapterconnector/adapters/spandata_test.go
@@ -136,6 +136,18 @@ var langchainChainOutputArrayFormatSpan = map[string]any{
 	"output.mime_type":        "application/json",
 }
 
+var langchainChainOutputWrappedFormatSpan = map[string]any{
+	"openinference.span.kind": "CHAIN",
+	"output.value":            `{"messages": [{"type": "ai", "data": {"content": "The weather in Seattle is 72F and sunny.", "additional_kwargs": {"usage": {"prompt_tokens": 403, "completion_tokens": 15, "total_tokens": 418}, "stop_reason": "end_turn", "model_id": "anthropic.claude-3-haiku-20240307-v1:0"}, "type": "ai", "tool_calls": []}}]}`,
+	"output.mime_type":        "application/json",
+}
+
+var langchainChainOutputWrappedToolCallSpan = map[string]any{
+	"openinference.span.kind": "CHAIN",
+	"output.value":            `{"messages": [{"type": "ai", "data": {"content": "", "additional_kwargs": {"usage": {"prompt_tokens": 332, "completion_tokens": 53, "total_tokens": 385}, "stop_reason": "tool_use", "model_id": "anthropic.claude-3-haiku-20240307-v1:0"}, "type": "ai", "tool_calls": [{"name": "get_weather", "args": {"city": "Seattle"}, "id": "toolu_bdrk_01GdVCiXNUBY9jGNhN45bFrU"}]}}]}`,
+	"output.mime_type":        "application/json",
+}
+
 var langchainPromptSpan = map[string]any{
 	"openinference.span.kind":       "PROMPT",
 	"input.value":                   `{"input_language": "English", "output_language": "French", "input": "Hello"}`,


### PR DESCRIPTION
## Summary
- openinference-instrumentation-langchain v0.1.62 ([Arize-ai/openinference#2941](https://github.com/Arize-ai/openinference/pull/2941)) changed AIMessage serialization from `model_dump()` to `message_to_dict()`, wrapping messages in a `{"type": "ai", "data": {...}}` envelope
- `parseChainOutput` expected `additional_kwargs`, `content`, and `tool_calls` as direct children of the message object, so token extraction silently failed with the new format
- Add fallback: check `msg["data"]` when direct field access fails, supporting both flat (< 0.1.62) and wrapped (>= 0.1.62) formats

## Test plan
- [x] Added `TestLangchain_ChainOutputWrappedFormat` — validates token, model, and finish_reason extraction from wrapped format
- [x] Added `TestLangchain_ChainOutputWrappedToolCall` — validates tool call extraction from wrapped format
- [x] Existing flat format tests continue to pass