### PR TITLE
[extension/sigv4auth] Use shared credential chain

### DIFF
--- a/extension/sigv4authextension/README.md
+++ b/extension/sigv4authextension/README.md
@@ -28,6 +28,9 @@ The configuration fields are as follows:
     * [List of AWS regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html)
 * `service`: **Optional**. The AWS service for AWS Sigv4
     * Note for supported services an attempt will be made to obtain a valid service from the endpoint of the service you are exporting to. Supported services include - workspaces, es, logs and traces.
+* `profile`: **Optional**. AWS profile to use from the shared credentials file.
+* `shared_credentials_file`: **Optional**. Path to a shared credentials file.
+* `local_mode`: **Optional**. Disable EC2 IMDS region detection. Use when running outside EC2.
 
 
 ## Assume Role

--- a/extension/sigv4authextension/README.md
+++ b/extension/sigv4authextension/README.md
@@ -29,7 +29,7 @@ The configuration fields are as follows:
 * `service`: **Optional**. The AWS service for AWS Sigv4
     * Note for supported services an attempt will be made to obtain a valid service from the endpoint of the service you are exporting to. Supported services include - workspaces, es, logs and traces.
 * `profile`: **Optional**. AWS profile to use from the shared credentials file.
-* `shared_credentials_file`: **Optional**. Path to a shared credentials file.
+* `shared_credentials_file`: **Optional**. List of paths to shared credentials files.
 * `local_mode`: **Optional**. Disable EC2 IMDS region detection. Use when running outside EC2.
 
 

--- a/extension/sigv4authextension/config.go
+++ b/extension/sigv4authextension/config.go
@@ -6,7 +6,6 @@ package sigv4authextension // import "github.com/open-telemetry/opentelemetry-co
 import (
 	"errors"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"go.opentelemetry.io/collector/component"
 )
 
@@ -15,10 +14,9 @@ type Config struct {
 	Region                string     `mapstructure:"region,omitempty"`
 	Service               string     `mapstructure:"service,omitempty"`
 	Profile               string     `mapstructure:"profile,omitempty"`
-	SharedCredentialsFile string     `mapstructure:"shared_credentials_file,omitempty"`
+	SharedCredentialsFile []string   `mapstructure:"shared_credentials_file,omitempty"`
 	LocalMode             bool       `mapstructure:"local_mode,omitempty"`
 	AssumeRole            AssumeRole `mapstructure:"assume_role"`
-	credsProvider         *aws.CredentialsProvider
 }
 
 // AssumeRole holds the configuration needed to assume a role
@@ -40,10 +38,10 @@ func (cfg *Config) Validate() error {
 	return nil
 }
 
-// setDefaults applies default values to the configuration. Called at extension creation,
-// before any consumer reads the config.
-func (cfg *Config) setDefaults() {
-	if cfg.AssumeRole.STSRegion == "" && cfg.Region != "" {
-		cfg.AssumeRole.STSRegion = cfg.Region
+// resolvedSTSRegion returns AssumeRole.STSRegion if set, otherwise falls back to Region.
+func (cfg *Config) resolvedSTSRegion() string {
+	if cfg.AssumeRole.STSRegion != "" {
+		return cfg.AssumeRole.STSRegion
 	}
+	return cfg.Region
 }

--- a/extension/sigv4authextension/config.go
+++ b/extension/sigv4authextension/config.go
@@ -5,7 +5,6 @@ package sigv4authextension // import "github.com/open-telemetry/opentelemetry-co
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"go.opentelemetry.io/collector/component"
@@ -13,10 +12,13 @@ import (
 
 // Config stores the configuration for the Sigv4 Authenticator
 type Config struct {
-	Region        string     `mapstructure:"region,omitempty"`
-	Service       string     `mapstructure:"service,omitempty"`
-	AssumeRole    AssumeRole `mapstructure:"assume_role"`
-	credsProvider *aws.CredentialsProvider
+	Region                string     `mapstructure:"region,omitempty"`
+	Service               string     `mapstructure:"service,omitempty"`
+	Profile               string     `mapstructure:"profile,omitempty"`
+	SharedCredentialsFile string     `mapstructure:"shared_credentials_file,omitempty"`
+	LocalMode             bool       `mapstructure:"local_mode,omitempty"`
+	AssumeRole            AssumeRole `mapstructure:"assume_role"`
+	credsProvider         *aws.CredentialsProvider
 }
 
 // AssumeRole holds the configuration needed to assume a role
@@ -30,31 +32,18 @@ type AssumeRole struct {
 // compile time check that the Config struct satisfies the component.Config interface
 var _ component.Config = (*Config)(nil)
 
-// Validate checks that the configuration is valid.
-// We aim to catch most errors here to ensure that we
-// fail early and to avoid revalidating static data.
+// Validate checks that the configuration is well-formed.
 func (cfg *Config) Validate() error {
+	if cfg.AssumeRole.WebIdentityTokenFile != "" && cfg.AssumeRole.ARN == "" {
+		return errors.New("must specify ARN when using WebIdentityTokenFile")
+	}
+	return nil
+}
+
+// setDefaults applies default values to the configuration. Called at extension creation,
+// before any consumer reads the config.
+func (cfg *Config) setDefaults() {
 	if cfg.AssumeRole.STSRegion == "" && cfg.Region != "" {
 		cfg.AssumeRole.STSRegion = cfg.Region
 	}
-
-	var credsProvider *aws.CredentialsProvider
-	var err error
-	if cfg.AssumeRole.WebIdentityTokenFile != "" {
-		if cfg.AssumeRole.ARN == "" {
-			return errors.New("must specify ARN when using WebIdentityTokenFile")
-		}
-		credsProvider, err = getCredsProviderFromWebIdentityConfig(cfg)
-	} else {
-		credsProvider, err = getCredsProviderFromConfig(cfg)
-	}
-	if err != nil {
-		return fmt.Errorf("could not retrieve credential provider: %w", err)
-	}
-	if credsProvider == nil {
-		return errors.New("credsProvider cannot be nil")
-	}
-	cfg.credsProvider = credsProvider
-
-	return nil
 }

--- a/extension/sigv4authextension/config_test.go
+++ b/extension/sigv4authextension/config_test.go
@@ -37,7 +37,6 @@ func TestLoadConfig(t *testing.T) {
 		Service: "service",
 		AssumeRole: AssumeRole{
 			SessionName: "role_session_name",
-			STSRegion:   "region",
 		},
 		// Ensure creds are the same for load config test; tested in extension_test.go
 		credsProvider: cfg.(*Config).credsProvider,
@@ -60,7 +59,6 @@ func TestLoadWebIdentityConfig(t *testing.T) {
 		AssumeRole: AssumeRole{
 			ARN:                  "arn:aws:iam::12345678910:role/my_role",
 			WebIdentityTokenFile: "testdata/token_file",
-			STSRegion:            "region",
 		},
 		credsProvider: cfg.(*Config).credsProvider,
 	}, cfg)
@@ -71,8 +69,11 @@ func TestLoadConfigError(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "missing_credentials").String())
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "web_identity_no_arn").String())
 	require.NoError(t, err)
 	require.NoError(t, sub.Unmarshal(cfg))
-	assert.Error(t, xconfmap.Validate(cfg))
+
+	err = xconfmap.Validate(cfg)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "must specify ARN")
 }

--- a/extension/sigv4authextension/config_test.go
+++ b/extension/sigv4authextension/config_test.go
@@ -38,8 +38,6 @@ func TestLoadConfig(t *testing.T) {
 		AssumeRole: AssumeRole{
 			SessionName: "role_session_name",
 		},
-		// Ensure creds are the same for load config test; tested in extension_test.go
-		credsProvider: cfg.(*Config).credsProvider,
 	}, cfg)
 }
 
@@ -60,7 +58,6 @@ func TestLoadWebIdentityConfig(t *testing.T) {
 			ARN:                  "arn:aws:iam::12345678910:role/my_role",
 			WebIdentityTokenFile: "testdata/token_file",
 		},
-		credsProvider: cfg.(*Config).credsProvider,
 	}, cfg)
 }
 

--- a/extension/sigv4authextension/extension.go
+++ b/extension/sigv4authextension/extension.go
@@ -17,6 +17,8 @@ import (
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/extension/extensionauth"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutilv2"
 )
 
 // sigv4Auth is a struct that implements the extensionauth.HTTPClient interface.
@@ -55,8 +57,8 @@ func (sa *sigv4Auth) RoundTripper(base http.RoundTripper) (http.RoundTripper, er
 	return &rt, nil
 }
 
-// newSigv4Extension() is called by createExtension() in factory.go and
-// returns a new sigv4Auth struct.
+// newSigv4Extension returns a new sigv4Auth from a Config whose credsProvider has already been resolved
+// (see resolveCredentialsProvider).
 func newSigv4Extension(cfg *Config, awsSDKInfo string, logger *zap.Logger) *sigv4Auth {
 	return &sigv4Auth{
 		cfg:        cfg,
@@ -65,31 +67,49 @@ func newSigv4Extension(cfg *Config, awsSDKInfo string, logger *zap.Logger) *sigv
 	}
 }
 
-// getCredsProviderFromConfig() is a helper function that gets AWS credentials
-// from the Config.
-func getCredsProviderFromConfig(cfg *Config) (*aws.CredentialsProvider, error) {
-	awscfg, err := awsconfig.LoadDefaultConfig(context.Background(),
-		awsconfig.WithRegion(cfg.AssumeRole.STSRegion),
+// resolveCredentialsProvider dispatches to the appropriate credential source (web-identity or the
+// shared-credentials chain) and stores the resulting provider on cfg.credsProvider. Errors are wrapped
+// consistently for both paths.
+func resolveCredentialsProvider(ctx context.Context, logger *zap.Logger, cfg *Config) error {
+	var (
+		creds *aws.CredentialsProvider
+		err   error
 	)
+	if cfg.AssumeRole.WebIdentityTokenFile != "" {
+		creds, err = getCredsProviderFromWebIdentityConfig(ctx, logger, cfg)
+	} else {
+		creds, err = getCredsProviderFromConfig(ctx, logger, cfg)
+	}
+	if err != nil {
+		return fmt.Errorf("could not retrieve credential provider: %w", err)
+	}
+	cfg.credsProvider = creds
+	return nil
+}
+
+// getCredsProviderFromConfig builds an aws.CredentialsProvider from cfg: shared profile/file when
+// configured, otherwise the SDK default chain, optionally wrapped with regional/partitional assume-role.
+func getCredsProviderFromConfig(ctx context.Context, logger *zap.Logger, cfg *Config) (*aws.CredentialsProvider, error) {
+	settings := awsutilv2.AWSSessionSettings{
+		Region:    cfg.AssumeRole.STSRegion,
+		RoleARN:   cfg.AssumeRole.ARN,
+		Profile:   cfg.Profile,
+		LocalMode: cfg.LocalMode,
+	}
+	if cfg.SharedCredentialsFile != "" {
+		settings.SharedCredentialsFile = []string{cfg.SharedCredentialsFile}
+	}
+	awscfg, err := awsutilv2.GetAWSConfig(ctx, logger, &settings)
 	if err != nil {
 		return nil, err
 	}
-	if cfg.AssumeRole.ARN != "" {
-		stsSvc := sts.NewFromConfig(awscfg)
-
-		provider := stscreds.NewAssumeRoleProvider(stsSvc, cfg.AssumeRole.ARN)
-		awscfg.Credentials = aws.NewCredentialsCache(provider)
-	}
-
-	_, err = awscfg.Credentials.Retrieve(context.Background())
-	if err != nil {
+	if _, err = awscfg.Credentials.Retrieve(ctx); err != nil {
 		return nil, err
 	}
-
 	return &awscfg.Credentials, nil
 }
 
-func getCredsProviderFromWebIdentityConfig(cfg *Config) (*aws.CredentialsProvider, error) {
+func getCredsProviderFromWebIdentityConfig(ctx context.Context, logger *zap.Logger, cfg *Config) (*aws.CredentialsProvider, error) {
 	tokenRetriever := stscreds.IdentityTokenRetriever(
 		stscreds.IdentityTokenFile(cfg.AssumeRole.WebIdentityTokenFile),
 	)
@@ -98,7 +118,7 @@ func getCredsProviderFromWebIdentityConfig(cfg *Config) (*aws.CredentialsProvide
 		return nil, fmt.Errorf("unable to retrieve token file: %w", err)
 	}
 
-	awscfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+	awscfg, err := awsconfig.LoadDefaultConfig(ctx,
 		awsconfig.WithWebIdentityRoleCredentialOptions(
 			func(options *stscreds.WebIdentityRoleOptions) {
 				options.TokenRetriever = tokenRetriever
@@ -114,6 +134,9 @@ func getCredsProviderFromWebIdentityConfig(cfg *Config) (*aws.CredentialsProvide
 
 	provider := stscreds.NewWebIdentityRoleProvider(stsSvc, cfg.AssumeRole.ARN, tokenRetriever)
 	awscfg.Credentials = aws.NewCredentialsCache(provider)
+	logger.Debug("Web identity credentials provider configured",
+		zap.String("role-arn", cfg.AssumeRole.ARN),
+		zap.String("region", cfg.AssumeRole.STSRegion))
 
 	return &awscfg.Credentials, nil
 }

--- a/extension/sigv4authextension/extension.go
+++ b/extension/sigv4authextension/extension.go
@@ -26,6 +26,7 @@ import (
 type sigv4Auth struct {
 	cfg                    *Config
 	logger                 *zap.Logger
+	credsProvider          *aws.CredentialsProvider
 	awsSDKInfo             string
 	component.StartFunc    // embedded default behavior to do nothing with Start()
 	component.ShutdownFunc // embedded default behavior to do nothing with Shutdown()
@@ -49,7 +50,7 @@ func (sa *sigv4Auth) RoundTripper(base http.RoundTripper) (http.RoundTripper, er
 		signer:        signer,
 		region:        cfg.Region,
 		service:       cfg.Service,
-		credsProvider: cfg.credsProvider,
+		credsProvider: sa.credsProvider,
 		awsSDKInfo:    sa.awsSDKInfo,
 		logger:        sa.logger,
 	}
@@ -57,20 +58,19 @@ func (sa *sigv4Auth) RoundTripper(base http.RoundTripper) (http.RoundTripper, er
 	return &rt, nil
 }
 
-// newSigv4Extension returns a new sigv4Auth from a Config whose credsProvider has already been resolved
-// (see resolveCredentialsProvider).
-func newSigv4Extension(cfg *Config, awsSDKInfo string, logger *zap.Logger) *sigv4Auth {
+// newSigv4Extension returns a new sigv4Auth backed by the given credentials provider.
+func newSigv4Extension(cfg *Config, credsProvider *aws.CredentialsProvider, awsSDKInfo string, logger *zap.Logger) *sigv4Auth {
 	return &sigv4Auth{
-		cfg:        cfg,
-		logger:     logger,
-		awsSDKInfo: awsSDKInfo,
+		cfg:           cfg,
+		credsProvider: credsProvider,
+		logger:        logger,
+		awsSDKInfo:    awsSDKInfo,
 	}
 }
 
-// resolveCredentialsProvider dispatches to the appropriate credential source (web-identity or the
-// shared-credentials chain) and stores the resulting provider on cfg.credsProvider. Errors are wrapped
-// consistently for both paths.
-func resolveCredentialsProvider(ctx context.Context, logger *zap.Logger, cfg *Config) error {
+// resolveCredentialsProvider dispatches to the appropriate credential source (web-identity or
+// the shared-credentials chain) and returns the resolved provider.
+func resolveCredentialsProvider(ctx context.Context, logger *zap.Logger, cfg *Config) (*aws.CredentialsProvider, error) {
 	var (
 		creds *aws.CredentialsProvider
 		err   error
@@ -81,23 +81,20 @@ func resolveCredentialsProvider(ctx context.Context, logger *zap.Logger, cfg *Co
 		creds, err = getCredsProviderFromConfig(ctx, logger, cfg)
 	}
 	if err != nil {
-		return fmt.Errorf("could not retrieve credential provider: %w", err)
+		return nil, fmt.Errorf("could not retrieve credential provider: %w", err)
 	}
-	cfg.credsProvider = creds
-	return nil
+	return creds, nil
 }
 
 // getCredsProviderFromConfig builds an aws.CredentialsProvider from cfg: shared profile/file when
 // configured, otherwise the SDK default chain, optionally wrapped with regional/partitional assume-role.
 func getCredsProviderFromConfig(ctx context.Context, logger *zap.Logger, cfg *Config) (*aws.CredentialsProvider, error) {
 	settings := awsutilv2.AWSSessionSettings{
-		Region:    cfg.AssumeRole.STSRegion,
-		RoleARN:   cfg.AssumeRole.ARN,
-		Profile:   cfg.Profile,
-		LocalMode: cfg.LocalMode,
-	}
-	if cfg.SharedCredentialsFile != "" {
-		settings.SharedCredentialsFile = []string{cfg.SharedCredentialsFile}
+		Region:                cfg.resolvedSTSRegion(),
+		RoleARN:               cfg.AssumeRole.ARN,
+		Profile:               cfg.Profile,
+		LocalMode:             cfg.LocalMode,
+		SharedCredentialsFile: cfg.SharedCredentialsFile,
 	}
 	awscfg, err := awsutilv2.GetAWSConfig(ctx, logger, &settings)
 	if err != nil {
@@ -118,6 +115,7 @@ func getCredsProviderFromWebIdentityConfig(ctx context.Context, logger *zap.Logg
 		return nil, fmt.Errorf("unable to retrieve token file: %w", err)
 	}
 
+	stsRegion := cfg.resolvedSTSRegion()
 	awscfg, err := awsconfig.LoadDefaultConfig(ctx,
 		awsconfig.WithWebIdentityRoleCredentialOptions(
 			func(options *stscreds.WebIdentityRoleOptions) {
@@ -125,7 +123,7 @@ func getCredsProviderFromWebIdentityConfig(ctx context.Context, logger *zap.Logg
 				options.RoleARN = cfg.AssumeRole.ARN
 			},
 		),
-		awsconfig.WithRegion(cfg.AssumeRole.STSRegion),
+		awsconfig.WithRegion(stsRegion),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load AWS configuration: %w", err)
@@ -136,7 +134,7 @@ func getCredsProviderFromWebIdentityConfig(ctx context.Context, logger *zap.Logg
 	awscfg.Credentials = aws.NewCredentialsCache(provider)
 	logger.Debug("Web identity credentials provider configured",
 		zap.String("role-arn", cfg.AssumeRole.ARN),
-		zap.String("region", cfg.AssumeRole.STSRegion))
+		zap.String("region", stsRegion))
 
 	return &awscfg.Credentials, nil
 }

--- a/extension/sigv4authextension/extension_test.go
+++ b/extension/sigv4authextension/extension_test.go
@@ -6,6 +6,7 @@ package sigv4authextension
 import (
 	"context"
 	"net/http"
+	"path/filepath"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -19,7 +20,7 @@ import (
 func TestNewSigv4Extension(t *testing.T) {
 	cfg := &Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}}
 
-	sa := newSigv4Extension(cfg, "awsSDKInfo", zap.NewNop())
+	sa := newSigv4Extension(cfg, nil, "awsSDKInfo", zap.NewNop())
 	assert.Equal(t, cfg.Region, sa.cfg.Region)
 	assert.Equal(t, cfg.Service, sa.cfg.Service)
 	assert.Equal(t, cfg.AssumeRole.ARN, sa.cfg.AssumeRole.ARN)
@@ -30,9 +31,9 @@ func TestRoundTripper(t *testing.T) {
 
 	base := (http.RoundTripper)(http.DefaultTransport.(*http.Transport).Clone())
 	awsSDKInfo := "awsSDKInfo"
-	cfg := &Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}, credsProvider: awsCredsProvider}
+	cfg := &Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}}
 
-	sa := newSigv4Extension(cfg, awsSDKInfo, zap.NewNop())
+	sa := newSigv4Extension(cfg, awsCredsProvider, awsSDKInfo, zap.NewNop())
 	assert.NotNil(t, sa)
 
 	rt, err := sa.RoundTripper(base)
@@ -43,7 +44,7 @@ func TestRoundTripper(t *testing.T) {
 	assert.Equal(t, cfg.Region, si.region)
 	assert.Equal(t, cfg.Service, si.service)
 	assert.Equal(t, awsSDKInfo, si.awsSDKInfo)
-	assert.Equal(t, cfg.credsProvider, si.credsProvider)
+	assert.Equal(t, awsCredsProvider, si.credsProvider)
 }
 
 func TestGetCredsProviderFromConfig(t *testing.T) {
@@ -72,8 +73,6 @@ func TestGetCredsProviderFromConfig(t *testing.T) {
 	// run tests
 	for _, testcase := range tests {
 		t.Run(testcase.name, func(t *testing.T) {
-			// Isolate the credential chain so tests are deterministic regardless of
-			// the host's ~/.aws config, environment variables, or IMDS access.
 			isolateAWSEnv(t)
 			t.Setenv("AWS_ACCESS_KEY_ID", testcase.AccessKeyID)
 			t.Setenv("AWS_SECRET_ACCESS_KEY", testcase.SecretAccessKey)
@@ -93,6 +92,54 @@ func TestGetCredsProviderFromConfig(t *testing.T) {
 			require.NotNil(t, creds)
 		})
 	}
+}
+
+func TestGetCredsProviderFromConfig_SharedCredentialsFile(t *testing.T) {
+	isolateAWSEnv(t)
+	cfg := &Config{
+		Region:                "region",
+		Service:               "service",
+		SharedCredentialsFile: []string{filepath.Join("testdata", "credentials")},
+		AssumeRole:            AssumeRole{STSRegion: "region"},
+	}
+
+	credsProvider, err := getCredsProviderFromConfig(t.Context(), zap.NewNop(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, credsProvider)
+
+	creds, err := (*credsProvider).Retrieve(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", creds.AccessKeyID)
+}
+
+func TestGetCredsProviderFromConfig_Profile(t *testing.T) {
+	isolateAWSEnv(t)
+	cfg := &Config{
+		Region:                "region",
+		Service:               "service",
+		Profile:               "default",
+		SharedCredentialsFile: []string{filepath.Join("testdata", "credentials")},
+		AssumeRole:            AssumeRole{STSRegion: "region"},
+	}
+
+	credsProvider, err := getCredsProviderFromConfig(t.Context(), zap.NewNop(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, credsProvider)
+}
+
+func TestGetCredsProviderFromConfig_LocalMode(t *testing.T) {
+	isolateAWSEnv(t)
+	cfg := &Config{
+		Region:                "region",
+		Service:               "service",
+		LocalMode:             true,
+		SharedCredentialsFile: []string{filepath.Join("testdata", "credentials")},
+		AssumeRole:            AssumeRole{STSRegion: "region"},
+	}
+
+	credsProvider, err := getCredsProviderFromConfig(t.Context(), zap.NewNop(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, credsProvider)
 }
 
 func TestGetCredsProviderFromWebIdentityConfig(t *testing.T) {
@@ -115,6 +162,7 @@ func TestGetCredsProviderFromWebIdentityConfig(t *testing.T) {
 	// run tests
 	for _, testcase := range tests {
 		t.Run(testcase.name, func(t *testing.T) {
+			isolateAWSEnv(t)
 			credsProvider, err := getCredsProviderFromWebIdentityConfig(t.Context(), zap.NewNop(), testcase.cfg)
 
 			if testcase.shouldError {

--- a/extension/sigv4authextension/extension_test.go
+++ b/extension/sigv4authextension/extension_test.go
@@ -109,7 +109,7 @@ func TestGetCredsProviderFromConfig_SharedCredentialsFile(t *testing.T) {
 
 	creds, err := (*credsProvider).Retrieve(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", creds.AccessKeyID)
+	assert.Equal(t, "FAKEAWSACCESSKEYID00", creds.AccessKeyID)
 }
 
 func TestGetCredsProviderFromConfig_Profile(t *testing.T) {
@@ -117,7 +117,7 @@ func TestGetCredsProviderFromConfig_Profile(t *testing.T) {
 	cfg := &Config{
 		Region:                "region",
 		Service:               "service",
-		Profile:               "default",
+		Profile:               "testprofile",
 		SharedCredentialsFile: []string{filepath.Join("testdata", "credentials")},
 		AssumeRole:            AssumeRole{STSRegion: "region"},
 	}
@@ -125,6 +125,10 @@ func TestGetCredsProviderFromConfig_Profile(t *testing.T) {
 	credsProvider, err := getCredsProviderFromConfig(t.Context(), zap.NewNop(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, credsProvider)
+
+	creds, err := (*credsProvider).Retrieve(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "FAKEAWSACCESSKEYID01", creds.AccessKeyID)
 }
 
 func TestGetCredsProviderFromConfig_LocalMode(t *testing.T) {

--- a/extension/sigv4authextension/extension_test.go
+++ b/extension/sigv4authextension/extension_test.go
@@ -72,9 +72,12 @@ func TestGetCredsProviderFromConfig(t *testing.T) {
 	// run tests
 	for _, testcase := range tests {
 		t.Run(testcase.name, func(t *testing.T) {
+			// Isolate the credential chain so tests are deterministic regardless of
+			// the host's ~/.aws config, environment variables, or IMDS access.
+			isolateAWSEnv(t)
 			t.Setenv("AWS_ACCESS_KEY_ID", testcase.AccessKeyID)
 			t.Setenv("AWS_SECRET_ACCESS_KEY", testcase.SecretAccessKey)
-			credsProvider, err := getCredsProviderFromConfig(testcase.cfg)
+			credsProvider, err := getCredsProviderFromConfig(t.Context(), zap.NewNop(), testcase.cfg)
 
 			if testcase.shouldError {
 				assert.Error(t, err)
@@ -112,7 +115,7 @@ func TestGetCredsProviderFromWebIdentityConfig(t *testing.T) {
 	// run tests
 	for _, testcase := range tests {
 		t.Run(testcase.name, func(t *testing.T) {
-			credsProvider, err := getCredsProviderFromWebIdentityConfig(testcase.cfg)
+			credsProvider, err := getCredsProviderFromWebIdentityConfig(t.Context(), zap.NewNop(), testcase.cfg)
 
 			if testcase.shouldError {
 				assert.Error(t, err)
@@ -172,4 +175,20 @@ func mockCredentials() *aws.CredentialsProvider {
 	awscfg.Credentials = aws.NewCredentialsCache(provider)
 
 	return &awscfg.Credentials
+}
+
+// isolateAWSEnv prevents the v2 SDK from reading the host's shared credentials
+// or config files by overriding HOME, AWS_SHARED_CREDENTIALS_FILE,
+// AWS_CONFIG_FILE, AWS_PROFILE, AWS_EC2_METADATA_DISABLED, and the static
+// credential env vars. Tests that need specific values for credential env vars
+// should call t.Setenv after this helper.
+func isolateAWSEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/nonexistent")
+	t.Setenv("AWS_CONFIG_FILE", "/nonexistent")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
 }

--- a/extension/sigv4authextension/factory.go
+++ b/extension/sigv4authextension/factory.go
@@ -5,7 +5,6 @@ package sigv4authextension // import "github.com/open-telemetry/opentelemetry-co
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -29,9 +28,6 @@ func createExtension(ctx context.Context, set extension.Settings, cfg component.
 	credsProvider, err := resolveCredentialsProvider(ctx, set.Logger, c)
 	if err != nil {
 		return nil, err
-	}
-	if credsProvider == nil {
-		return nil, errors.New("credential provider cannot be nil")
 	}
 	awsSDKInfo := fmt.Sprintf("%s/%s", aws.SDKName, aws.SDKVersion)
 	return newSigv4Extension(c, credsProvider, awsSDKInfo, set.Logger), nil

--- a/extension/sigv4authextension/factory.go
+++ b/extension/sigv4authextension/factory.go
@@ -19,14 +19,16 @@ func NewFactory() extension.Factory {
 	return extension.NewFactory(metadata.Type, createDefaultConfig, createExtension, metadata.ExtensionStability)
 }
 
-// createDefaultConfig() creates a Config struct with default values.
-// We only set the ID here.
 func createDefaultConfig() component.Config {
 	return &Config{}
 }
 
-// createExtension() calls newSigv4Extension() in extension.go to create the extension.
-func createExtension(_ context.Context, set extension.Settings, cfg component.Config) (extension.Extension, error) {
+func createExtension(ctx context.Context, set extension.Settings, cfg component.Config) (extension.Extension, error) {
+	c := cfg.(*Config)
+	c.setDefaults()
+	if err := resolveCredentialsProvider(ctx, set.Logger, c); err != nil {
+		return nil, err
+	}
 	awsSDKInfo := fmt.Sprintf("%s/%s", aws.SDKName, aws.SDKVersion)
-	return newSigv4Extension(cfg.(*Config), awsSDKInfo, set.Logger), nil
+	return newSigv4Extension(c, awsSDKInfo, set.Logger), nil
 }

--- a/extension/sigv4authextension/factory.go
+++ b/extension/sigv4authextension/factory.go
@@ -5,6 +5,7 @@ package sigv4authextension // import "github.com/open-telemetry/opentelemetry-co
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -25,10 +26,13 @@ func createDefaultConfig() component.Config {
 
 func createExtension(ctx context.Context, set extension.Settings, cfg component.Config) (extension.Extension, error) {
 	c := cfg.(*Config)
-	c.setDefaults()
-	if err := resolveCredentialsProvider(ctx, set.Logger, c); err != nil {
+	credsProvider, err := resolveCredentialsProvider(ctx, set.Logger, c)
+	if err != nil {
 		return nil, err
 	}
+	if credsProvider == nil {
+		return nil, errors.New("credential provider cannot be nil")
+	}
 	awsSDKInfo := fmt.Sprintf("%s/%s", aws.SDKName, aws.SDKVersion)
-	return newSigv4Extension(c, awsSDKInfo, set.Logger), nil
+	return newSigv4Extension(c, credsProvider, awsSDKInfo, set.Logger), nil
 }

--- a/extension/sigv4authextension/factory_test.go
+++ b/extension/sigv4authextension/factory_test.go
@@ -4,23 +4,33 @@
 package sigv4authextension
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/extension/extensiontest"
 )
 
 func TestNewFactory(t *testing.T) {
+	isolateAWSEnv(t)
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join("testdata", "credentials"))
+
 	f := NewFactory()
 	assert.NotNil(t, f)
 
 	cfg := createDefaultConfig().(*Config)
 	assert.Equal(t, f.CreateDefaultConfig().(*Config), cfg)
+	cfg.Region = "us-east-1"
 
-	ext, _ := createExtension(t.Context(), extensiontest.NewNopSettings(f.Type()), cfg)
-	fext, _ := f.Create(t.Context(), extensiontest.NewNopSettings(f.Type()), cfg)
-	assert.Equal(t, fext, ext)
+	ext, err := createExtension(t.Context(), extensiontest.NewNopSettings(f.Type()), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+
+	fext, err := f.Create(t.Context(), extensiontest.NewNopSettings(f.Type()), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, fext)
 }
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -30,10 +40,13 @@ func TestCreateDefaultConfig(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
+	isolateAWSEnv(t)
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join("testdata", "credentials"))
+
 	cfg := createDefaultConfig().(*Config)
 	cfg.Region = "us-east-1"
 
 	ext, err := createExtension(t.Context(), extensiontest.NewNopSettings(extensiontest.NopType), cfg)
-	assert.NoError(t, err)
-	assert.NotNil(t, ext)
+	require.NoError(t, err)
+	require.NotNil(t, ext)
 }

--- a/extension/sigv4authextension/factory_test.go
+++ b/extension/sigv4authextension/factory_test.go
@@ -31,6 +31,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
+	cfg.Region = "us-east-1"
 
 	ext, err := createExtension(t.Context(), extensiontest.NewNopSettings(extensiontest.NopType), cfg)
 	assert.NoError(t, err)

--- a/extension/sigv4authextension/go.mod
+++ b/extension/sigv4authextension/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.13
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.66
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.18
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutilv2 v0.124.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.30.0
 	go.opentelemetry.io/collector/component/componenttest v0.124.0
@@ -20,6 +21,8 @@ require (
 )
 
 require (
+	github.com/amazon-contributing/opentelemetry-collector-contrib/override/awsv2 v0.124.1 // indirect
+	github.com/aws/aws-sdk-go v1.55.6 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
@@ -69,3 +72,7 @@ retract (
 	v0.76.1
 	v0.65.0
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutilv2 => ../../internal/aws/awsutilv2
+
+replace github.com/amazon-contributing/opentelemetry-collector-contrib/override/awsv2 => ../../override/awsv2

--- a/extension/sigv4authextension/go.sum
+++ b/extension/sigv4authextension/go.sum
@@ -1,3 +1,5 @@
+github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
+github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
 github.com/aws/aws-sdk-go-v2 v1.36.3/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
 github.com/aws/aws-sdk-go-v2/config v1.29.13 h1:RgdPqWoE8nPpIekpVpDJsBckbqT4Liiaq9f35pbTh1Y=
@@ -65,6 +67,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/extension/sigv4authextension/metadata.yaml
+++ b/extension/sigv4authextension/metadata.yaml
@@ -18,4 +18,5 @@ tests:
   config:
     region: us-east-1
     profile: default
-    shared_credentials_file: testdata/credentials
+    shared_credentials_file:
+      - testdata/credentials

--- a/extension/sigv4authextension/metadata.yaml
+++ b/extension/sigv4authextension/metadata.yaml
@@ -16,3 +16,6 @@ tests:
         - "net/http.(*persistConn).writeLoop"
         - "internal/poll.runtime_pollWait"
   config:
+    region: us-east-1
+    profile: default
+    shared_credentials_file: testdata/credentials

--- a/extension/sigv4authextension/signingroundtripper_test.go
+++ b/extension/sigv4authextension/signingroundtripper_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 )
@@ -34,24 +35,28 @@ func TestRoundTrip(t *testing.T) {
 		rt          http.RoundTripper
 		shouldError bool
 		cfg         *Config
+		creds       *aws.CredentialsProvider
 	}{
 		{
 			"valid_round_tripper",
 			defaultRoundTripper,
 			false,
-			&Config{Region: "region", Service: "service", credsProvider: awsCredsProvider},
+			&Config{Region: "region", Service: "service"},
+			awsCredsProvider,
 		},
 		{
 			"error_round_tripper",
 			errorRoundTripper,
 			true,
-			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}, credsProvider: awsCredsProvider},
+			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}},
+			awsCredsProvider,
 		},
 		{
 			"error_invalid_credsProvider",
 			defaultRoundTripper,
 			true,
-			&Config{Region: "region", Service: "service", credsProvider: nil},
+			&Config{Region: "region", Service: "service"},
+			nil,
 		},
 	}
 
@@ -74,7 +79,7 @@ func TestRoundTrip(t *testing.T) {
 			defer server.Close()
 			serverURL, _ := url.Parse(server.URL)
 
-			sa := newSigv4Extension(testcase.cfg, awsSDKInfo, zap.NewNop())
+			sa := newSigv4Extension(testcase.cfg, testcase.creds, awsSDKInfo, zap.NewNop())
 			rt, err := sa.RoundTripper(testcase.rt)
 			assert.NoError(t, err)
 
@@ -177,7 +182,7 @@ func TestInferServiceAndRegion(t *testing.T) {
 	// run tests
 	for _, testcase := range tests {
 		t.Run(testcase.name, func(t *testing.T) {
-			sa := newSigv4Extension(testcase.cfg, "awsSDKInfo", zap.NewNop())
+			sa := newSigv4Extension(testcase.cfg, nil, "awsSDKInfo", zap.NewNop())
 			assert.NotNil(t, sa)
 
 			rt, err := sa.RoundTripper((http.RoundTripper)(http.DefaultTransport.(*http.Transport).Clone()))

--- a/extension/sigv4authextension/testdata/config.yaml
+++ b/extension/sigv4authextension/testdata/config.yaml
@@ -3,9 +3,11 @@ sigv4auth:
   service: "service"
   assume_role:
     session_name: "role_session_name"
-sigv4auth/missing_credentials:
+sigv4auth/web_identity_no_arn:
   region: "region"
   service: "service"
+  assume_role:
+    web_identity_token_file: "testdata/token_file"
 sigv4auth/web_identity:
   region: "region"
   service: "service"

--- a/extension/sigv4authextension/testdata/credentials
+++ b/extension/sigv4authextension/testdata/credentials
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY

--- a/extension/sigv4authextension/testdata/credentials
+++ b/extension/sigv4authextension/testdata/credentials
@@ -1,3 +1,7 @@
 [default]
-aws_access_key_id = AKIAIOSFODNN7EXAMPLE
-aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+aws_access_key_id = FAKEAWSACCESSKEYID00
+aws_secret_access_key = FakeSecretAccessKeyForTestingOnly0000000
+
+[testprofile]
+aws_access_key_id = FAKEAWSACCESSKEYID01
+aws_secret_access_key = FakeSecretAccessKeyForTestingOnly0000001


### PR DESCRIPTION
#### Description
Updates the sigv4auth extension to use the credential chain added as part of https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/549 instead of the default `awsconfig.LoadDefaultConfig`.

- Adds `profile`, `shared_credentials_file`, and `local_mode` config fields to match the `internal/aws/awsutil` (and `internal/aws/awsutilv2`) settings.
- Delegates credential resolution to `awsutilv2.GetAWSConfig`
- Moves credential resolution out of `Validate()` and into `createExtension()`

#### Testing
Updated unit tests and updated `metadata.yaml` to use `testdata/credentials` to prevent the chain from trying to use local environment credentials during testing.
