### PR TITLE
Update module paths to amazon-contributing for amazon-specific components (attributestocontext and awscloudwatchlogsprovisioner)

### DIFF
--- a/extension/awscloudwatchlogsprovisionerextension/config.go
+++ b/extension/awscloudwatchlogsprovisionerextension/config.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package awscloudwatchlogsprovisionerextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension"
+package awscloudwatchlogsprovisionerextension // import "github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension"
 
 import (
 	"errors"

--- a/extension/awscloudwatchlogsprovisionerextension/cwlogsclient.go
+++ b/extension/awscloudwatchlogsprovisionerextension/cwlogsclient.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package awscloudwatchlogsprovisionerextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension"
+package awscloudwatchlogsprovisionerextension // import "github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension"
 
 import (
 	"context"

--- a/extension/awscloudwatchlogsprovisionerextension/doc.go
+++ b/extension/awscloudwatchlogsprovisionerextension/doc.go
@@ -6,4 +6,4 @@
 // Package awscloudwatchlogsprovisionerextension implements extensionauth.HTTPClient
 // to dynamically set x-aws-log-group headers and create CloudWatch log groups and
 // streams on first encounter.
-package awscloudwatchlogsprovisionerextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension"
+package awscloudwatchlogsprovisionerextension // import "github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension"

--- a/extension/awscloudwatchlogsprovisionerextension/extension.go
+++ b/extension/awscloudwatchlogsprovisionerextension/extension.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package awscloudwatchlogsprovisionerextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension"
+package awscloudwatchlogsprovisionerextension // import "github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension"
 
 import (
 	"context"

--- a/extension/awscloudwatchlogsprovisionerextension/factory.go
+++ b/extension/awscloudwatchlogsprovisionerextension/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package awscloudwatchlogsprovisionerextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension"
+package awscloudwatchlogsprovisionerextension // import "github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension"
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension/internal/metadata"
+	"github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension/internal/metadata"
 )
 
 func NewFactory() extension.Factory {

--- a/extension/awscloudwatchlogsprovisionerextension/go.mod
+++ b/extension/awscloudwatchlogsprovisionerextension/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-telemetry/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension
+module github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension
 
 go 1.24.13
 

--- a/extension/awscloudwatchlogsprovisionerextension/internal/metadata/generated_status.go
+++ b/extension/awscloudwatchlogsprovisionerextension/internal/metadata/generated_status.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	Type      = component.MustNewType("awscloudwatchlogsprovisioner")
-	ScopeName = "github.com/open-telemetry/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension"
+	ScopeName = "github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension"
 )
 
 const (

--- a/processor/attributestocontextprocessor/config.go
+++ b/processor/attributestocontextprocessor/config.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package attributestocontextprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributestocontextprocessor"
+package attributestocontextprocessor // import "github.com/amazon-contributing/opentelemetry-collector-contrib/processor/attributestocontextprocessor"
 
 import (
 	"errors"
@@ -9,7 +9,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributestocontextprocessor/internal/actions"
+	"github.com/amazon-contributing/opentelemetry-collector-contrib/processor/attributestocontextprocessor/internal/actions"
 )
 
 type ActionKeyValue = actions.KeyValue

--- a/processor/attributestocontextprocessor/doc.go
+++ b/processor/attributestocontextprocessor/doc.go
@@ -4,4 +4,4 @@
 //go:generate mdatagen metadata.yaml
 
 // Package attributestocontextprocessor copies resource attributes into client.Metadata.
-package attributestocontextprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributestocontextprocessor"
+package attributestocontextprocessor // import "github.com/amazon-contributing/opentelemetry-collector-contrib/processor/attributestocontextprocessor"

--- a/processor/attributestocontextprocessor/factory.go
+++ b/processor/attributestocontextprocessor/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package attributestocontextprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributestocontextprocessor"
+package attributestocontextprocessor // import "github.com/amazon-contributing/opentelemetry-collector-contrib/processor/attributestocontextprocessor"
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/processor"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributestocontextprocessor/internal/metadata"
+	"github.com/amazon-contributing/opentelemetry-collector-contrib/processor/attributestocontextprocessor/internal/metadata"
 )
 
 func NewFactory() processor.Factory {

--- a/processor/attributestocontextprocessor/factory_test.go
+++ b/processor/attributestocontextprocessor/factory_test.go
@@ -12,7 +12,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/processor/processortest"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributestocontextprocessor/internal/metadata"
+	"github.com/amazon-contributing/opentelemetry-collector-contrib/processor/attributestocontextprocessor/internal/metadata"
 )
 
 func TestFactory_Type(t *testing.T) {

--- a/processor/attributestocontextprocessor/go.mod
+++ b/processor/attributestocontextprocessor/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributestocontextprocessor
+module github.com/amazon-contributing/opentelemetry-collector-contrib/processor/attributestocontextprocessor
 
 go 1.24.13
 

--- a/processor/attributestocontextprocessor/internal/actions/actions.go
+++ b/processor/attributestocontextprocessor/internal/actions/actions.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package actions // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributestocontextprocessor/internal/actions"
+package actions // import "github.com/amazon-contributing/opentelemetry-collector-contrib/processor/attributestocontextprocessor/internal/actions"
 
 import (
 	"strings"

--- a/processor/attributestocontextprocessor/internal/metadata/generated_status.go
+++ b/processor/attributestocontextprocessor/internal/metadata/generated_status.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	Type      = component.MustNewType("attributestocontext")
-	ScopeName = "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributestocontextprocessor"
+	ScopeName = "github.com/amazon-contributing/opentelemetry-collector-contrib/processor/attributestocontextprocessor"
 )
 
 const (

--- a/processor/attributestocontextprocessor/logs.go
+++ b/processor/attributestocontextprocessor/logs.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package attributestocontextprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributestocontextprocessor"
+package attributestocontextprocessor // import "github.com/amazon-contributing/opentelemetry-collector-contrib/processor/attributestocontextprocessor"
 
 import (
 	"context"
@@ -12,7 +12,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/processor"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributestocontextprocessor/internal/actions"
+	"github.com/amazon-contributing/opentelemetry-collector-contrib/processor/attributestocontextprocessor/internal/actions"
 )
 
 type logsProcessor struct {


### PR DESCRIPTION
Following example of:
- https://github.com/amazon-contributing/opentelemetry-collector-contrib/tree/aws-cwa-dev/override/aws
- https://github.com/amazon-contributing/opentelemetry-collector-contrib/tree/aws-cwa-dev/extension/awsmiddleware 

```diff
- import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension
- import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributestocontextprocessor"
+ import "github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awscloudwatchlogsprovisionerextension"
+ import "github.com/amazon-contributing/opentelemetry-collector-contrib/processor/attributestocontextprocessor"
```