### PR TITLE
Add override package for AWS SDK v2 support

### DIFF
--- a/override/awsv2/Makefile
+++ b/override/awsv2/Makefile
@@ -1,0 +1,1 @@
+include ../../Makefile.Common

--- a/override/awsv2/credential.go
+++ b/override/awsv2/credential.go
@@ -45,7 +45,7 @@ func (c *CredentialsChainOverride) AppendCredentialsChain(factory CredentialsPro
 	c.factories = append(c.factories, factory)
 }
 
-// GetCredentialsChain returns a snapshot of the registered factories; callers may iterate without locking.
+// GetCredentialsChain returns a snapshot of the registered factories, so callers may iterate without locking.
 func (c *CredentialsChainOverride) GetCredentialsChain() []CredentialsProviderFactory {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -55,7 +55,7 @@ func (c *CredentialsChainOverride) GetCredentialsChain() []CredentialsProviderFa
 // NewV1ProviderAdapter wraps a v1 SDK credentials.Provider as an aws.CredentialsProvider, or returns
 // nil if the provider is nil.
 //
-// To convey expiration, the provider must implement credentialsv1.Expirer; most v1 providers do via embedded
+// To convey expiration, the provider must implement credentialsv1.Expirer. Most v1 providers do via embedded
 // credentials.Expiry. Without it, the v2 CredentialsCache treats the credentials as never-expiring.
 //
 // v1's Provider.Retrieve takes no context, so the ctx passed to v2 Retrieve does not propagate.

--- a/override/awsv2/credential.go
+++ b/override/awsv2/credential.go
@@ -1,0 +1,95 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package awsv2 // import "github.com/amazon-contributing/opentelemetry-collector-contrib/override/awsv2"
+
+import (
+	"context"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	credentialsv1 "github.com/aws/aws-sdk-go/aws/credentials"
+)
+
+// CredentialsProviderFactory creates an aws.CredentialsProvider for the given shared credentials file path.
+type CredentialsProviderFactory func(file string) aws.CredentialsProvider
+
+// CredentialsChainOverride is a process-global registry of CredentialsProviderFactory functions.
+// External packages register custom factories via AppendCredentialsChain in init().
+type CredentialsChainOverride struct {
+	mu        sync.Mutex
+	factories []CredentialsProviderFactory
+}
+
+var (
+	credentialsChainOverride     *CredentialsChainOverride
+	credentialsChainOverrideOnce sync.Once
+)
+
+// GetCredentialsChainOverride returns the process-global registry.
+func GetCredentialsChainOverride() *CredentialsChainOverride {
+	credentialsChainOverrideOnce.Do(func() {
+		credentialsChainOverride = &CredentialsChainOverride{}
+	})
+	return credentialsChainOverride
+}
+
+// AppendCredentialsChain registers a factory. For a v1 SDK provider, compose with NewV1ProviderAdapter:
+//
+//	override.AppendCredentialsChain(func(file string) aws.CredentialsProvider {
+//	    return awsv2.NewV1ProviderAdapter(myV1Factory(file))
+//	})
+func (c *CredentialsChainOverride) AppendCredentialsChain(factory CredentialsProviderFactory) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.factories = append(c.factories, factory)
+}
+
+// GetCredentialsChain returns a snapshot of the registered factories; callers may iterate without locking.
+func (c *CredentialsChainOverride) GetCredentialsChain() []CredentialsProviderFactory {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]CredentialsProviderFactory(nil), c.factories...)
+}
+
+// NewV1ProviderAdapter wraps a v1 SDK credentials.Provider as an aws.CredentialsProvider, or returns
+// nil if the provider is nil.
+//
+// To convey expiration, the provider must implement credentialsv1.Expirer; most v1 providers do via embedded
+// credentials.Expiry. Without it, the v2 CredentialsCache treats the credentials as never-expiring.
+//
+// v1's Provider.Retrieve takes no context, so the ctx passed to v2 Retrieve does not propagate.
+func NewV1ProviderAdapter(p credentialsv1.Provider) aws.CredentialsProvider {
+	if p == nil {
+		return nil
+	}
+	return &v1ProviderAdapter{provider: p}
+}
+
+// v1ProviderAdapter implements aws.CredentialsProvider for a v1 credentials.Provider.
+type v1ProviderAdapter struct {
+	provider credentialsv1.Provider
+}
+
+var _ aws.CredentialsProvider = (*v1ProviderAdapter)(nil)
+
+func (a *v1ProviderAdapter) Retrieve(_ context.Context) (aws.Credentials, error) {
+	val, err := a.provider.Retrieve()
+	if err != nil {
+		return aws.Credentials{}, err
+	}
+	creds := aws.Credentials{
+		AccessKeyID:     val.AccessKeyID,
+		SecretAccessKey: val.SecretAccessKey,
+		SessionToken:    val.SessionToken,
+		Source:          val.ProviderName,
+	}
+	// Honor v1 expiration via credentialsv1.Expirer (commonly satisfied via embedded credentials.Expiry).
+	if expirer, ok := a.provider.(credentialsv1.Expirer); ok {
+		if exp := expirer.ExpiresAt(); !exp.IsZero() {
+			creds.CanExpire = true
+			creds.Expires = exp
+		}
+	}
+	return creds, nil
+}

--- a/override/awsv2/credential_test.go
+++ b/override/awsv2/credential_test.go
@@ -61,8 +61,8 @@ func TestAppendCredentialsChain_NilFactoryReturnPropagates(t *testing.T) {
 	resetOverride(t)
 
 	o := GetCredentialsChainOverride()
-	// Factory returns nil for paths it doesn't handle. The registry stores the factory as-is;
-	// downstream chain consumers must filter nil. This test pins that behavior.
+	// Factory returns nil for paths it doesn't handle. The registry stores the factory as-is.
+	// Downstream chain consumers must filter nil. This test pins that behavior.
 	o.AppendCredentialsChain(func(filename string) aws.CredentialsProvider {
 		if filename == "match" {
 			return staticV2Provider("got-match")

--- a/override/awsv2/credential_test.go
+++ b/override/awsv2/credential_test.go
@@ -1,0 +1,202 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package awsv2
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	credentialsv1 "github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCredentialsChainOverride_Singleton(t *testing.T) {
+	resetOverride(t)
+
+	first := GetCredentialsChainOverride()
+	second := GetCredentialsChainOverride()
+	assert.Same(t, first, second)
+}
+
+func TestAppendCredentialsChain_OrderPreserved(t *testing.T) {
+	resetOverride(t)
+
+	o := GetCredentialsChainOverride()
+	o.AppendCredentialsChain(staticV2Factory("first"))
+	o.AppendCredentialsChain(staticV2Factory("second"))
+	o.AppendCredentialsChain(staticV2Factory("third"))
+
+	chain := o.GetCredentialsChain()
+	require.Len(t, chain, 3)
+
+	for i, want := range []string{"first", "second", "third"} {
+		creds, err := chain[i]("any").Retrieve(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, want, creds.AccessKeyID)
+	}
+}
+
+func TestGetCredentialsChain_ReturnsCopy(t *testing.T) {
+	resetOverride(t)
+
+	o := GetCredentialsChainOverride()
+	o.AppendCredentialsChain(staticV2Factory("only"))
+
+	chain := o.GetCredentialsChain()
+	chain[0] = staticV2Factory("clobbered") // mutate the returned slice
+
+	internal := o.GetCredentialsChain()
+	creds, err := internal[0]("any").Retrieve(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "only", creds.AccessKeyID, "registry must not be affected by callers mutating the returned slice")
+}
+
+func TestAppendCredentialsChain_NilFactoryReturnPropagates(t *testing.T) {
+	resetOverride(t)
+
+	o := GetCredentialsChainOverride()
+	// Factory returns nil for paths it doesn't handle. The registry stores the factory as-is;
+	// downstream chain consumers must filter nil. This test pins that behavior.
+	o.AppendCredentialsChain(func(filename string) aws.CredentialsProvider {
+		if filename == "match" {
+			return staticV2Provider("got-match")
+		}
+		return nil
+	})
+
+	chain := o.GetCredentialsChain()
+	require.Len(t, chain, 1)
+	assert.Nil(t, chain[0]("nope"))
+	assert.NotNil(t, chain[0]("match"))
+}
+
+func TestAppendCredentialsChain_ConcurrentRegistration(t *testing.T) {
+	resetOverride(t)
+
+	const n = 50
+	o := GetCredentialsChainOverride()
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			o.AppendCredentialsChain(staticV2Factory("concurrent"))
+		}()
+	}
+	wg.Wait()
+
+	assert.Len(t, o.GetCredentialsChain(), n,
+		"all concurrent registrations must persist; a missing entry indicates a lock bug")
+}
+
+func TestNewV1ProviderAdapter_Nil(t *testing.T) {
+	assert.Nil(t, NewV1ProviderAdapter(nil), "nil v1 provider should yield nil v2 provider")
+}
+
+func TestNewV1ProviderAdapter_Static(t *testing.T) {
+	v2Provider := NewV1ProviderAdapter(&staticV1Provider{
+		value: credentialsv1.Value{
+			AccessKeyID:     "v1-static",
+			SecretAccessKey: "secret",
+			SessionToken:    "session-token",
+			ProviderName:    "test",
+		},
+	})
+	require.NotNil(t, v2Provider)
+
+	creds, err := v2Provider.Retrieve(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "v1-static", creds.AccessKeyID)
+	assert.Equal(t, "secret", creds.SecretAccessKey)
+	assert.Equal(t, "session-token", creds.SessionToken)
+	assert.Equal(t, "test", creds.Source)
+	assert.False(t, creds.CanExpire)
+}
+
+func TestNewV1ProviderAdapter_Expiring(t *testing.T) {
+	expiry := time.Now().Add(15 * time.Minute)
+	v2Provider := NewV1ProviderAdapter(&expiringV1Provider{
+		value:  credentialsv1.Value{AccessKeyID: "v1-expiring", SecretAccessKey: "secret"},
+		expiry: expiry,
+	})
+
+	creds, err := v2Provider.Retrieve(t.Context())
+	require.NoError(t, err)
+	assert.True(t, creds.CanExpire)
+	assert.Equal(t, expiry, creds.Expires)
+}
+
+func TestNewV1ProviderAdapter_ZeroExpiresAt(t *testing.T) {
+	v2Provider := NewV1ProviderAdapter(&expiringV1Provider{
+		value: credentialsv1.Value{AccessKeyID: "zero-exp"},
+		// expiry left as zero value
+	})
+
+	creds, err := v2Provider.Retrieve(t.Context())
+	require.NoError(t, err)
+	assert.False(t, creds.CanExpire, "zero ExpiresAt should not enable expiration")
+	assert.True(t, creds.Expires.IsZero())
+}
+
+func TestNewV1ProviderAdapter_RetrieveError(t *testing.T) {
+	v2Provider := NewV1ProviderAdapter(&staticV1Provider{err: errors.New("v1 failure")})
+	_, err := v2Provider.Retrieve(t.Context())
+	assert.ErrorContains(t, err, "v1 failure")
+}
+
+// resetOverride clears the singleton so each test starts fresh. Tests in this package mutate process-global state,
+// so they cannot run in parallel with each other.
+func resetOverride(t *testing.T) {
+	t.Helper()
+	credentialsChainOverride = nil
+	credentialsChainOverrideOnce = sync.Once{}
+}
+
+func staticV2Provider(accessKey string) aws.CredentialsProvider {
+	return aws.CredentialsProviderFunc(func(_ context.Context) (aws.Credentials, error) {
+		return aws.Credentials{AccessKeyID: accessKey, SecretAccessKey: "secret"}, nil
+	})
+}
+
+func staticV2Factory(accessKey string) CredentialsProviderFactory {
+	return func(string) aws.CredentialsProvider { return staticV2Provider(accessKey) }
+}
+
+// staticV1Provider returns a fixed value/error and has no expiration semantics.
+type staticV1Provider struct {
+	value credentialsv1.Value
+	err   error
+}
+
+func (s *staticV1Provider) Retrieve() (credentialsv1.Value, error) {
+	return s.value, s.err
+}
+
+func (s *staticV1Provider) IsExpired() bool {
+	return false
+}
+
+// expiringV1Provider satisfies credentialsv1.Expirer to mirror v1 providers that embed credentials.Expiry.
+type expiringV1Provider struct {
+	value  credentialsv1.Value
+	expiry time.Time
+}
+
+func (e *expiringV1Provider) Retrieve() (credentialsv1.Value, error) {
+	return e.value, nil
+}
+
+func (e *expiringV1Provider) IsExpired() bool {
+	return time.Now().After(e.expiry)
+}
+
+func (e *expiringV1Provider) ExpiresAt() time.Time {
+	return e.expiry
+}

--- a/override/awsv2/go.mod
+++ b/override/awsv2/go.mod
@@ -1,0 +1,16 @@
+module github.com/amazon-contributing/opentelemetry-collector-contrib/override/awsv2
+
+go 1.24.13
+
+require (
+	github.com/aws/aws-sdk-go v1.55.6
+	github.com/aws/aws-sdk-go-v2 v1.36.3
+	github.com/aws/smithy-go v1.22.2
+	github.com/stretchr/testify v1.11.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/override/awsv2/go.sum
+++ b/override/awsv2/go.sum
@@ -1,0 +1,16 @@
+github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
+github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
+github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
+github.com/aws/aws-sdk-go-v2 v1.36.3/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
+github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
+github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/override/awsv2/imds_retryer.go
+++ b/override/awsv2/imds_retryer.go
@@ -15,26 +15,27 @@ import (
 // DefaultIMDSRetries is the recommended default retry count for NewIMDSRetryer.
 const DefaultIMDSRetries = 1
 
-// IMDSRetryer extends retry.Standard to treat smithyhttp.ResponseError as retryable.
-type IMDSRetryer struct {
+// imdsRetryer extends retry.Standard to treat smithyhttp.ResponseError as retryable.
+type imdsRetryer struct {
 	*retry.Standard
 }
 
-var _ aws.RetryerV2 = (*IMDSRetryer)(nil)
+var _ aws.RetryerV2 = (*imdsRetryer)(nil)
 
-// NewIMDSRetryer allows us to retry IMDS errors
-func NewIMDSRetryer(retries int) *IMDSRetryer {
+// NewIMDSRetryer returns an IMDS retryer with MaxAttempts = retries + 1. Negative values are clamped to 0.
+// The retryer treats any smithyhttp.ResponseError as retryable. Otherwise behavior matches retry.Standard.
+func NewIMDSRetryer(retries int) aws.RetryerV2 {
 	if retries < 0 {
 		retries = 0
 	}
-	return &IMDSRetryer{
+	return &imdsRetryer{
 		Standard: retry.NewStandard(func(o *retry.StandardOptions) {
 			o.MaxAttempts = retries + 1 // MaxAttempts include the first attempt
 		}),
 	}
 }
 
-func (r *IMDSRetryer) IsErrorRetryable(err error) bool {
+func (r *imdsRetryer) IsErrorRetryable(err error) bool {
 	// SDKv2 returns a ResponseError on request failure. Any of those errors is considered retryable.
 	// https://github.com/aws/aws-sdk-go-v2/blob/dcbed91b6c6235022f15eda6ea526dbb91e1cb81/feature/ec2/imds/request_middleware.go#L185-L191
 	var responseErr *smithyhttp.ResponseError

--- a/override/awsv2/imds_retryer.go
+++ b/override/awsv2/imds_retryer.go
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+// Portions of this file Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package awsv2 // import "github.com/amazon-contributing/opentelemetry-collector-contrib/override/awsv2"
+
+import (
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+// DefaultIMDSRetries is the recommended default retry count for NewIMDSRetryer.
+const DefaultIMDSRetries = 1
+
+// IMDSRetryer extends retry.Standard to treat smithyhttp.ResponseError as retryable.
+type IMDSRetryer struct {
+	*retry.Standard
+}
+
+var _ aws.RetryerV2 = (*IMDSRetryer)(nil)
+
+// NewIMDSRetryer allows us to retry IMDS errors
+func NewIMDSRetryer(retries int) *IMDSRetryer {
+	if retries < 0 {
+		retries = 0
+	}
+	return &IMDSRetryer{
+		Standard: retry.NewStandard(func(o *retry.StandardOptions) {
+			o.MaxAttempts = retries + 1 // MaxAttempts include the first attempt
+		}),
+	}
+}
+
+func (r *IMDSRetryer) IsErrorRetryable(err error) bool {
+	// SDKv2 returns a ResponseError on request failure. Any of those errors is considered retryable.
+	// https://github.com/aws/aws-sdk-go-v2/blob/dcbed91b6c6235022f15eda6ea526dbb91e1cb81/feature/ec2/imds/request_middleware.go#L185-L191
+	var responseErr *smithyhttp.ResponseError
+	return errors.As(err, &responseErr) || r.Standard.IsErrorRetryable(err)
+}

--- a/override/awsv2/imds_retryer_test.go
+++ b/override/awsv2/imds_retryer_test.go
@@ -18,47 +18,26 @@ func TestIMDSRetryer_IsErrorRetryable(t *testing.T) {
 		err  error
 		want bool
 	}{
-		"ErrorIsNilNotRetryable": {
+		"Nil": {
 			err:  nil,
 			want: false,
 		},
-		"ErrorIsIMDSResponseErrorRetryable": {
-			err: &smithyhttp.ResponseError{
-				Response: &smithyhttp.Response{
-					Response: &http.Response{
-						StatusCode: http.StatusNotFound,
-					},
-				},
-				Err: errors.New("request to EC2 IMDS failed"),
-			},
+		"ResponseError4xx": {
+			err:  smithyResponseError(http.StatusNotFound),
 			want: true,
 		},
-		"ErrorIsIMDSResponseError5xxRetryable": {
-			err: &smithyhttp.ResponseError{
-				Response: &smithyhttp.Response{
-					Response: &http.Response{
-						StatusCode: http.StatusInternalServerError,
-					},
-				},
-				Err: errors.New("request to EC2 IMDS failed"),
-			},
+		"ResponseError5xx": {
+			err:  smithyResponseError(http.StatusInternalServerError),
 			want: true,
 		},
-		"ErrorIsWrappedIMDSResponseErrorRetryable": {
+		"WrappedResponseError": {
 			err: errors.Join(
 				errors.New("outer error"),
-				&smithyhttp.ResponseError{
-					Response: &smithyhttp.Response{
-						Response: &http.Response{
-							StatusCode: http.StatusServiceUnavailable,
-						},
-					},
-					Err: errors.New("request to EC2 IMDS failed"),
-				},
+				smithyResponseError(http.StatusServiceUnavailable),
 			),
 			want: true,
 		},
-		"ErrorIsGenericErrorNotRetryableByDefault": {
+		"GenericError": {
 			err:  errors.New("some other error"),
 			want: false, // Standard retryer doesn't treat generic errors as retryable by default
 		},
@@ -83,7 +62,7 @@ func TestIMDSRetryer_MaxAttempts(t *testing.T) {
 			retries: DefaultIMDSRetries,
 			want:    DefaultIMDSRetries + 1,
 		},
-		"TwoRetries": {
+		"PositiveRetries": {
 			retries: 2,
 			want:    3,
 		},
@@ -102,5 +81,15 @@ func TestIMDSRetryer_MaxAttempts(t *testing.T) {
 			retryer := NewIMDSRetryer(testCase.retries)
 			assert.Equal(t, testCase.want, retryer.MaxAttempts())
 		})
+	}
+}
+
+// smithyResponseError builds a *smithyhttp.ResponseError carrying the given HTTP status code.
+func smithyResponseError(statusCode int) *smithyhttp.ResponseError {
+	return &smithyhttp.ResponseError{
+		Response: &smithyhttp.Response{
+			Response: &http.Response{StatusCode: statusCode},
+		},
+		Err: errors.New("request to EC2 IMDS failed"),
 	}
 }

--- a/override/awsv2/imds_retryer_test.go
+++ b/override/awsv2/imds_retryer_test.go
@@ -1,0 +1,106 @@
+// Copyright The OpenTelemetry Authors
+// Portions of this file Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package awsv2
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIMDSRetryer_IsErrorRetryable(t *testing.T) {
+	testCases := map[string]struct {
+		err  error
+		want bool
+	}{
+		"ErrorIsNilNotRetryable": {
+			err:  nil,
+			want: false,
+		},
+		"ErrorIsIMDSResponseErrorRetryable": {
+			err: &smithyhttp.ResponseError{
+				Response: &smithyhttp.Response{
+					Response: &http.Response{
+						StatusCode: http.StatusNotFound,
+					},
+				},
+				Err: errors.New("request to EC2 IMDS failed"),
+			},
+			want: true,
+		},
+		"ErrorIsIMDSResponseError5xxRetryable": {
+			err: &smithyhttp.ResponseError{
+				Response: &smithyhttp.Response{
+					Response: &http.Response{
+						StatusCode: http.StatusInternalServerError,
+					},
+				},
+				Err: errors.New("request to EC2 IMDS failed"),
+			},
+			want: true,
+		},
+		"ErrorIsWrappedIMDSResponseErrorRetryable": {
+			err: errors.Join(
+				errors.New("outer error"),
+				&smithyhttp.ResponseError{
+					Response: &smithyhttp.Response{
+						Response: &http.Response{
+							StatusCode: http.StatusServiceUnavailable,
+						},
+					},
+					Err: errors.New("request to EC2 IMDS failed"),
+				},
+			),
+			want: true,
+		},
+		"ErrorIsGenericErrorNotRetryableByDefault": {
+			err:  errors.New("some other error"),
+			want: false, // Standard retryer doesn't treat generic errors as retryable by default
+		},
+	}
+
+	retryer := NewIMDSRetryer(DefaultIMDSRetries)
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := retryer.IsErrorRetryable(testCase.err)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}
+
+func TestIMDSRetryer_MaxAttempts(t *testing.T) {
+	testCases := map[string]struct {
+		retries int
+		want    int
+	}{
+		"DefaultRetries": {
+			retries: DefaultIMDSRetries,
+			want:    DefaultIMDSRetries + 1,
+		},
+		"TwoRetries": {
+			retries: 2,
+			want:    3,
+		},
+		"ZeroRetries": {
+			retries: 0,
+			want:    1,
+		},
+		"NegativeRetries": {
+			retries: -2,
+			want:    1,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			retryer := NewIMDSRetryer(testCase.retries)
+			assert.Equal(t, testCase.want, retryer.MaxAttempts())
+		})
+	}
+}

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,6 +7,7 @@ module-sets:
     modules:
       - github.com/amazon-contributing/opentelemetry-collector-contrib/extension/awsmiddleware
       - github.com/amazon-contributing/opentelemetry-collector-contrib/override/aws
+      - github.com/amazon-contributing/opentelemetry-collector-contrib/override/awsv2
       - github.com/open-telemetry/opentelemetry-collector-contrib
       - github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor
       - github.com/open-telemetry/opentelemetry-collector-contrib/cmd/otlphistgen


### PR DESCRIPTION
#### Description
Adds an AWS SDK v2 version of the `override/aws` package. This allows callers a shared location for the IMDS retryer (based on https://github.com/aws/amazon-cloudwatch-agent/blob/feature/aws-sdk-v2/internal/retryer/imdsretryer.go) and a registry for credential chain overrides.

Also includes an AWS SDK Go v1 to v2 credential adapter.

#### Testing
Added unit tests.
