### PR TITLE
fix: add awscwotlpbatchsplit to logs/cloudwatch pipeline

### DIFF
--- a/.chloggen/fix-agentcore-logs-batch-split.yaml
+++ b/.chloggen/fix-agentcore-logs-batch-split.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cmd/otelcol-agentcore
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add awscwotlpbatchsplit processor to logs/cloudwatch pipeline to prevent oversized logs from being dropped
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [503]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/otelcol-agentcore/config.yaml
+++ b/cmd/otelcol-agentcore/config.yaml
@@ -53,7 +53,7 @@ service:
   pipelines:
     logs/cloudwatch:
       receivers: [otlp]
-      processors: [batch]
+      processors: [batch, awscwotlpbatchsplit]
       exporters: [otlphttp/logs]
     metrics:
       receivers: [otlp]


### PR DESCRIPTION
Add `awscwotlpbatchsplit` processor to the `logs/cloudwatch` pipeline in the agentcore collector config