### PR TITLE
Update LIS scraper service selector for renamed ec2-instance-store-plugin

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/nvme/nvme_lis_scraper_config.go
+++ b/receiver/awscontainerinsightreceiver/internal/nvme/nvme_lis_scraper_config.go
@@ -20,7 +20,7 @@ const (
 	lisCollectionInterval        = 60 * time.Second
 	lisJobName                   = "containerInsightsNVMeLISScraper"
 	lisScraperMetricsPath        = "/metrics"
-	lisScraperK8sServiceSelector = "app.kubernetes.io/name=instance-store-plugin"
+	lisScraperK8sServiceSelector = "app.kubernetes.io/name=ec2-instance-store-plugin"
 	lisNamespaceDiscoveryName    = "kube-system"
 )
 


### PR DESCRIPTION
## Summary

The EC2 Instance Store CSI driver was renamed from `instance-store-plugin` to `ec2-instance-store-plugin`, but the CWAgent LIS scraper label selector was not updated. This causes Kubernetes service discovery to find zero matching services, so the `containerInsightsNVMeLISScraper` job has no targets and never scrapes LIS metrics.

## Changes

Updated the label selector in `nvme_lis_scraper_config.go`:
```
- lisScraperK8sServiceSelector = "app.kubernetes.io/name=instance-store-plugin"
+ lisScraperK8sServiceSelector = "app.kubernetes.io/name=ec2-instance-store-plugin"
```

## Test Results

### Unit Tests
All 6 tests in the `nvme` package pass:
- `TestNewNVMEScraperEndToEnd` — PASS
- `TestNvmeScraperJobName` — PASS
- `TestGetLisScraperConfig` — PASS
- `TestLisMetricRelabelConfig` — PASS
- `TestNewLisNVMEScraperEndToEnd` — PASS
- `TestLisNvmeScraperJobName` — PASS

### Integration Test
1. Built CWAgent docker image with the fix and deployed to the cluster
2. Verified `containerInsightsNVMeLISScraper` scrape job is active and discovering `ec2-instance-store-plugin-metrics.kube-system.svc:8101`
3. Confirmed 9 LIS metrics flowing to CloudWatch in the `ContainerInsights` namespace:
   - `node_diskio_instance_store_volume_queue_length`
   - `node_diskio_instance_store_total_read_bytes`
   - `node_diskio_instance_store_total_read_ops`
   - `node_diskio_instance_store_total_read_time`
   - `node_diskio_instance_store_total_write_bytes`
   - `node_diskio_instance_store_total_write_ops`
   - `node_diskio_instance_store_total_write_time`
   - `node_diskio_instance_store_ec2_instance_performance_exceeded_iops`
   - `node_diskio_instance_store_ec2_instance_performance_exceeded_tp`
4. EMF logs confirmed in `/aws/containerinsights/cwa-liscsi-test/performance` with `Type: NodeInstanceStore`
