### PR TITLE
Add debug log when EFA counter file is missing

### DIFF
--- a/receiver/awsefareceiver/scraper.go
+++ b/receiver/awsefareceiver/scraper.go
@@ -244,6 +244,8 @@ func (s *efaScraper) recordMetrics(ts pcommon.Timestamp, counters map[string]uin
 	for _, c := range efaCounters {
 		val, ok := counters[c.name]
 		if !ok {
+			s.logger.Debug("Counter not found for device, skipping",
+				zap.String("counter", c.name), zap.String("device", device))
 			continue
 		}
 		if val > math.MaxInt64 {


### PR DESCRIPTION
When a configured metric's sysfs counter file doesn't exist (e.g., retrans_bytes on older EFA drivers without Nitro v4+), log at debug level to aid troubleshooting. Previously this was completely silent.
