### PR TITLE
  feat(awsemfexporter): add namespace and log_group_name to metric_declarations

### DIFF
--- a/exporter/awsemfexporter/README.md
+++ b/exporter/awsemfexporter/README.md
@@ -63,6 +63,8 @@ incoming metrics' labels and metric names.
 | `dimensions`                       | List of dimension sets to be exported. Dimension sets that include dimensions that are not labels are ignored. Use empty dimension set `[]` for metrics without labels. | [[ ]]   |
 | `metric_name_selectors`            | List of regex strings to filter metric names by.                                                                                                                        |         |
 | [`label_matchers`](#label_matcher) | (Optional) list of label matching rules to filter metrics by their labels. This rule is applied to any metric that matches any of the label matchers.                   | [ ]     |
+| `namespace`                        | (Optional) per-declaration CloudWatch namespace. Supports the same `{Placeholder}` tokens as the exporter-level `namespace` (resolved from resource attributes, then labels). Declarations with distinct namespaces produce separate measurements in the EMF event; each carries only its own dimensions (they are not merged).                      |         |
+| `log_group_name`                   | (Optional) per-declaration CloudWatch log group. Same placeholder syntax as the exporter-level `log_group_name`. Declarations with distinct log groups produce separate EMF events (one per log group).                                                                                                                                              |         |
 
 #### label_matcher
 
@@ -141,3 +143,31 @@ exporters:
         metric_name_selectors:
           - "^node_filesystem_readonly$"
 ```
+
+Per-declaration `namespace` and `log_group_name` overrides let different
+metrics route to different CloudWatch namespaces and log groups from a
+single exporter. Both fields are optional, support `{Placeholder}` tokens,
+and fall back to the exporter-level configuration when empty:
+
+```yaml
+exporters:
+  awsemf:
+    namespace: DefaultNamespace
+    log_group_name: /default/metrics
+    metric_declarations:
+      - metric_name_selectors: [ "^Latency$" ]
+        dimensions: [ [ Service, Operation ] ]
+        # inherits the exporter-level namespace and log group
+
+      - metric_name_selectors: [ "^ErrorCount$" ]
+        dimensions: [ [ Service, ErrorType ] ]
+        namespace: CustomErrorNamespace
+        log_group_name: /custom/errors/{ClusterName}   # placeholders resolved
+                                                        # from resource attrs,
+                                                        # then labels
+```
+
+When two declarations match the same metric with different resolved
+overrides, namespace differences produce multiple measurements inside the
+same EMF event, while log-group differences split into separate EMF events
+(one per resolved log group).

--- a/exporter/awsemfexporter/grouped_metric.go
+++ b/exporter/awsemfexporter/grouped_metric.go
@@ -19,6 +19,10 @@ type groupedMetric struct {
 	labels   map[string]string
 	metrics  map[string]*metricInfo
 	metadata cWMetricMetadata
+	// resourceAttrs is a snapshot of the source ResourceMetrics' resource
+	// attributes. Used for two-pass placeholder resolution on per-declaration
+	// namespace / log_group_name overrides. Not part of the group key.
+	resourceAttrs map[string]string
 }
 
 // metricInfo defines value and unit for OT Metrics
@@ -36,6 +40,7 @@ func addToGroupedMetric(
 	descriptor map[string]MetricDescriptor,
 	config *Config,
 	calculators *emfCalculators,
+	resourceAttrs map[string]string,
 ) error {
 	dps := getDataPoints(pmd, metadata, config.logger)
 	if dps == nil || dps.Len() == 0 {
@@ -47,7 +52,8 @@ func addToGroupedMetric(
 	if shouldConvertToDistribution(pmd, config) {
 		histogram, labels, updatedMetadata := convertToDistribution(filteredDps, metadata, patternReplaceSucceeded, config)
 		if histogram != nil {
-			upsertGroupedMetric(groupedMetrics, updatedMetadata, labels, pmd.Name(), histogram, translateUnit(pmd, descriptor), config.logger)
+			fanOutByLogGroupOverride(groupedMetrics, updatedMetadata, labels, pmd.Name(), histogram,
+				translateUnit(pmd, descriptor), resourceAttrs, config)
 		}
 	} else {
 		for i, dp := range filteredDps {
@@ -70,11 +76,70 @@ func addToGroupedMetric(
 					metadata.metricDataType = pmetric.MetricTypeSum
 				}
 			}
-			upsertGroupedMetric(groupedMetrics, metadata, labels, dp.name, dp.value, translateUnit(pmd, descriptor), config.logger)
+			fanOutByLogGroupOverride(groupedMetrics, metadata, labels, dp.name, dp.value,
+				translateUnit(pmd, descriptor), resourceAttrs, config)
 		}
 	}
 
 	return nil
+}
+
+// fanOutByLogGroupOverride upserts the metric into one groupedMetric per
+// distinct effective log group. The set of effective log groups is derived
+// from the matching metric_declarations:
+//   - a declaration with no log_group_name override contributes the global
+//     (pre-resolved) log group already on metadata.
+//   - a declaration with an override contributes its resolved value.
+//
+// If no declaration matches (or no declarations are configured), the metric
+// lands in a single bucket at the global log group — identical to the
+// pre-override behavior.
+//
+// MatchesLabels and placeholder resolution both use filtered labels (i.e.
+// labels with AWS-EMF meta keys stripped), matching what
+// groupedMetricToCWMeasurementsWithFilters does downstream. If these two
+// sites diverged, a declaration could contribute a bucket here but then be
+// dropped by the filter pass, silently losing its metrics. Raw labels are
+// still stored on the groupedMetric via upsertGroupedMetric — callers that
+// care about the full label set (dimension rollup, EMF field emission)
+// continue to see it.
+func fanOutByLogGroupOverride(
+	groupedMetrics map[any]*groupedMetric,
+	metadata cWMetricMetadata,
+	labels map[string]string,
+	metricName string,
+	metricVal any,
+	unit string,
+	resourceAttrs map[string]string,
+	config *Config,
+) {
+	logger := config.logger
+	filteredLabels := filterAWSEMFAttributes(labels, true)
+	buckets := map[string]struct{}{}
+	matchedAnyDecl := false
+	for _, decl := range config.MetricDeclarations {
+		if !decl.MatchesName(metricName) || !decl.MatchesLabels(filteredLabels) {
+			continue
+		}
+		matchedAnyDecl = true
+		if decl.LogGroupName == "" {
+			buckets[metadata.logGroup] = struct{}{}
+			continue
+		}
+		buckets[replacePatternsTwoPass(decl.LogGroupName, resourceAttrs, filteredLabels, logger)] = struct{}{}
+	}
+	// No declarations configured, or none matched: preserve current behavior
+	// (one group at the global log group; downstream filter will drop metrics
+	// that match no declaration when declarations are configured).
+	if !matchedAnyDecl || len(buckets) == 0 {
+		buckets[metadata.logGroup] = struct{}{}
+	}
+
+	for lg := range buckets {
+		metaCopy := metadata
+		metaCopy.logGroup = lg
+		upsertGroupedMetric(groupedMetrics, metaCopy, labels, metricName, metricVal, unit, logger, resourceAttrs)
+	}
 }
 
 type kubernetesObj struct {
@@ -243,6 +308,7 @@ func upsertGroupedMetric(
 	metricVal any,
 	unit string,
 	logger *zap.Logger,
+	resourceAttrs map[string]string,
 ) {
 	metric := &metricInfo{value: metricVal, unit: unit}
 	groupKey := aws.NewKey(metadata.groupedMetricMetadata, labels)
@@ -256,9 +322,10 @@ func upsertGroupedMetric(
 		}
 	} else {
 		groupedMetrics[groupKey] = &groupedMetric{
-			labels:   labels,
-			metrics:  map[string]*metricInfo{metricName: metric},
-			metadata: metadata,
+			labels:        labels,
+			metrics:       map[string]*metricInfo{metricName: metric},
+			metadata:      metadata,
+			resourceAttrs: resourceAttrs,
 		}
 	}
 }

--- a/exporter/awsemfexporter/grouped_metric_test.go
+++ b/exporter/awsemfexporter/grouped_metric_test.go
@@ -114,7 +114,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 					true,
 					nil,
 					testCfg,
-					emfCalcs)
+					emfCalcs, nil)
 				assert.NoError(t, err)
 			}
 
@@ -156,7 +156,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 				true,
 				nil,
 				testCfg,
-				emfCalcs)
+				emfCalcs, nil)
 			assert.NoError(t, err)
 		}
 
@@ -227,7 +227,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 				true,
 				nil,
 				testCfg,
-				emfCalcs)
+				emfCalcs, nil)
 			assert.NoError(t, err)
 		}
 
@@ -277,7 +277,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 			true,
 			nil,
 			testCfg,
-			emfCalcs)
+			emfCalcs, nil)
 		assert.NoError(t, err)
 
 		metricMetadata2 := generateTestMetricMetadata(namespace,
@@ -287,7 +287,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 			instrumentationLibName,
 			metric.Type(),
 		)
-		err = addToGroupedMetric(metric, groupedMetrics, metricMetadata2, true, nil, testCfg, emfCalcs)
+		err = addToGroupedMetric(metric, groupedMetrics, metricMetadata2, true, nil, testCfg, emfCalcs, nil)
 		assert.NoError(t, err)
 
 		assert.Len(t, groupedMetrics, 2)
@@ -345,6 +345,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 				nil,
 				testCfg,
 				emfCalcs,
+				nil,
 			)
 			assert.NoError(t, err)
 		}
@@ -386,6 +387,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 			nil,
 			testCfg,
 			emfCalcs,
+			nil,
 		)
 		assert.NoError(t, err)
 		assert.Empty(t, groupedMetrics)
@@ -427,6 +429,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 				nil,
 				testCfg,
 				emfCalcs,
+				nil,
 			)
 			assert.NoError(t, err)
 		}
@@ -478,6 +481,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 				nil,
 				cfg,
 				emfCalcs,
+				nil,
 			)
 			assert.NoError(t, err)
 		}
@@ -537,6 +541,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 			nil,
 			cfg,
 			emfCalcs,
+			nil,
 		)
 
 		// Verify results
@@ -611,6 +616,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 				nil,
 				cfg,
 				emfCalcs,
+				nil,
 			)
 			assert.NoError(t, err)
 		}
@@ -716,7 +722,7 @@ func BenchmarkAddToGroupedMetric(b *testing.B) {
 		groupedMetrics := make(map[any]*groupedMetric)
 		for i := 0; i < numMetrics; i++ {
 			metadata := generateTestMetricMetadata("namespace", int64(1596151098037), "log-group", "log-stream", "cloudwatch-otel", metrics.At(i).Type())
-			err := addToGroupedMetric(metrics.At(i), groupedMetrics, metadata, true, nil, testCfg, emfCalcs)
+			err := addToGroupedMetric(metrics.At(i), groupedMetrics, metadata, true, nil, testCfg, emfCalcs, nil)
 			assert.NoError(b, err)
 		}
 	}

--- a/exporter/awsemfexporter/metric_declaration.go
+++ b/exporter/awsemfexporter/metric_declaration.go
@@ -26,6 +26,12 @@ type MetricDeclaration struct {
 	// (Optional) List of label matchers that define matching rules to filter against
 	// the labels of incoming metrics.
 	LabelMatchers []*LabelMatcher `mapstructure:"label_matchers"`
+	// (Optional) Namespace override for metrics matching this declaration.
+	// If empty, the global Config.Namespace is used.
+	Namespace string `mapstructure:"namespace"`
+	// (Optional) Log group name override for metrics matching this declaration.
+	// If empty, the global Config.LogGroupName is used.
+	LogGroupName string `mapstructure:"log_group_name"`
 
 	// metricRegexList is a list of compiled regexes for metric name selectors.
 	metricRegexList []*regexp.Regexp

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -387,36 +387,44 @@ func groupedMetricToCWMeasurementsWithFilters(groupedMetric *groupedMetric, conf
 	// Apply single/zero dimension rollup to labels
 	rollupDimensionArray := dimensionRollup(config.DimensionRollupOption, labels)
 
-	// Collect log group overrides across all groups to detect conflicts.
-	// LogGroupName is event-level (one per groupedMetric), not per-measurement like Namespace.
-	// If multiple groups specify different log group overrides, log a debug message and use the first.
-	// This situation should not occur in practice because metrics with different label sets
-	// are placed in separate groupedMetric objects during the grouping phase, so they never
-	// share an event.
+	// LogGroup is per-event (one EMF event → one PutLogEvents call → one log group),
+	// so different declarations targeting the same metric can conflict. First override wins.
+	//
+	// Example conflict: two declarations both select "Latency" but with different dimensions
+	// and different log_group_name overrides:
+	//
+	//   - metric_name_selectors: [Latency]
+	//     dimensions: [[Service]]
+	//     log_group_name: /service/latency         # override A
+	//
+	//   - metric_name_selectors: [Latency]
+	//     dimensions: [[Service, Operation]]
+	//     log_group_name: /operation/latency        # override B (conflicts with A)
 	var firstLogGroupOverride string
 
 	// Translate each group into a CW Measurement
 	cWMeasurements = make([]cWMeasurement, 0, len(metricDeclGroups))
 	for _, group := range metricDeclGroups {
 		var dimensions [][]string
-		// Extract dimensions and check for namespace/logGroup override from matched declarations
+		// Extract dimensions and resolve per-declaration overrides
 		nsOverridden := false
 		ns := groupedMetric.metadata.namespace
 		logGroupOverride := ""
 		for _, metricDeclIdx := range group.metricDeclIdxList {
 			dims := metricDeclarations[metricDeclIdx].ExtractDimensions(labels)
 			dimensions = append(dimensions, dims...)
-			// Use namespace from first matched declaration that has one
+			// Namespace is per-measurement (each cWMeasurement in the EMF event can have
+			// its own namespace), so no conflict detection is needed — first match wins.
 			if !nsOverridden && metricDeclarations[metricDeclIdx].Namespace != "" {
 				ns = metricDeclarations[metricDeclIdx].Namespace
 				nsOverridden = true
 			}
-			// Use log group from first matched declaration that has one
+			// First log group override wins (see conflict comment above)
 			if logGroupOverride == "" && metricDeclarations[metricDeclIdx].LogGroupName != "" {
 				logGroupOverride = metricDeclarations[metricDeclIdx].LogGroupName
 			}
 		}
-		// Track log group override and warn on conflicts across groups
+		// Warn when a later declaration wants a different log group than the first match
 		if logGroupOverride != "" {
 			if firstLogGroupOverride == "" {
 				firstLogGroupOverride = logGroupOverride
@@ -444,8 +452,7 @@ func groupedMetricToCWMeasurementsWithFilters(groupedMetric *groupedMetric, conf
 		}
 	}
 
-	// Apply the log group override once after all groups are processed.
-	// Resolve placeholders (e.g., {ClusterName}) to match the behavior of the global Config.LogGroupName.
+	// Apply log group override, resolving placeholders (e.g., {ClusterName}) from labels.
 	if firstLogGroupOverride != "" {
 		resolved, _ := replacePatterns(firstLogGroupOverride, labels, config.logger)
 		groupedMetric.metadata.logGroup = resolved

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -387,14 +387,46 @@ func groupedMetricToCWMeasurementsWithFilters(groupedMetric *groupedMetric, conf
 	// Apply single/zero dimension rollup to labels
 	rollupDimensionArray := dimensionRollup(config.DimensionRollupOption, labels)
 
+	// Collect log group overrides across all groups to detect conflicts.
+	// LogGroupName is event-level (one per groupedMetric), not per-measurement like Namespace.
+	// If multiple groups specify different log group overrides, log a debug message and use the first.
+	// This situation should not occur in practice because metrics with different label sets
+	// are placed in separate groupedMetric objects during the grouping phase, so they never
+	// share an event.
+	var firstLogGroupOverride string
+
 	// Translate each group into a CW Measurement
 	cWMeasurements = make([]cWMeasurement, 0, len(metricDeclGroups))
 	for _, group := range metricDeclGroups {
 		var dimensions [][]string
-		// Extract dimensions from matched metric declarations
+		// Extract dimensions and check for namespace/logGroup override from matched declarations
+		nsOverridden := false
+		ns := groupedMetric.metadata.namespace
+		logGroupOverride := ""
 		for _, metricDeclIdx := range group.metricDeclIdxList {
 			dims := metricDeclarations[metricDeclIdx].ExtractDimensions(labels)
 			dimensions = append(dimensions, dims...)
+			// Use namespace from first matched declaration that has one
+			if !nsOverridden && metricDeclarations[metricDeclIdx].Namespace != "" {
+				ns = metricDeclarations[metricDeclIdx].Namespace
+				nsOverridden = true
+			}
+			// Use log group from first matched declaration that has one
+			if logGroupOverride == "" && metricDeclarations[metricDeclIdx].LogGroupName != "" {
+				logGroupOverride = metricDeclarations[metricDeclIdx].LogGroupName
+			}
+		}
+		// Track log group override and warn on conflicts across groups
+		if logGroupOverride != "" {
+			if firstLogGroupOverride == "" {
+				firstLogGroupOverride = logGroupOverride
+			} else if firstLogGroupOverride != logGroupOverride {
+				config.logger.Debug(
+					"Conflicting log_group_name overrides in metric declarations for the same grouped metric; using first override",
+					zap.String("first", firstLogGroupOverride),
+					zap.String("conflicting", logGroupOverride),
+				)
+			}
 		}
 		dimensions = append(dimensions, rollupDimensionArray...)
 
@@ -404,12 +436,19 @@ func groupedMetricToCWMeasurementsWithFilters(groupedMetric *groupedMetric, conf
 		// Export metrics only with non-empty dimensions list
 		if len(dimensions) > 0 {
 			cwm := cWMeasurement{
-				Namespace:  groupedMetric.metadata.namespace,
+				Namespace:  ns,
 				Dimensions: dimensions,
 				Metrics:    group.metrics,
 			}
 			cWMeasurements = append(cWMeasurements, cwm)
 		}
+	}
+
+	// Apply the log group override once after all groups are processed.
+	// Resolve placeholders (e.g., {ClusterName}) to match the behavior of the global Config.LogGroupName.
+	if firstLogGroupOverride != "" {
+		resolved, _ := replacePatterns(firstLogGroupOverride, labels, config.logger)
+		groupedMetric.metadata.logGroup = resolved
 	}
 
 	return

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -135,6 +135,7 @@ func (mt metricTranslator) translateOTelToGroupedMetric(rm pmetric.ResourceMetri
 	cWNamespace := getNamespace(rm, config.Namespace)
 	logGroup, logStream, patternReplaceSucceeded := getLogInfo(rm, cWNamespace, config)
 	deltaInitialValue := config.RetainInitialValueOfDeltaMetric
+	resourceAttrs := attrMaptoStringMap(rm.Resource().Attributes())
 
 	ilms := rm.ScopeMetrics()
 	var metricReceiver string
@@ -176,7 +177,7 @@ func (mt metricTranslator) translateOTelToGroupedMetric(rm pmetric.ResourceMetri
 				instrumentationScopeName: instrumentationScopeName,
 				receiver:                 metricReceiver,
 			}
-			err := addToGroupedMetric(metric, groupedMetrics, metadata, patternReplaceSucceeded, mt.metricDescriptor, config, mt.calculators)
+			err := addToGroupedMetric(metric, groupedMetrics, metadata, patternReplaceSucceeded, mt.metricDescriptor, config, mt.calculators, resourceAttrs)
 			if err != nil {
 				return err
 			}
@@ -307,15 +308,51 @@ func groupedMetricToCWMeasurement(groupedMetric *groupedMetric, config *Config) 
 
 // groupedMetricToCWMeasurementsWithFilters filters the grouped metric using the given list of metric
 // declarations and returns the corresponding list of CW Measurements.
+//
+// Per-declaration overrides:
+//   - log_group_name: LogGroup is per-EMF-event, so fan-out by effective log
+//     group happens at grouping time (see fanOutByLogGroupOverride). This
+//     function only contributes measurements that belong to *this*
+//     groupedMetric's log group: declarations without an override always
+//     participate (they inherit the global log group, matching
+//     groupedMetric.metadata.logGroup by construction), and declarations
+//     whose resolved override != metadata.logGroup are skipped. Note that
+//     the global log group itself may be "undefined" when resolution failed
+//     upstream; declarations without an override still participate in that
+//     case, preserving the pre-override behavior.
+//   - namespace: Namespace is per-cWMeasurement, so a single groupedMetric
+//     can emit multiple measurements with distinct namespaces within the
+//     same EMF event. Declarations matching the same dimension group are
+//     partitioned by their resolved namespace; each partition emits its
+//     own cWMeasurement carrying only that partition's dimensions.
+//
+// Both overrides support {Placeholder} tokens resolved via a two-pass
+// strategy (resource attrs first, labels fallback).
 func groupedMetricToCWMeasurementsWithFilters(groupedMetric *groupedMetric, config *Config) (cWMeasurements []cWMeasurement) {
 	labels := filterAWSEMFAttributes(groupedMetric.labels, true)
 
-	// Filter metric declarations by labels
+	// Filter metric declarations by labels and log-group match. A declaration
+	// with no log_group_name override inherits the global log group and
+	// always participates here; a declaration with an override participates
+	// only when its resolved value equals this groupedMetric's log group.
+	currentLogGroup := groupedMetric.metadata.logGroup
 	metricDeclarations := make([]*MetricDeclaration, 0, len(config.MetricDeclarations))
 	for _, metricDeclaration := range config.MetricDeclarations {
-		if metricDeclaration.MatchesLabels(labels) {
-			metricDeclarations = append(metricDeclarations, metricDeclaration)
+		if !metricDeclaration.MatchesLabels(labels) {
+			continue
 		}
+		if metricDeclaration.LogGroupName != "" {
+			resolved := replacePatternsTwoPass(
+				metricDeclaration.LogGroupName,
+				groupedMetric.resourceAttrs,
+				labels,
+				config.logger,
+			)
+			if resolved != currentLogGroup {
+				continue
+			}
+		}
+		metricDeclarations = append(metricDeclarations, metricDeclaration)
 	}
 
 	// If the whole batch of metrics don't match any metric declarations, drop them
@@ -387,75 +424,41 @@ func groupedMetricToCWMeasurementsWithFilters(groupedMetric *groupedMetric, conf
 	// Apply single/zero dimension rollup to labels
 	rollupDimensionArray := dimensionRollup(config.DimensionRollupOption, labels)
 
-	// LogGroup is per-event (one EMF event → one PutLogEvents call → one log group),
-	// so different declarations targeting the same metric can conflict. First override wins.
-	//
-	// Example conflict: two declarations both select "Latency" but with different dimensions
-	// and different log_group_name overrides:
-	//
-	//   - metric_name_selectors: [Latency]
-	//     dimensions: [[Service]]
-	//     log_group_name: /service/latency         # override A
-	//
-	//   - metric_name_selectors: [Latency]
-	//     dimensions: [[Service, Operation]]
-	//     log_group_name: /operation/latency        # override B (conflicts with A)
-	var firstLogGroupOverride string
-
-	// Translate each group into a CW Measurement
+	// Translate each group into cWMeasurement(s). A single group can emit
+	// multiple measurements when its matching declarations resolve to
+	// different namespaces.
 	cWMeasurements = make([]cWMeasurement, 0, len(metricDeclGroups))
 	for _, group := range metricDeclGroups {
-		var dimensions [][]string
-		// Extract dimensions and resolve per-declaration overrides
-		nsOverridden := false
-		ns := groupedMetric.metadata.namespace
-		logGroupOverride := ""
+		// Partition the declarations in this group by their resolved namespace.
+		// Preserve insertion order so output is deterministic w.r.t. config order.
+		nsOrder := make([]string, 0)
+		byNamespace := make(map[string][][]string)
 		for _, metricDeclIdx := range group.metricDeclIdxList {
-			dims := metricDeclarations[metricDeclIdx].ExtractDimensions(labels)
-			dimensions = append(dimensions, dims...)
-			// Namespace is per-measurement (each cWMeasurement in the EMF event can have
-			// its own namespace), so no conflict detection is needed — first match wins.
-			if !nsOverridden && metricDeclarations[metricDeclIdx].Namespace != "" {
-				ns = metricDeclarations[metricDeclIdx].Namespace
-				nsOverridden = true
+			decl := metricDeclarations[metricDeclIdx]
+			ns := groupedMetric.metadata.namespace
+			if decl.Namespace != "" {
+				ns = replacePatternsTwoPass(decl.Namespace, groupedMetric.resourceAttrs, labels, config.logger)
 			}
-			// First log group override wins (see conflict comment above)
-			if logGroupOverride == "" && metricDeclarations[metricDeclIdx].LogGroupName != "" {
-				logGroupOverride = metricDeclarations[metricDeclIdx].LogGroupName
+			if _, seen := byNamespace[ns]; !seen {
+				nsOrder = append(nsOrder, ns)
+			}
+			byNamespace[ns] = append(byNamespace[ns], decl.ExtractDimensions(labels)...)
+		}
+
+		for _, ns := range nsOrder {
+			dimensions := append([][]string{}, byNamespace[ns]...)
+			dimensions = append(dimensions, rollupDimensionArray...)
+			dimensions = dedupDimensions(dimensions)
+
+			// Export metrics only with non-empty dimensions list
+			if len(dimensions) > 0 {
+				cWMeasurements = append(cWMeasurements, cWMeasurement{
+					Namespace:  ns,
+					Dimensions: dimensions,
+					Metrics:    group.metrics,
+				})
 			}
 		}
-		// Warn when a later declaration wants a different log group than the first match
-		if logGroupOverride != "" {
-			if firstLogGroupOverride == "" {
-				firstLogGroupOverride = logGroupOverride
-			} else if firstLogGroupOverride != logGroupOverride {
-				config.logger.Debug(
-					"Conflicting log_group_name overrides in metric declarations for the same grouped metric; using first override",
-					zap.String("first", firstLogGroupOverride),
-					zap.String("conflicting", logGroupOverride),
-				)
-			}
-		}
-		dimensions = append(dimensions, rollupDimensionArray...)
-
-		// De-duplicate dimensions
-		dimensions = dedupDimensions(dimensions)
-
-		// Export metrics only with non-empty dimensions list
-		if len(dimensions) > 0 {
-			cwm := cWMeasurement{
-				Namespace:  ns,
-				Dimensions: dimensions,
-				Metrics:    group.metrics,
-			}
-			cWMeasurements = append(cWMeasurements, cwm)
-		}
-	}
-
-	// Apply log group override, resolving placeholders (e.g., {ClusterName}) from labels.
-	if firstLogGroupOverride != "" {
-		resolved, _ := replacePatterns(firstLogGroupOverride, labels, config.logger)
-		groupedMetric.metadata.logGroup = resolved
 	}
 
 	return

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -2912,3 +2912,250 @@ func generateTestMetrics(tm testMetric) pmetric.Metrics {
 	}
 	return md
 }
+
+// Tests for per-declaration namespace and log_group_name overrides
+
+
+func TestGroupedMetricToCWMeasurementsWithNamespaceOverride(t *testing.T) {
+	timestamp := int64(1596151098037)
+	namespace := "Namespace"
+
+	labels := map[string]string{
+		"a": "A",
+		"b": "B",
+		"c": "C",
+	}
+	metrics := map[string]*metricInfo{
+		"metric1": {
+			value: 1,
+			unit:  "Count",
+		},
+		"metric2": {
+			value: 200,
+			unit:  "Count",
+		},
+	}
+
+	logger := zap.NewNop()
+
+	t.Run("declaration with namespace override", func(t *testing.T) {
+		decl := &MetricDeclaration{
+			Dimensions:          [][]string{{"a"}, {"a", "c"}},
+			MetricNameSelectors: []string{"metric.*"},
+			Namespace:           "OverrideNamespace",
+		}
+		err := decl.init(logger)
+		assert.NoError(t, err)
+
+		groupedMetric := &groupedMetric{
+			labels:  labels,
+			metrics: metrics,
+			metadata: cWMetricMetadata{
+				groupedMetricMetadata: groupedMetricMetadata{
+					namespace:   namespace,
+					timestampMs: timestamp,
+				},
+			},
+		}
+		config := &Config{
+			DimensionRollupOption: "",
+			MetricDeclarations:    []*MetricDeclaration{decl},
+			logger:                logger,
+		}
+
+		cWMeasurements := groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)
+		assert.Len(t, cWMeasurements, 1)
+		assert.Equal(t, "OverrideNamespace", cWMeasurements[0].Namespace)
+	})
+
+	t.Run("declaration without namespace uses global", func(t *testing.T) {
+		decl := &MetricDeclaration{
+			Dimensions:          [][]string{{"a"}},
+			MetricNameSelectors: []string{"metric.*"},
+		}
+		err := decl.init(logger)
+		assert.NoError(t, err)
+
+		groupedMetric := &groupedMetric{
+			labels:  labels,
+			metrics: metrics,
+			metadata: cWMetricMetadata{
+				groupedMetricMetadata: groupedMetricMetadata{
+					namespace:   namespace,
+					timestampMs: timestamp,
+				},
+			},
+		}
+		config := &Config{
+			DimensionRollupOption: "",
+			MetricDeclarations:    []*MetricDeclaration{decl},
+			logger:                logger,
+		}
+
+		cWMeasurements := groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)
+		assert.Len(t, cWMeasurements, 1)
+		assert.Equal(t, namespace, cWMeasurements[0].Namespace)
+	})
+
+	t.Run("mixed declarations with and without namespace override", func(t *testing.T) {
+		decl1 := &MetricDeclaration{
+			Dimensions:          [][]string{{"a"}},
+			MetricNameSelectors: []string{"metric1"},
+		}
+		decl2 := &MetricDeclaration{
+			Dimensions:          [][]string{{"a", "b"}},
+			MetricNameSelectors: []string{"metric2"},
+			Namespace:           "OverrideNamespace",
+		}
+		err := decl1.init(logger)
+		assert.NoError(t, err)
+		err = decl2.init(logger)
+		assert.NoError(t, err)
+
+		groupedMetric := &groupedMetric{
+			labels:  labels,
+			metrics: metrics,
+			metadata: cWMetricMetadata{
+				groupedMetricMetadata: groupedMetricMetadata{
+					namespace:   namespace,
+					timestampMs: timestamp,
+				},
+			},
+		}
+		config := &Config{
+			DimensionRollupOption: "",
+			MetricDeclarations:    []*MetricDeclaration{decl1, decl2},
+			logger:                logger,
+		}
+
+		cWMeasurements := groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)
+		assert.Len(t, cWMeasurements, 2)
+
+		var m1Measurement, m2Measurement *cWMeasurement
+		for i := range cWMeasurements {
+			for _, m := range cWMeasurements[i].Metrics {
+				if m.Name == "metric1" {
+					m1Measurement = &cWMeasurements[i]
+				}
+				if m.Name == "metric2" {
+					m2Measurement = &cWMeasurements[i]
+				}
+			}
+		}
+
+		assert.NotNil(t, m1Measurement)
+		assert.NotNil(t, m2Measurement)
+		assert.Equal(t, namespace, m1Measurement.Namespace)
+		assert.Equal(t, "OverrideNamespace", m2Measurement.Namespace)
+	})
+}
+
+func TestGroupedMetricToCWMeasurementsWithLogGroupOverride(t *testing.T) {
+	timestamp := int64(1596151098037)
+	namespace := "Namespace"
+	logGroup := "/default/log-group"
+
+	labels := map[string]string{
+		"a": "A",
+		"b": "B",
+		"c": "C",
+	}
+	metrics := map[string]*metricInfo{
+		"metric1": {value: 1, unit: "Count"},
+	}
+	logger := zap.NewNop()
+
+	t.Run("declaration with log_group_name override", func(t *testing.T) {
+		decl := &MetricDeclaration{
+			Dimensions:          [][]string{{"a"}, {"a", "b"}},
+			MetricNameSelectors: []string{"metric.*"},
+			LogGroupName:        "/override/log-group",
+		}
+		err := decl.init(logger)
+		assert.NoError(t, err)
+
+		groupedMetric := &groupedMetric{
+			labels:  labels,
+			metrics: metrics,
+			metadata: cWMetricMetadata{
+				groupedMetricMetadata: groupedMetricMetadata{
+					namespace:   namespace,
+					timestampMs: timestamp,
+					logGroup:    logGroup,
+				},
+			},
+		}
+		config := &Config{
+			DimensionRollupOption: "",
+			MetricDeclarations:    []*MetricDeclaration{decl},
+			logger:                logger,
+		}
+
+		groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)
+		assert.Equal(t, "/override/log-group", groupedMetric.metadata.logGroup)
+	})
+
+	t.Run("declaration without log_group_name uses global", func(t *testing.T) {
+		decl := &MetricDeclaration{
+			Dimensions:          [][]string{{"a"}},
+			MetricNameSelectors: []string{"metric.*"},
+		}
+		err := decl.init(logger)
+		assert.NoError(t, err)
+
+		groupedMetric := &groupedMetric{
+			labels:  labels,
+			metrics: metrics,
+			metadata: cWMetricMetadata{
+				groupedMetricMetadata: groupedMetricMetadata{
+					namespace:   namespace,
+					timestampMs: timestamp,
+					logGroup:    logGroup,
+				},
+			},
+		}
+		config := &Config{
+			DimensionRollupOption: "",
+			MetricDeclarations:    []*MetricDeclaration{decl},
+			logger:                logger,
+		}
+
+		groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)
+		assert.Equal(t, logGroup, groupedMetric.metadata.logGroup)
+	})
+
+	t.Run("log_group_name with placeholder resolved from labels", func(t *testing.T) {
+		decl := &MetricDeclaration{
+			Dimensions:          [][]string{{"a"}},
+			MetricNameSelectors: []string{"metric.*"},
+			LogGroupName:        "/override/{ClusterName}/metrics",
+		}
+		err := decl.init(logger)
+		assert.NoError(t, err)
+
+		labelsWithCluster := map[string]string{
+			"a":           "A",
+			"b":           "B",
+			"ClusterName": "my-cluster",
+		}
+		groupedMetric := &groupedMetric{
+			labels:  labelsWithCluster,
+			metrics: metrics,
+			metadata: cWMetricMetadata{
+				groupedMetricMetadata: groupedMetricMetadata{
+					namespace:   namespace,
+					timestampMs: timestamp,
+					logGroup:    logGroup,
+				},
+			},
+		}
+		config := &Config{
+			DimensionRollupOption: "",
+			MetricDeclarations:    []*MetricDeclaration{decl},
+			logger:                logger,
+		}
+
+		groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)
+		assert.Equal(t, "/override/my-cluster/metrics", groupedMetric.metadata.logGroup)
+	})
+}

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -2913,8 +2913,13 @@ func generateTestMetrics(tm testMetric) pmetric.Metrics {
 	return md
 }
 
-// Tests for per-declaration namespace and log_group_name overrides
-
+// Tests for per-declaration namespace and log_group_name overrides.
+//
+// Namespace overrides split at measurement-emission time: one grouped metric
+// can emit multiple cWMeasurements with distinct namespaces within the same
+// EMF event. Log-group overrides split at grouping time: metrics matching
+// multiple declarations with different log_group_name end up in distinct
+// groupedMetric entries (and thus distinct EMF events).
 
 func TestGroupedMetricToCWMeasurementsWithNamespaceOverride(t *testing.T) {
 	timestamp := int64(1596151098037)
@@ -2926,14 +2931,8 @@ func TestGroupedMetricToCWMeasurementsWithNamespaceOverride(t *testing.T) {
 		"c": "C",
 	}
 	metrics := map[string]*metricInfo{
-		"metric1": {
-			value: 1,
-			unit:  "Count",
-		},
-		"metric2": {
-			value: 200,
-			unit:  "Count",
-		},
+		"metric1": {value: 1, unit: "Count"},
+		"metric2": {value: 200, unit: "Count"},
 	}
 
 	logger := zap.NewNop()
@@ -2944,18 +2943,14 @@ func TestGroupedMetricToCWMeasurementsWithNamespaceOverride(t *testing.T) {
 			MetricNameSelectors: []string{"metric.*"},
 			Namespace:           "OverrideNamespace",
 		}
-		err := decl.init(logger)
-		assert.NoError(t, err)
+		require.NoError(t, decl.init(logger))
 
-		groupedMetric := &groupedMetric{
+		gm := &groupedMetric{
 			labels:  labels,
 			metrics: metrics,
-			metadata: cWMetricMetadata{
-				groupedMetricMetadata: groupedMetricMetadata{
-					namespace:   namespace,
-					timestampMs: timestamp,
-				},
-			},
+			metadata: cWMetricMetadata{groupedMetricMetadata: groupedMetricMetadata{
+				namespace: namespace, timestampMs: timestamp,
+			}},
 		}
 		config := &Config{
 			DimensionRollupOption: "",
@@ -2963,9 +2958,9 @@ func TestGroupedMetricToCWMeasurementsWithNamespaceOverride(t *testing.T) {
 			logger:                logger,
 		}
 
-		cWMeasurements := groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)
-		assert.Len(t, cWMeasurements, 1)
-		assert.Equal(t, "OverrideNamespace", cWMeasurements[0].Namespace)
+		out := groupedMetricToCWMeasurementsWithFilters(gm, config)
+		assert.Len(t, out, 1)
+		assert.Equal(t, "OverrideNamespace", out[0].Namespace)
 	})
 
 	t.Run("declaration without namespace uses global", func(t *testing.T) {
@@ -2973,31 +2968,52 @@ func TestGroupedMetricToCWMeasurementsWithNamespaceOverride(t *testing.T) {
 			Dimensions:          [][]string{{"a"}},
 			MetricNameSelectors: []string{"metric.*"},
 		}
-		err := decl.init(logger)
-		assert.NoError(t, err)
+		require.NoError(t, decl.init(logger))
 
-		groupedMetric := &groupedMetric{
+		gm := &groupedMetric{
 			labels:  labels,
 			metrics: metrics,
-			metadata: cWMetricMetadata{
-				groupedMetricMetadata: groupedMetricMetadata{
-					namespace:   namespace,
-					timestampMs: timestamp,
-				},
-			},
+			metadata: cWMetricMetadata{groupedMetricMetadata: groupedMetricMetadata{
+				namespace: namespace, timestampMs: timestamp,
+			}},
 		}
-		config := &Config{
-			DimensionRollupOption: "",
-			MetricDeclarations:    []*MetricDeclaration{decl},
-			logger:                logger,
-		}
+		config := &Config{MetricDeclarations: []*MetricDeclaration{decl}, logger: logger}
 
-		cWMeasurements := groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)
-		assert.Len(t, cWMeasurements, 1)
-		assert.Equal(t, namespace, cWMeasurements[0].Namespace)
+		out := groupedMetricToCWMeasurementsWithFilters(gm, config)
+		assert.Len(t, out, 1)
+		assert.Equal(t, namespace, out[0].Namespace)
 	})
 
-	t.Run("mixed declarations with and without namespace override", func(t *testing.T) {
+	t.Run("two declarations, different namespaces, same metric → two measurements in one EMF event", func(t *testing.T) {
+		decl1 := &MetricDeclaration{
+			Dimensions:          [][]string{{"a"}},
+			MetricNameSelectors: []string{"metric1"},
+			Namespace:           "NS_A",
+		}
+		decl2 := &MetricDeclaration{
+			Dimensions:          [][]string{{"a", "b"}},
+			MetricNameSelectors: []string{"metric1"},
+			Namespace:           "NS_B",
+		}
+		require.NoError(t, decl1.init(logger))
+		require.NoError(t, decl2.init(logger))
+
+		gm := &groupedMetric{
+			labels:  labels,
+			metrics: map[string]*metricInfo{"metric1": {value: 1, unit: "Count"}},
+			metadata: cWMetricMetadata{groupedMetricMetadata: groupedMetricMetadata{
+				namespace: namespace, timestampMs: timestamp,
+			}},
+		}
+		config := &Config{MetricDeclarations: []*MetricDeclaration{decl1, decl2}, logger: logger}
+
+		out := groupedMetricToCWMeasurementsWithFilters(gm, config)
+		assert.Len(t, out, 2)
+		namespaces := []string{out[0].Namespace, out[1].Namespace}
+		assert.ElementsMatch(t, []string{"NS_A", "NS_B"}, namespaces)
+	})
+
+	t.Run("mixed: one declaration with override, one without → two measurements (global + override)", func(t *testing.T) {
 		decl1 := &MetricDeclaration{
 			Dimensions:          [][]string{{"a"}},
 			MetricNameSelectors: []string{"metric1"},
@@ -3007,155 +3023,317 @@ func TestGroupedMetricToCWMeasurementsWithNamespaceOverride(t *testing.T) {
 			MetricNameSelectors: []string{"metric2"},
 			Namespace:           "OverrideNamespace",
 		}
-		err := decl1.init(logger)
-		assert.NoError(t, err)
-		err = decl2.init(logger)
-		assert.NoError(t, err)
+		require.NoError(t, decl1.init(logger))
+		require.NoError(t, decl2.init(logger))
 
-		groupedMetric := &groupedMetric{
+		gm := &groupedMetric{
 			labels:  labels,
 			metrics: metrics,
-			metadata: cWMetricMetadata{
-				groupedMetricMetadata: groupedMetricMetadata{
-					namespace:   namespace,
-					timestampMs: timestamp,
-				},
-			},
+			metadata: cWMetricMetadata{groupedMetricMetadata: groupedMetricMetadata{
+				namespace: namespace, timestampMs: timestamp,
+			}},
 		}
-		config := &Config{
-			DimensionRollupOption: "",
-			MetricDeclarations:    []*MetricDeclaration{decl1, decl2},
-			logger:                logger,
-		}
+		config := &Config{MetricDeclarations: []*MetricDeclaration{decl1, decl2}, logger: logger}
 
-		cWMeasurements := groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)
-		assert.Len(t, cWMeasurements, 2)
+		out := groupedMetricToCWMeasurementsWithFilters(gm, config)
+		assert.Len(t, out, 2)
 
-		var m1Measurement, m2Measurement *cWMeasurement
-		for i := range cWMeasurements {
-			for _, m := range cWMeasurements[i].Metrics {
+		var m1, m2 *cWMeasurement
+		for i := range out {
+			for _, m := range out[i].Metrics {
 				if m.Name == "metric1" {
-					m1Measurement = &cWMeasurements[i]
+					m1 = &out[i]
 				}
 				if m.Name == "metric2" {
-					m2Measurement = &cWMeasurements[i]
+					m2 = &out[i]
 				}
 			}
 		}
+		require.NotNil(t, m1)
+		require.NotNil(t, m2)
+		assert.Equal(t, namespace, m1.Namespace)
+		assert.Equal(t, "OverrideNamespace", m2.Namespace)
+	})
 
-		assert.NotNil(t, m1Measurement)
-		assert.NotNil(t, m2Measurement)
-		assert.Equal(t, namespace, m1Measurement.Namespace)
-		assert.Equal(t, "OverrideNamespace", m2Measurement.Namespace)
+	t.Run("placeholder resolved from resource attrs", func(t *testing.T) {
+		decl := &MetricDeclaration{
+			Dimensions:          [][]string{{"a"}},
+			MetricNameSelectors: []string{"metric.*"},
+			Namespace:           "{ClusterName}",
+		}
+		require.NoError(t, decl.init(logger))
+
+		gm := &groupedMetric{
+			labels:        labels,
+			metrics:       metrics,
+			resourceAttrs: map[string]string{"ClusterName": "my-cluster"},
+			metadata: cWMetricMetadata{groupedMetricMetadata: groupedMetricMetadata{
+				namespace: namespace, timestampMs: timestamp,
+			}},
+		}
+		config := &Config{MetricDeclarations: []*MetricDeclaration{decl}, logger: logger}
+
+		out := groupedMetricToCWMeasurementsWithFilters(gm, config)
+		require.Len(t, out, 1)
+		assert.Equal(t, "my-cluster", out[0].Namespace)
+	})
+
+	t.Run("placeholder falls back to labels when missing from resource attrs", func(t *testing.T) {
+		decl := &MetricDeclaration{
+			Dimensions:          [][]string{{"a"}},
+			MetricNameSelectors: []string{"metric.*"},
+			Namespace:           "{ClusterName}",
+		}
+		require.NoError(t, decl.init(logger))
+
+		labelsWithCluster := map[string]string{"a": "A", "b": "B", "ClusterName": "label-cluster"}
+		gm := &groupedMetric{
+			labels:  labelsWithCluster,
+			metrics: metrics,
+			metadata: cWMetricMetadata{groupedMetricMetadata: groupedMetricMetadata{
+				namespace: namespace, timestampMs: timestamp,
+			}},
+		}
+		config := &Config{MetricDeclarations: []*MetricDeclaration{decl}, logger: logger}
+
+		out := groupedMetricToCWMeasurementsWithFilters(gm, config)
+		require.Len(t, out, 1)
+		assert.Equal(t, "label-cluster", out[0].Namespace)
+	})
+
+	t.Run("placeholder missing from both → undefined", func(t *testing.T) {
+		decl := &MetricDeclaration{
+			Dimensions:          [][]string{{"a"}},
+			MetricNameSelectors: []string{"metric.*"},
+			Namespace:           "{ClusterName}",
+		}
+		require.NoError(t, decl.init(logger))
+
+		gm := &groupedMetric{
+			labels:  labels,
+			metrics: metrics,
+			metadata: cWMetricMetadata{groupedMetricMetadata: groupedMetricMetadata{
+				namespace: namespace, timestampMs: timestamp,
+			}},
+		}
+		config := &Config{MetricDeclarations: []*MetricDeclaration{decl}, logger: logger}
+
+		out := groupedMetricToCWMeasurementsWithFilters(gm, config)
+		require.Len(t, out, 1)
+		assert.Equal(t, "undefined", out[0].Namespace)
 	})
 }
 
-func TestGroupedMetricToCWMeasurementsWithLogGroupOverride(t *testing.T) {
-	timestamp := int64(1596151098037)
-	namespace := "Namespace"
-	logGroup := "/default/log-group"
-
-	labels := map[string]string{
-		"a": "A",
-		"b": "B",
-		"c": "C",
-	}
-	metrics := map[string]*metricInfo{
-		"metric1": {value: 1, unit: "Count"},
-	}
+func TestFanOutByLogGroupOverride(t *testing.T) {
 	logger := zap.NewNop()
+	const globalLogGroup = "/default/log-group"
 
-	t.Run("declaration with log_group_name override", func(t *testing.T) {
+	// Build a single-datapoint gauge metric named "metric1" with label a=A,b=B.
+	buildInput := func() pmetric.Metric {
+		rms := pmetric.NewResourceMetrics()
+		ilm := rms.ScopeMetrics().AppendEmpty()
+		m := ilm.Metrics().AppendEmpty()
+		m.SetName("metric1")
+		dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+		dp.SetDoubleValue(1.0)
+		dp.Attributes().PutStr("a", "A")
+		dp.Attributes().PutStr("b", "B")
+		return m
+	}
+	baseMeta := cWMetricMetadata{groupedMetricMetadata: groupedMetricMetadata{
+		namespace:      "NS",
+		timestampMs:    1596151098037,
+		logGroup:       globalLogGroup,
+		logStream:      "stream",
+		metricDataType: pmetric.MetricTypeGauge,
+	}}
+
+	t.Run("single override → single groupedMetric at overridden log group", func(t *testing.T) {
 		decl := &MetricDeclaration{
-			Dimensions:          [][]string{{"a"}, {"a", "b"}},
+			Dimensions:          [][]string{{"a"}},
 			MetricNameSelectors: []string{"metric.*"},
 			LogGroupName:        "/override/log-group",
 		}
-		err := decl.init(logger)
-		assert.NoError(t, err)
+		require.NoError(t, decl.init(logger))
 
-		groupedMetric := &groupedMetric{
-			labels:  labels,
-			metrics: metrics,
-			metadata: cWMetricMetadata{
-				groupedMetricMetadata: groupedMetricMetadata{
-					namespace:   namespace,
-					timestampMs: timestamp,
-					logGroup:    logGroup,
-				},
-			},
-		}
 		config := &Config{
-			DimensionRollupOption: "",
-			MetricDeclarations:    []*MetricDeclaration{decl},
-			logger:                logger,
+			MetricDeclarations: []*MetricDeclaration{decl},
+			logger:             logger,
 		}
-
-		groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)
-		assert.Equal(t, "/override/log-group", groupedMetric.metadata.logGroup)
+		calcs := setupEmfCalculators()
+		groupedMetrics := map[any]*groupedMetric{}
+		require.NoError(t, addToGroupedMetric(buildInput(), groupedMetrics, baseMeta, true, nil, config, calcs, nil))
+		require.Len(t, groupedMetrics, 1)
+		for _, g := range groupedMetrics {
+			assert.Equal(t, "/override/log-group", g.metadata.logGroup)
+		}
 	})
 
-	t.Run("declaration without log_group_name uses global", func(t *testing.T) {
-		decl := &MetricDeclaration{
+	t.Run("two declarations, different log groups → two groupedMetrics", func(t *testing.T) {
+		decl1 := &MetricDeclaration{
+			Dimensions:          [][]string{{"a"}},
+			MetricNameSelectors: []string{"metric.*"},
+			LogGroupName:        "/log-a",
+		}
+		decl2 := &MetricDeclaration{
+			Dimensions:          [][]string{{"a", "b"}},
+			MetricNameSelectors: []string{"metric.*"},
+			LogGroupName:        "/log-b",
+		}
+		require.NoError(t, decl1.init(logger))
+		require.NoError(t, decl2.init(logger))
+
+		config := &Config{
+			MetricDeclarations: []*MetricDeclaration{decl1, decl2},
+			logger:             logger,
+		}
+		calcs := setupEmfCalculators()
+		groupedMetrics := map[any]*groupedMetric{}
+		require.NoError(t, addToGroupedMetric(buildInput(), groupedMetrics, baseMeta, true, nil, config, calcs, nil))
+
+		require.Len(t, groupedMetrics, 2)
+		got := make(map[string]bool, 2)
+		for _, g := range groupedMetrics {
+			got[g.metadata.logGroup] = true
+		}
+		assert.True(t, got["/log-a"])
+		assert.True(t, got["/log-b"])
+	})
+
+	t.Run("mixed override and no-override → two groupedMetrics (global + override)", func(t *testing.T) {
+		decl1 := &MetricDeclaration{
 			Dimensions:          [][]string{{"a"}},
 			MetricNameSelectors: []string{"metric.*"},
 		}
-		err := decl.init(logger)
-		assert.NoError(t, err)
-
-		groupedMetric := &groupedMetric{
-			labels:  labels,
-			metrics: metrics,
-			metadata: cWMetricMetadata{
-				groupedMetricMetadata: groupedMetricMetadata{
-					namespace:   namespace,
-					timestampMs: timestamp,
-					logGroup:    logGroup,
-				},
-			},
+		decl2 := &MetricDeclaration{
+			Dimensions:          [][]string{{"a", "b"}},
+			MetricNameSelectors: []string{"metric.*"},
+			LogGroupName:        "/override",
 		}
+		require.NoError(t, decl1.init(logger))
+		require.NoError(t, decl2.init(logger))
+
 		config := &Config{
-			DimensionRollupOption: "",
-			MetricDeclarations:    []*MetricDeclaration{decl},
-			logger:                logger,
+			MetricDeclarations: []*MetricDeclaration{decl1, decl2},
+			logger:             logger,
 		}
+		calcs := setupEmfCalculators()
+		groupedMetrics := map[any]*groupedMetric{}
+		require.NoError(t, addToGroupedMetric(buildInput(), groupedMetrics, baseMeta, true, nil, config, calcs, nil))
 
-		groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)
-		assert.Equal(t, logGroup, groupedMetric.metadata.logGroup)
+		require.Len(t, groupedMetrics, 2)
+		got := make(map[string]bool, 2)
+		for _, g := range groupedMetrics {
+			got[g.metadata.logGroup] = true
+		}
+		assert.True(t, got[globalLogGroup])
+		assert.True(t, got["/override"])
 	})
 
-	t.Run("log_group_name with placeholder resolved from labels", func(t *testing.T) {
+	t.Run("log_group_name placeholder resolved from resource attrs", func(t *testing.T) {
 		decl := &MetricDeclaration{
 			Dimensions:          [][]string{{"a"}},
 			MetricNameSelectors: []string{"metric.*"},
-			LogGroupName:        "/override/{ClusterName}/metrics",
+			LogGroupName:        "/{ClusterName}/metrics",
 		}
-		err := decl.init(logger)
-		assert.NoError(t, err)
+		require.NoError(t, decl.init(logger))
 
-		labelsWithCluster := map[string]string{
-			"a":           "A",
-			"b":           "B",
-			"ClusterName": "my-cluster",
-		}
-		groupedMetric := &groupedMetric{
-			labels:  labelsWithCluster,
-			metrics: metrics,
-			metadata: cWMetricMetadata{
-				groupedMetricMetadata: groupedMetricMetadata{
-					namespace:   namespace,
-					timestampMs: timestamp,
-					logGroup:    logGroup,
-				},
-			},
-		}
-		config := &Config{
-			DimensionRollupOption: "",
-			MetricDeclarations:    []*MetricDeclaration{decl},
-			logger:                logger,
-		}
+		config := &Config{MetricDeclarations: []*MetricDeclaration{decl}, logger: logger}
+		calcs := setupEmfCalculators()
+		groupedMetrics := map[any]*groupedMetric{}
+		resAttrs := map[string]string{"ClusterName": "my-cluster"}
+		require.NoError(t, addToGroupedMetric(buildInput(), groupedMetrics, baseMeta, true, nil, config, calcs, resAttrs))
 
-		groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)
-		assert.Equal(t, "/override/my-cluster/metrics", groupedMetric.metadata.logGroup)
+		require.Len(t, groupedMetrics, 1)
+		for _, g := range groupedMetrics {
+			assert.Equal(t, "/my-cluster/metrics", g.metadata.logGroup)
+		}
+	})
+
+	t.Run("log_group_name placeholder falls back to labels", func(t *testing.T) {
+		decl := &MetricDeclaration{
+			Dimensions:          [][]string{{"a"}},
+			MetricNameSelectors: []string{"metric.*"},
+			LogGroupName:        "/{ClusterName}/metrics",
+		}
+		require.NoError(t, decl.init(logger))
+
+		rms := pmetric.NewResourceMetrics()
+		ilm := rms.ScopeMetrics().AppendEmpty()
+		m := ilm.Metrics().AppendEmpty()
+		m.SetName("metric1")
+		dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+		dp.SetDoubleValue(1.0)
+		dp.Attributes().PutStr("a", "A")
+		dp.Attributes().PutStr("ClusterName", "label-cluster")
+
+		config := &Config{MetricDeclarations: []*MetricDeclaration{decl}, logger: logger}
+		calcs := setupEmfCalculators()
+		groupedMetrics := map[any]*groupedMetric{}
+		require.NoError(t, addToGroupedMetric(m, groupedMetrics, baseMeta, true, nil, config, calcs, nil))
+
+		require.Len(t, groupedMetrics, 1)
+		for _, g := range groupedMetrics {
+			assert.Equal(t, "/label-cluster/metrics", g.metadata.logGroup)
+		}
+	})
+
+	t.Run("log_group_name placeholder missing from both → undefined", func(t *testing.T) {
+		decl := &MetricDeclaration{
+			Dimensions:          [][]string{{"a"}},
+			MetricNameSelectors: []string{"metric.*"},
+			LogGroupName:        "/{ClusterName}/metrics",
+		}
+		require.NoError(t, decl.init(logger))
+
+		config := &Config{MetricDeclarations: []*MetricDeclaration{decl}, logger: logger}
+		calcs := setupEmfCalculators()
+		groupedMetrics := map[any]*groupedMetric{}
+		require.NoError(t, addToGroupedMetric(buildInput(), groupedMetrics, baseMeta, true, nil, config, calcs, nil))
+
+		require.Len(t, groupedMetrics, 1)
+		for _, g := range groupedMetrics {
+			assert.Equal(t, "/undefined/metrics", g.metadata.logGroup)
+		}
+	})
+
+	// Regression: fan-out and the downstream filter must see the same label
+	// set. Both now operate on filterAWSEMFAttributes-stripped labels. If they
+	// diverge, a declaration whose label_matchers or {Placeholder} depend on a
+	// stripped key would contribute a bucket in fan-out but get dropped in the
+	// filter pass, silently losing the metric.
+	t.Run("matches_labels consistent across fan-out and filter when EMF meta keys are present", func(t *testing.T) {
+		decl := &MetricDeclaration{
+			Dimensions:          [][]string{{"a"}},
+			MetricNameSelectors: []string{"metric.*"},
+			LogGroupName:        "/override",
+		}
+		require.NoError(t, decl.init(logger))
+
+		// Build a metric whose datapoint carries the EMF storage-resolution
+		// attribute and an entity-prefixed label — both stripped by
+		// filterAWSEMFAttributes.
+		rms := pmetric.NewResourceMetrics()
+		ilm := rms.ScopeMetrics().AppendEmpty()
+		m := ilm.Metrics().AppendEmpty()
+		m.SetName("metric1")
+		dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+		dp.SetDoubleValue(1.0)
+		dp.Attributes().PutStr("a", "A")
+		dp.Attributes().PutStr("aws.emf.storage_resolution", "1")
+		dp.Attributes().PutStr("com.amazonaws.cloudwatch.entity.internal.service.name", "svc")
+
+		config := &Config{MetricDeclarations: []*MetricDeclaration{decl}, logger: logger}
+		calcs := setupEmfCalculators()
+		groupedMetrics := map[any]*groupedMetric{}
+		require.NoError(t, addToGroupedMetric(m, groupedMetrics, baseMeta, true, nil, config, calcs, nil))
+
+		require.Len(t, groupedMetrics, 1)
+		for _, g := range groupedMetrics {
+			assert.Equal(t, "/override", g.metadata.logGroup)
+			// And the downstream filter must not drop this group.
+			out := groupedMetricToCWMeasurementsWithFilters(g, config)
+			require.Len(t, out, 1, "filter must not drop the group that fan-out produced")
+		}
 	})
 }

--- a/exporter/awsemfexporter/util.go
+++ b/exporter/awsemfexporter/util.go
@@ -36,6 +36,27 @@ func replacePatterns(s string, attrMap map[string]string, logger *zap.Logger) (s
 	return s, success
 }
 
+// replacePatternsTwoPass resolves {Placeholder} tokens in s using resourceAttrs
+// first; if any token is missing from resourceAttrs, it retries against labels.
+// Mirrors the two-pass strategy in replacePatternsIfNeeded so per-declaration
+// overrides honor the same resolution behavior as the global LogGroupName.
+//
+// The labels-fallback pass runs against the original template, not the
+// partially-resolved first-pass output — matching replacePatternsIfNeeded.
+// Tokens that remain unresolved after both passes become "undefined" per
+// replacePatterns semantics.
+func replacePatternsTwoPass(s string, resourceAttrs, labels map[string]string, logger *zap.Logger) string {
+	if s == "" {
+		return s
+	}
+	resolved, ok := replacePatterns(s, resourceAttrs, logger)
+	if ok {
+		return resolved
+	}
+	fallback, _ := replacePatterns(s, labels, logger)
+	return fallback
+}
+
 func replacePatternWithAttrValue(s, patternKey string, attrMap map[string]string, logger *zap.Logger) (string, bool) {
 	pattern := "{" + patternKey + "}"
 	if strings.Contains(s, pattern) {

--- a/exporter/awsemfexporter/util_test.go
+++ b/exporter/awsemfexporter/util_test.go
@@ -365,3 +365,81 @@ func TestGetLogInfo(t *testing.T) {
 		}
 	}
 }
+
+func TestReplacePatternsTwoPass(t *testing.T) {
+	logger := zap.NewNop()
+
+	tests := []struct {
+		name          string
+		template      string
+		resourceAttrs map[string]string
+		labels        map[string]string
+		want          string
+	}{
+		{
+			name:     "empty template returns empty",
+			template: "",
+			want:     "",
+		},
+		{
+			name:     "no placeholders returns template verbatim",
+			template: "/plain/log-group",
+			want:     "/plain/log-group",
+		},
+		{
+			name:          "resolved from resource attrs on first pass",
+			template:      "/{ClusterName}/metrics",
+			resourceAttrs: map[string]string{"ClusterName": "cluster-a"},
+			labels:        map[string]string{"ClusterName": "should-be-ignored"},
+			want:          "/cluster-a/metrics",
+		},
+		{
+			name:          "falls back to labels when missing from resource attrs",
+			template:      "/{ClusterName}/metrics",
+			resourceAttrs: map[string]string{},
+			labels:        map[string]string{"ClusterName": "cluster-from-labels"},
+			want:          "/cluster-from-labels/metrics",
+		},
+		{
+			name:          "falls back to labels when resource-attr lookup yields empty",
+			template:      "/{ClusterName}/metrics",
+			resourceAttrs: map[string]string{"ClusterName": ""},
+			labels:        map[string]string{"ClusterName": "cluster-from-labels"},
+			want:          "/cluster-from-labels/metrics",
+		},
+		{
+			name:     "unresolved placeholder in both maps becomes undefined",
+			template: "/{ClusterName}/metrics",
+			want:     "/undefined/metrics",
+		},
+		{
+			name:          "resource-attr resolution wins when both maps supply value",
+			template:      "/{ClusterName}/{TaskId}",
+			resourceAttrs: map[string]string{"ClusterName": "cluster-res", "TaskId": "task-res"},
+			labels:        map[string]string{"ClusterName": "cluster-lbl", "TaskId": "task-lbl"},
+			want:          "/cluster-res/task-res",
+		},
+		{
+			// When resource attrs partially resolve (ClusterName present, TaskId missing),
+			// the full fallback pass runs against labels — both tokens resolve there.
+			name:          "partial resource match forces label-pass for all tokens",
+			template:      "/{ClusterName}/{TaskId}",
+			resourceAttrs: map[string]string{"ClusterName": "cluster-res"},
+			labels:        map[string]string{"ClusterName": "cluster-lbl", "TaskId": "task-lbl"},
+			want:          "/cluster-lbl/task-lbl",
+		},
+		{
+			name:          "semconv attribute name also accepted on resource pass",
+			template:      "/{ClusterName}/metrics",
+			resourceAttrs: map[string]string{"aws.ecs.cluster.name": "cluster-via-semconv"},
+			want:          "/cluster-via-semconv/metrics",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := replacePatternsTwoPass(tc.template, tc.resourceAttrs, tc.labels, logger)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Allow `metric_declarations` to override `namespace` and `log_group_name` per declaration, so different metrics can route to different CloudWatch namespaces and log groups from the same exporter.

Both fields are optional. When omitted, the global exporter config is used (fully backward compatible).

## Example

```yaml
exporters:
  awsemf:
    namespace: DefaultNamespace
    log_group_name: /default/metrics
    metric_declarations:
      - metric_name_selectors: [Latency]
        dimensions: [[Service, Operation]]
        # uses global namespace and log group

      - metric_name_selectors: [ErrorCount]
        dimensions: [[Service, ErrorType]]
        namespace: CustomNamespace             # override
        log_group_name: /custom/error-metrics  # override
```

## Changes

- Add optional `Namespace` and `LogGroupName` fields to `MetricDeclaration`
- Apply overrides from matched declaration in `groupedMetricToCWMeasurementsWithFilters()`
- Add 5 unit tests covering override, fallback, and mixed declarations

No breaking changes. All existing tests pass.
