### PR TITLE
[extension/sigv4auth] Use default for AWSSessionSettings

### DIFF
--- a/extension/sigv4authextension/README.md
+++ b/extension/sigv4authextension/README.md
@@ -23,14 +23,18 @@ The configuration fields are as follows:
   * `web_identity_token_file`: The path to the file containing the JWT token to be exchanged
   * `sts_region`: The AWS region where STS is used to assumed the configured role
     * Note that if a role is intended to be assumed, and `sts_region` is not provided, then `sts_region` will default to the value for `region` if `region` is provided
-* `region`: **Optional**. The AWS region for the service you are exporting to for AWS Sigv4. This is differentiated from `sts_region` to handle cross region authentication
-    * Note that an attempt will be made to obtain a valid region from the endpoint of the service you are exporting to
-    * [List of AWS regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html)
 * `service`: **Optional**. The AWS service for AWS Sigv4
     * Note for supported services an attempt will be made to obtain a valid service from the endpoint of the service you are exporting to. Supported services include - workspaces, es, logs and traces.
-* `profile`: **Optional**. AWS profile to use from the shared credentials file.
-* `shared_credentials_file`: **Optional**. List of paths to shared credentials files.
-* `local_mode`: **Optional**. Disable EC2 IMDS region detection. Use when running outside EC2.
+
+The extension also accepts the standard AWS session settings — `region`, `profile`,
+`shared_credentials_file`, `local_mode`, `role_arn`, `external_id`, `endpoint`,
+`proxy_address`, `certificate_file_path`, `no_verify_ssl`, `request_timeout_seconds`,
+`imds_retries`. See [`AWSSessionSettings`](../../internal/aws/awsutilv2/awsconfig.go)
+for the full list.
+
+> Note that an attempt will be made to obtain a valid `region` from the endpoint of the service you are exporting to. `region` is differentiated from `assume_role.sts_region` to handle cross region authentication. See the [list of AWS regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html).
+
+> The role ARN can be set via either `role_arn` (inherited from session settings) or `assume_role.arn`, but not both.
 
 
 ## Assume Role

--- a/extension/sigv4authextension/config.go
+++ b/extension/sigv4authextension/config.go
@@ -7,16 +7,16 @@ import (
 	"errors"
 
 	"go.opentelemetry.io/collector/component"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutilv2"
 )
 
 // Config stores the configuration for the Sigv4 Authenticator
 type Config struct {
-	Region                string     `mapstructure:"region,omitempty"`
-	Service               string     `mapstructure:"service,omitempty"`
-	Profile               string     `mapstructure:"profile,omitempty"`
-	SharedCredentialsFile []string   `mapstructure:"shared_credentials_file,omitempty"`
-	LocalMode             bool       `mapstructure:"local_mode,omitempty"`
-	AssumeRole            AssumeRole `mapstructure:"assume_role"`
+	awsutilv2.AWSSessionSettings `mapstructure:",squash"`
+
+	Service    string     `mapstructure:"service,omitempty"`
+	AssumeRole AssumeRole `mapstructure:"assume_role"`
 }
 
 // AssumeRole holds the configuration needed to assume a role
@@ -34,6 +34,9 @@ var _ component.Config = (*Config)(nil)
 func (cfg *Config) Validate() error {
 	if cfg.AssumeRole.WebIdentityTokenFile != "" && cfg.AssumeRole.ARN == "" {
 		return errors.New("must specify ARN when using WebIdentityTokenFile")
+	}
+	if cfg.AssumeRole.ARN != "" && cfg.RoleARN != "" {
+		return errors.New("role_arn and assume_role.arn cannot both be set")
 	}
 	return nil
 }

--- a/extension/sigv4authextension/config.go
+++ b/extension/sigv4authextension/config.go
@@ -32,13 +32,22 @@ var _ component.Config = (*Config)(nil)
 
 // Validate checks that the configuration is well-formed.
 func (cfg *Config) Validate() error {
-	if cfg.AssumeRole.WebIdentityTokenFile != "" && cfg.AssumeRole.ARN == "" {
-		return errors.New("must specify ARN when using WebIdentityTokenFile")
-	}
 	if cfg.AssumeRole.ARN != "" && cfg.RoleARN != "" {
 		return errors.New("role_arn and assume_role.arn cannot both be set")
 	}
+	if cfg.AssumeRole.WebIdentityTokenFile != "" && cfg.resolvedRoleARN() == "" {
+		return errors.New("must specify role_arn or assume_role.arn when using WebIdentityTokenFile")
+	}
 	return nil
+}
+
+// resolvedRoleARN returns whichever of cfg.RoleARN (top-level) or cfg.AssumeRole.ARN is set.
+// Validate guarantees they are not both set; returns "" when neither is set.
+func (cfg *Config) resolvedRoleARN() string {
+	if cfg.AssumeRole.ARN != "" {
+		return cfg.AssumeRole.ARN
+	}
+	return cfg.RoleARN
 }
 
 // resolvedSTSRegion returns AssumeRole.STSRegion if set, otherwise falls back to Region.

--- a/extension/sigv4authextension/config_test.go
+++ b/extension/sigv4authextension/config_test.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutilv2"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -32,13 +33,15 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, sub.Unmarshal(cfg))
 
 	assert.NoError(t, xconfmap.Validate(cfg))
-	assert.Equal(t, &Config{
-		Region:  "region",
-		Service: "service",
+	expected := &Config{
+		AWSSessionSettings: awsutilv2.CreateDefaultSessionConfig(),
+		Service:            "service",
 		AssumeRole: AssumeRole{
 			SessionName: "role_session_name",
 		},
-	}, cfg)
+	}
+	expected.Region = "region"
+	assert.Equal(t, expected, cfg)
 }
 
 func TestLoadWebIdentityConfig(t *testing.T) {
@@ -51,14 +54,16 @@ func TestLoadWebIdentityConfig(t *testing.T) {
 	require.NoError(t, sub.Unmarshal(cfg))
 
 	assert.NoError(t, xconfmap.Validate(cfg))
-	assert.Equal(t, &Config{
-		Region:  "region",
-		Service: "service",
+	expected := &Config{
+		AWSSessionSettings: awsutilv2.CreateDefaultSessionConfig(),
+		Service:            "service",
 		AssumeRole: AssumeRole{
 			ARN:                  "arn:aws:iam::12345678910:role/my_role",
 			WebIdentityTokenFile: "testdata/token_file",
 		},
-	}, cfg)
+	}
+	expected.Region = "region"
+	assert.Equal(t, expected, cfg)
 }
 
 func TestLoadConfigError(t *testing.T) {

--- a/extension/sigv4authextension/config_test.go
+++ b/extension/sigv4authextension/config_test.go
@@ -79,3 +79,17 @@ func TestLoadConfigError(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "must specify ARN")
 }
+
+func TestValidateRejectsBothRoleARNs(t *testing.T) {
+	cfg := &Config{
+		AWSSessionSettings: awsutilv2.AWSSessionSettings{
+			RoleARN: "arn:aws:iam::123456789012:role/role1",
+		},
+		AssumeRole: AssumeRole{
+			ARN: "arn:aws:iam::123456789012:role/role2",
+		},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "role_arn and assume_role.arn cannot both be set")
+}

--- a/extension/sigv4authextension/config_test.go
+++ b/extension/sigv4authextension/config_test.go
@@ -77,7 +77,7 @@ func TestLoadConfigError(t *testing.T) {
 
 	err = xconfmap.Validate(cfg)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "must specify ARN")
+	assert.ErrorContains(t, err, "must specify role_arn or assume_role.arn")
 }
 
 func TestValidateRejectsBothRoleARNs(t *testing.T) {
@@ -92,4 +92,35 @@ func TestValidateRejectsBothRoleARNs(t *testing.T) {
 	err := cfg.Validate()
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "role_arn and assume_role.arn cannot both be set")
+}
+
+func TestResolvedRoleARN(t *testing.T) {
+	const sessionARN = "arn:aws:iam::123456789012:role/session"
+	const assumeARN = "arn:aws:iam::123456789012:role/assume"
+	tests := []struct {
+		name string
+		cfg  *Config
+		want string
+	}{
+		{
+			name: "neither_set",
+			cfg:  &Config{},
+			want: "",
+		},
+		{
+			name: "session_role_arn_only",
+			cfg:  &Config{AWSSessionSettings: awsutilv2.AWSSessionSettings{RoleARN: sessionARN}},
+			want: sessionARN,
+		},
+		{
+			name: "assume_role_arn_only",
+			cfg:  &Config{AssumeRole: AssumeRole{ARN: assumeARN}},
+			want: assumeARN,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.cfg.resolvedRoleARN())
+		})
+	}
 }

--- a/extension/sigv4authextension/extension.go
+++ b/extension/sigv4authextension/extension.go
@@ -91,9 +91,7 @@ func resolveCredentialsProvider(ctx context.Context, logger *zap.Logger, cfg *Co
 func getCredsProviderFromConfig(ctx context.Context, logger *zap.Logger, cfg *Config) (*aws.CredentialsProvider, error) {
 	settings := cfg.AWSSessionSettings
 	settings.Region = cfg.resolvedSTSRegion()
-	if cfg.AssumeRole.ARN != "" {
-		settings.RoleARN = cfg.AssumeRole.ARN
-	}
+	settings.RoleARN = cfg.resolvedRoleARN()
 	awscfg, err := awsutilv2.GetAWSConfig(ctx, logger, &settings)
 	if err != nil {
 		return nil, err
@@ -114,11 +112,12 @@ func getCredsProviderFromWebIdentityConfig(ctx context.Context, logger *zap.Logg
 	}
 
 	stsRegion := cfg.resolvedSTSRegion()
+	roleARN := cfg.resolvedRoleARN()
 	awscfg, err := awsconfig.LoadDefaultConfig(ctx,
 		awsconfig.WithWebIdentityRoleCredentialOptions(
 			func(options *stscreds.WebIdentityRoleOptions) {
 				options.TokenRetriever = tokenRetriever
-				options.RoleARN = cfg.AssumeRole.ARN
+				options.RoleARN = roleARN
 			},
 		),
 		awsconfig.WithRegion(stsRegion),
@@ -128,10 +127,10 @@ func getCredsProviderFromWebIdentityConfig(ctx context.Context, logger *zap.Logg
 	}
 	stsSvc := sts.NewFromConfig(awscfg)
 
-	provider := stscreds.NewWebIdentityRoleProvider(stsSvc, cfg.AssumeRole.ARN, tokenRetriever)
+	provider := stscreds.NewWebIdentityRoleProvider(stsSvc, roleARN, tokenRetriever)
 	awscfg.Credentials = aws.NewCredentialsCache(provider)
 	logger.Debug("Web identity credentials provider configured",
-		zap.String("role-arn", cfg.AssumeRole.ARN),
+		zap.String("role-arn", roleARN),
 		zap.String("region", stsRegion))
 
 	return &awscfg.Credentials, nil

--- a/extension/sigv4authextension/extension.go
+++ b/extension/sigv4authextension/extension.go
@@ -89,12 +89,10 @@ func resolveCredentialsProvider(ctx context.Context, logger *zap.Logger, cfg *Co
 // getCredsProviderFromConfig builds an aws.CredentialsProvider from cfg: shared profile/file when
 // configured, otherwise the SDK default chain, optionally wrapped with regional/partitional assume-role.
 func getCredsProviderFromConfig(ctx context.Context, logger *zap.Logger, cfg *Config) (*aws.CredentialsProvider, error) {
-	settings := awsutilv2.AWSSessionSettings{
-		Region:                cfg.resolvedSTSRegion(),
-		RoleARN:               cfg.AssumeRole.ARN,
-		Profile:               cfg.Profile,
-		LocalMode:             cfg.LocalMode,
-		SharedCredentialsFile: cfg.SharedCredentialsFile,
+	settings := cfg.AWSSessionSettings
+	settings.Region = cfg.resolvedSTSRegion()
+	if cfg.AssumeRole.ARN != "" {
+		settings.RoleARN = cfg.AssumeRole.ARN
 	}
 	awscfg, err := awsutilv2.GetAWSConfig(ctx, logger, &settings)
 	if err != nil {

--- a/extension/sigv4authextension/extension_test.go
+++ b/extension/sigv4authextension/extension_test.go
@@ -177,11 +177,23 @@ func TestGetCredsProviderFromWebIdentityConfig(t *testing.T) {
 		shouldError bool
 	}{
 		{
-			"valid_token",
+			"valid_token_with_assume_role_arn",
 			&Config{
 				AWSSessionSettings: awsutilv2.AWSSessionSettings{Region: "region"},
 				Service:            "service",
 				AssumeRole:         AssumeRole{ARN: "arn:aws:iam::123456789012:role/my_role", WebIdentityTokenFile: "testdata/token_file"},
+			},
+			false,
+		},
+		{
+			"valid_token_with_role_arn",
+			&Config{
+				AWSSessionSettings: awsutilv2.AWSSessionSettings{
+					Region:  "region",
+					RoleARN: "arn:aws:iam::123456789012:role/my_role",
+				},
+				Service:    "service",
+				AssumeRole: AssumeRole{WebIdentityTokenFile: "testdata/token_file"},
 			},
 			false,
 		},

--- a/extension/sigv4authextension/extension_test.go
+++ b/extension/sigv4authextension/extension_test.go
@@ -15,10 +15,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutilv2"
 )
 
 func TestNewSigv4Extension(t *testing.T) {
-	cfg := &Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}}
+	cfg := &Config{
+		AWSSessionSettings: awsutilv2.AWSSessionSettings{Region: "region"},
+		Service:            "service",
+		AssumeRole:         AssumeRole{ARN: "rolearn", STSRegion: "region"},
+	}
 
 	sa := newSigv4Extension(cfg, nil, "awsSDKInfo", zap.NewNop())
 	assert.Equal(t, cfg.Region, sa.cfg.Region)
@@ -31,7 +37,11 @@ func TestRoundTripper(t *testing.T) {
 
 	base := (http.RoundTripper)(http.DefaultTransport.(*http.Transport).Clone())
 	awsSDKInfo := "awsSDKInfo"
-	cfg := &Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}}
+	cfg := &Config{
+		AWSSessionSettings: awsutilv2.AWSSessionSettings{Region: "region"},
+		Service:            "service",
+		AssumeRole:         AssumeRole{ARN: "rolearn", STSRegion: "region"},
+	}
 
 	sa := newSigv4Extension(cfg, awsCredsProvider, awsSDKInfo, zap.NewNop())
 	assert.NotNil(t, sa)
@@ -57,14 +67,22 @@ func TestGetCredsProviderFromConfig(t *testing.T) {
 	}{
 		{
 			"success_case_without_role",
-			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{STSRegion: "region"}},
+			&Config{
+				AWSSessionSettings: awsutilv2.AWSSessionSettings{Region: "region"},
+				Service:            "service",
+				AssumeRole:         AssumeRole{STSRegion: "region"},
+			},
 			"AccessKeyID",
 			"SecretAccessKey",
 			false,
 		},
 		{
 			"failure_case_without_role",
-			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{STSRegion: "region"}},
+			&Config{
+				AWSSessionSettings: awsutilv2.AWSSessionSettings{Region: "region"},
+				Service:            "service",
+				AssumeRole:         AssumeRole{STSRegion: "region"},
+			},
 			"",
 			"",
 			true,
@@ -97,10 +115,12 @@ func TestGetCredsProviderFromConfig(t *testing.T) {
 func TestGetCredsProviderFromConfig_SharedCredentialsFile(t *testing.T) {
 	isolateAWSEnv(t)
 	cfg := &Config{
-		Region:                "region",
-		Service:               "service",
-		SharedCredentialsFile: []string{filepath.Join("testdata", "credentials")},
-		AssumeRole:            AssumeRole{STSRegion: "region"},
+		AWSSessionSettings: awsutilv2.AWSSessionSettings{
+			Region:                "region",
+			SharedCredentialsFile: []string{filepath.Join("testdata", "credentials")},
+		},
+		Service:    "service",
+		AssumeRole: AssumeRole{STSRegion: "region"},
 	}
 
 	credsProvider, err := getCredsProviderFromConfig(t.Context(), zap.NewNop(), cfg)
@@ -115,11 +135,13 @@ func TestGetCredsProviderFromConfig_SharedCredentialsFile(t *testing.T) {
 func TestGetCredsProviderFromConfig_Profile(t *testing.T) {
 	isolateAWSEnv(t)
 	cfg := &Config{
-		Region:                "region",
-		Service:               "service",
-		Profile:               "testprofile",
-		SharedCredentialsFile: []string{filepath.Join("testdata", "credentials")},
-		AssumeRole:            AssumeRole{STSRegion: "region"},
+		AWSSessionSettings: awsutilv2.AWSSessionSettings{
+			Region:                "region",
+			Profile:               "testprofile",
+			SharedCredentialsFile: []string{filepath.Join("testdata", "credentials")},
+		},
+		Service:    "service",
+		AssumeRole: AssumeRole{STSRegion: "region"},
 	}
 
 	credsProvider, err := getCredsProviderFromConfig(t.Context(), zap.NewNop(), cfg)
@@ -134,11 +156,13 @@ func TestGetCredsProviderFromConfig_Profile(t *testing.T) {
 func TestGetCredsProviderFromConfig_LocalMode(t *testing.T) {
 	isolateAWSEnv(t)
 	cfg := &Config{
-		Region:                "region",
-		Service:               "service",
-		LocalMode:             true,
-		SharedCredentialsFile: []string{filepath.Join("testdata", "credentials")},
-		AssumeRole:            AssumeRole{STSRegion: "region"},
+		AWSSessionSettings: awsutilv2.AWSSessionSettings{
+			Region:                "region",
+			LocalMode:             true,
+			SharedCredentialsFile: []string{filepath.Join("testdata", "credentials")},
+		},
+		Service:    "service",
+		AssumeRole: AssumeRole{STSRegion: "region"},
 	}
 
 	credsProvider, err := getCredsProviderFromConfig(t.Context(), zap.NewNop(), cfg)
@@ -154,12 +178,20 @@ func TestGetCredsProviderFromWebIdentityConfig(t *testing.T) {
 	}{
 		{
 			"valid_token",
-			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "arn:aws:iam::123456789012:role/my_role", WebIdentityTokenFile: "testdata/token_file"}},
+			&Config{
+				AWSSessionSettings: awsutilv2.AWSSessionSettings{Region: "region"},
+				Service:            "service",
+				AssumeRole:         AssumeRole{ARN: "arn:aws:iam::123456789012:role/my_role", WebIdentityTokenFile: "testdata/token_file"},
+			},
 			false,
 		},
 		{
 			"missing_token_file",
-			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "arn:aws:iam::123456789012:role/my_role", WebIdentityTokenFile: "testdata/no_token_file"}},
+			&Config{
+				AWSSessionSettings: awsutilv2.AWSSessionSettings{Region: "region"},
+				Service:            "service",
+				AssumeRole:         AssumeRole{ARN: "arn:aws:iam::123456789012:role/my_role", WebIdentityTokenFile: "testdata/no_token_file"},
+			},
 			true,
 		},
 	}

--- a/extension/sigv4authextension/factory.go
+++ b/extension/sigv4authextension/factory.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/extension"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutilv2"
 )
 
 // NewFactory creates a factory for the Sigv4 Authenticator extension.
@@ -20,7 +21,9 @@ func NewFactory() extension.Factory {
 }
 
 func createDefaultConfig() component.Config {
-	return &Config{}
+	return &Config{
+		AWSSessionSettings: awsutilv2.CreateDefaultSessionConfig(),
+	}
 }
 
 func createExtension(ctx context.Context, set extension.Settings, cfg component.Config) (extension.Extension, error) {

--- a/extension/sigv4authextension/factory_test.go
+++ b/extension/sigv4authextension/factory_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/extension/extensiontest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutilv2"
 )
 
 func TestNewFactory(t *testing.T) {
@@ -35,7 +37,7 @@ func TestNewFactory(t *testing.T) {
 
 func TestCreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	assert.Equal(t, &Config{}, cfg)
+	assert.Equal(t, &Config{AWSSessionSettings: awsutilv2.CreateDefaultSessionConfig()}, cfg)
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
 }
 

--- a/extension/sigv4authextension/signingroundtripper_test.go
+++ b/extension/sigv4authextension/signingroundtripper_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutilv2"
 )
 
 type errorRoundTripper struct{}
@@ -41,21 +43,21 @@ func TestRoundTrip(t *testing.T) {
 			"valid_round_tripper",
 			defaultRoundTripper,
 			false,
-			&Config{Region: "region", Service: "service"},
+			&Config{AWSSessionSettings: awsutilv2.AWSSessionSettings{Region: "region"}, Service: "service"},
 			awsCredsProvider,
 		},
 		{
 			"error_round_tripper",
 			errorRoundTripper,
 			true,
-			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}},
+			&Config{AWSSessionSettings: awsutilv2.AWSSessionSettings{Region: "region"}, Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}},
 			awsCredsProvider,
 		},
 		{
 			"error_invalid_credsProvider",
 			defaultRoundTripper,
 			true,
-			&Config{Region: "region", Service: "service"},
+			&Config{AWSSessionSettings: awsutilv2.AWSSessionSettings{Region: "region"}, Service: "service"},
 			nil,
 		},
 	}
@@ -152,14 +154,14 @@ func TestInferServiceAndRegion(t *testing.T) {
 		{
 			"no_match_with_config",
 			req4,
-			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}},
+			&Config{AWSSessionSettings: awsutilv2.AWSSessionSettings{Region: "region"}, Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}},
 			"service",
 			"region",
 		},
 		{
 			"match_with_config",
 			req5,
-			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}},
+			&Config{AWSSessionSettings: awsutilv2.AWSSessionSettings{Region: "region"}, Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}},
 			"service",
 			"region",
 		},

--- a/internal/aws/awsutilv2/awsconfig.go
+++ b/internal/aws/awsutilv2/awsconfig.go
@@ -7,13 +7,13 @@ package awsutilv2 // import "github.com/open-telemetry/opentelemetry-collector-c
 // AWSSessionSettings defines the common session configs for the v2 AWS credential chain.
 type AWSSessionSettings struct {
 	// NumberOfWorkers is the maximum idle connections per host.
-	NumberOfWorkers int `mapstructure:"num_workers,omitempty"`
+	NumberOfWorkers int `mapstructure:"num_workers"`
 	// Endpoint overrides the AWS service endpoint.
 	Endpoint string `mapstructure:"endpoint,omitempty"`
 	// RequestTimeoutSeconds is the per-request HTTP timeout in seconds.
-	RequestTimeoutSeconds int `mapstructure:"request_timeout_seconds,omitempty"`
+	RequestTimeoutSeconds int `mapstructure:"request_timeout_seconds"`
 	// MaxRetries is the number of retries beyond the initial attempt.
-	MaxRetries int `mapstructure:"max_retries,omitempty"`
+	MaxRetries int `mapstructure:"max_retries"`
 	// NoVerifySSL disables TLS certificate verification.
 	NoVerifySSL bool `mapstructure:"no_verify_ssl,omitempty"`
 	// ProxyAddress is the HTTP proxy address. When empty, the SDK default (http.ProxyFromEnvironment) honors
@@ -34,7 +34,7 @@ type AWSSessionSettings struct {
 	// CertificateFilePath adds a custom certificates file.
 	CertificateFilePath string `mapstructure:"certificate_file_path,omitempty"`
 	// IMDSRetries is the number of retries beyond the initial attempt for IMDS region resolution.
-	IMDSRetries int `mapstructure:"imds_retries,omitempty"`
+	IMDSRetries int `mapstructure:"imds_retries"`
 	// ExternalID is used to verify third party role assumption.
 	ExternalID string `mapstructure:"external_id,omitempty"`
 }
@@ -44,14 +44,7 @@ type AWSSessionSettings struct {
 func CreateDefaultSessionConfig() AWSSessionSettings {
 	return AWSSessionSettings{
 		NumberOfWorkers:       8,
-		Endpoint:              "",
 		RequestTimeoutSeconds: 30,
 		MaxRetries:            2,
-		NoVerifySSL:           false,
-		ProxyAddress:          "",
-		Region:                "",
-		LocalMode:             false,
-		ResourceARN:           "",
-		RoleARN:               "",
 	}
 }

--- a/internal/aws/awsutilv2/awsconfig.go
+++ b/internal/aws/awsutilv2/awsconfig.go
@@ -7,34 +7,51 @@ package awsutilv2 // import "github.com/open-telemetry/opentelemetry-collector-c
 // AWSSessionSettings defines the common session configs for the v2 AWS credential chain.
 type AWSSessionSettings struct {
 	// NumberOfWorkers is the maximum idle connections per host.
-	NumberOfWorkers int `mapstructure:"num_workers"`
+	NumberOfWorkers int `mapstructure:"num_workers,omitempty"`
 	// Endpoint overrides the AWS service endpoint.
-	Endpoint string `mapstructure:"endpoint"`
-	// RequestTimeoutSeconds is the HTTP request timeout in seconds.
-	RequestTimeoutSeconds int `mapstructure:"request_timeout_seconds"`
+	Endpoint string `mapstructure:"endpoint,omitempty"`
+	// RequestTimeoutSeconds is the per-request HTTP timeout in seconds.
+	RequestTimeoutSeconds int `mapstructure:"request_timeout_seconds,omitempty"`
 	// MaxRetries is the number of retries beyond the initial attempt.
-	MaxRetries int `mapstructure:"max_retries"`
+	MaxRetries int `mapstructure:"max_retries,omitempty"`
 	// NoVerifySSL disables TLS certificate verification.
-	NoVerifySSL bool `mapstructure:"no_verify_ssl"`
+	NoVerifySSL bool `mapstructure:"no_verify_ssl,omitempty"`
 	// ProxyAddress is the HTTP proxy address. When empty, the SDK default (http.ProxyFromEnvironment) honors
 	// HTTPS_PROXY/HTTP_PROXY/NO_PROXY at request time.
-	ProxyAddress string `mapstructure:"proxy_address"`
+	ProxyAddress string `mapstructure:"proxy_address,omitempty"`
 	// Region is the AWS region for credential resolution and STS calls.
-	Region string `mapstructure:"region"`
+	Region string `mapstructure:"region,omitempty"`
 	// LocalMode skips EC2 IMDS region resolution.
-	LocalMode bool `mapstructure:"local_mode"`
+	LocalMode bool `mapstructure:"local_mode,omitempty"`
 	// ResourceARN is the Amazon Resource Name (ARN) of the AWS resource running the collector.
-	ResourceARN string `mapstructure:"resource_arn"`
+	ResourceARN string `mapstructure:"resource_arn,omitempty"`
 	// RoleARN is the IAM role to assume after resolving root credentials.
-	RoleARN string `mapstructure:"role_arn"`
+	RoleARN string `mapstructure:"role_arn,omitempty"`
 	// Profile changes the default profile for the shared credentials file.
-	Profile string `mapstructure:"profile"`
+	Profile string `mapstructure:"profile,omitempty"`
 	// SharedCredentialsFile changes the default shared credentials file location.
-	SharedCredentialsFile []string `mapstructure:"shared_credentials_file"`
+	SharedCredentialsFile []string `mapstructure:"shared_credentials_file,omitempty"`
 	// CertificateFilePath adds a custom certificates file.
-	CertificateFilePath string `mapstructure:"certificate_file_path"`
+	CertificateFilePath string `mapstructure:"certificate_file_path,omitempty"`
 	// IMDSRetries is the number of retries beyond the initial attempt for IMDS region resolution.
-	IMDSRetries int `mapstructure:"imds_retries"`
+	IMDSRetries int `mapstructure:"imds_retries,omitempty"`
 	// ExternalID is used to verify third party role assumption.
-	ExternalID string `mapstructure:"external_id"`
+	ExternalID string `mapstructure:"external_id,omitempty"`
+}
+
+// CreateDefaultSessionConfig returns AWSSessionSettings with sensible defaults. Mirrors v1
+// awsutil.CreateDefaultSessionConfig.
+func CreateDefaultSessionConfig() AWSSessionSettings {
+	return AWSSessionSettings{
+		NumberOfWorkers:       8,
+		Endpoint:              "",
+		RequestTimeoutSeconds: 30,
+		MaxRetries:            2,
+		NoVerifySSL:           false,
+		ProxyAddress:          "",
+		Region:                "",
+		LocalMode:             false,
+		ResourceARN:           "",
+		RoleARN:               "",
+	}
 }

--- a/internal/aws/awsutilv2/conn_test.go
+++ b/internal/aws/awsutilv2/conn_test.go
@@ -7,12 +7,16 @@ package awsutilv2
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
@@ -371,4 +375,287 @@ func TestBuildLoadOptions_Provider(t *testing.T) {
 // with only settings and region; shared config files, HTTP client, and credentials provider are nil.
 func testBuildLoadOptions(settings *AWSSessionSettings, region string) []func(*config.LoadOptions) error {
 	return buildLoadOptions(settings, region, nil, nil, nil, nil)
+}
+
+func TestGetAWSConfig_Region(t *testing.T) {
+	t.Run("FromEnv", func(t *testing.T) {
+		isolateAWSEnv(t)
+		t.Setenv("AWS_REGION", "eu-west-2")
+
+		cfg, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{LocalMode: true})
+		require.NoError(t, err)
+		assert.Equal(t, "eu-west-2", cfg.Region)
+	})
+
+	t.Run("FromSettings", func(t *testing.T) {
+		isolateAWSEnv(t)
+
+		cfg, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{
+			Region:    "ap-northeast-1",
+			LocalMode: true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "ap-northeast-1", cfg.Region)
+	})
+}
+
+func TestGetAWSConfig_SharedCredentials(t *testing.T) {
+	credsPath := tempCredentialsFile(t)
+
+	t.Run("FromEnv", func(t *testing.T) {
+		isolateAWSEnv(t)
+		t.Setenv("AWS_SHARED_CREDENTIALS_FILE", credsPath)
+		t.Setenv("AWS_PROFILE", testProfile)
+
+		cfg, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{
+			Region:    testRegion,
+			LocalMode: true,
+		})
+		require.NoError(t, err)
+
+		creds, err := cfg.Credentials.Retrieve(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "ASIAIKJ", creds.AccessKeyID)
+	})
+
+	t.Run("FromSettings", func(t *testing.T) {
+		isolateAWSEnv(t)
+
+		cfg, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{
+			Region:                testRegion,
+			LocalMode:             true,
+			Profile:               testProfile,
+			SharedCredentialsFile: []string{credsPath},
+		})
+		require.NoError(t, err)
+
+		creds, err := cfg.Credentials.Retrieve(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "ASIAIKJ", creds.AccessKeyID)
+	})
+}
+
+func TestGetAWSConfig_CABundle(t *testing.T) {
+	certPath := writeSelfSignedCert(t)
+
+	t.Run("FromEnv", func(t *testing.T) {
+		isolateAWSEnv(t)
+		t.Setenv("AWS_CA_BUNDLE", certPath)
+
+		cfg, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{
+			Region:    testRegion,
+			LocalMode: true,
+		})
+		require.NoError(t, err)
+		assertHTTPClientHasRootCAs(t, cfg.HTTPClient)
+	})
+
+	t.Run("FromSettings", func(t *testing.T) {
+		isolateAWSEnv(t)
+
+		cfg, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{
+			Region:              testRegion,
+			LocalMode:           true,
+			CertificateFilePath: certPath,
+		})
+		require.NoError(t, err)
+		assertHTTPClientHasRootCAs(t, cfg.HTTPClient)
+	})
+}
+
+func TestGetAWSConfig_Proxy(t *testing.T) {
+	const proxy = "http://proxy.example.com:3128"
+
+	t.Run("FromEnv", func(t *testing.T) {
+		isolateAWSEnv(t)
+		t.Setenv("HTTPS_PROXY", proxy)
+
+		cfg, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{
+			Region:    testRegion,
+			LocalMode: true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, proxy, resolvedProxyAddr(t, cfg.HTTPClient))
+	})
+
+	t.Run("FromSettings", func(t *testing.T) {
+		isolateAWSEnv(t)
+
+		cfg, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{
+			Region:       testRegion,
+			LocalMode:    true,
+			ProxyAddress: proxy,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, proxy, resolvedProxyAddr(t, cfg.HTTPClient))
+	})
+}
+
+func TestGetAWSConfig_Endpoint(t *testing.T) {
+	const endpoint = "https://endpoint.example.com"
+
+	isolateAWSEnv(t)
+
+	cfg, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{
+		Region:    testRegion,
+		LocalMode: true,
+		Endpoint:  endpoint,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, cfg.BaseEndpoint)
+	assert.Equal(t, endpoint, *cfg.BaseEndpoint)
+}
+
+// assertHTTPClientHasRootCAs verifies the HTTP client's TLS config has a custom CA pool loaded.
+func assertHTTPClientHasRootCAs(t *testing.T, httpClient aws.HTTPClient) {
+	t.Helper()
+	bc, ok := httpClient.(*awshttp.BuildableClient)
+	require.True(t, ok, "expected *awshttp.BuildableClient")
+	require.NotNil(t, bc.GetTransport().TLSClientConfig)
+	assert.NotNil(t, bc.GetTransport().TLSClientConfig.RootCAs,
+		"CA bundle should be populated in TLS config")
+}
+
+// resolvedProxyAddr returns the HTTP client's resolved proxy URL string, or empty if no proxy.
+func resolvedProxyAddr(t *testing.T, httpClient aws.HTTPClient) string {
+	t.Helper()
+	bc, ok := httpClient.(*awshttp.BuildableClient)
+	require.True(t, ok, "expected *awshttp.BuildableClient")
+	got := resolvedProxy(t, bc.GetTransport())
+	if got == nil {
+		return ""
+	}
+	return got.String()
+}
+
+// TestGetAWSConfig_StaticCredentialsFromEnv confirms AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY flow into the
+// credential chain when no Profile or SharedCredentialsFile override is configured.
+func TestGetAWSConfig_StaticCredentialsFromEnv(t *testing.T) {
+	isolateAWSEnv(t)
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
+
+	cfg, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{
+		Region:    testRegion,
+		LocalMode: true,
+	})
+	require.NoError(t, err)
+
+	creds, err := cfg.Credentials.Retrieve(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "AKIAEXAMPLE", creds.AccessKeyID)
+	assert.Equal(t, "secret", creds.SecretAccessKey)
+}
+
+// TestGetAWSConfig_WebIdentityFromEnv confirms AWS_WEB_IDENTITY_TOKEN_FILE activates the web identity
+// provider. The token file is non-existent so Retrieve fails deterministically with a token-read error.
+func TestGetAWSConfig_WebIdentityFromEnv(t *testing.T) {
+	isolateAWSEnv(t)
+	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "/nonexistent/web-identity-token")
+	t.Setenv("AWS_ROLE_ARN", testRoleARN)
+
+	cfg, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{
+		Region:    testRegion,
+		LocalMode: true,
+	})
+	require.NoError(t, err)
+
+	_, retrieveErr := cfg.Credentials.Retrieve(t.Context())
+	require.Error(t, retrieveErr)
+	assert.Contains(t, strings.ToLower(retrieveErr.Error()), "web-identity-token",
+		"web identity provider should have attempted to read the configured token file")
+}
+
+// TestGetAWSConfig_ContainerCredentialsFromEnv confirms AWS_CONTAINER_CREDENTIALS_FULL_URI activates the
+// container provider, using a local httptest server that returns synthetic credentials.
+func TestGetAWSConfig_ContainerCredentialsFromEnv(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"AccessKeyId":     "AKIACONTAINER",
+			"SecretAccessKey": "container-secret",
+			"Token":           "container-token",
+			"Expiration":      "2099-01-01T00:00:00Z"
+		}`))
+	}))
+	defer server.Close()
+
+	isolateAWSEnv(t)
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", server.URL+"/credentials")
+
+	cfg, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{
+		Region:    testRegion,
+		LocalMode: true,
+	})
+	require.NoError(t, err)
+
+	creds, err := cfg.Credentials.Retrieve(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "AKIACONTAINER", creds.AccessKeyID,
+		"creds should originate from the container credentials endpoint")
+}
+
+// TestGetAWSConfig_DualStackEndpointFromEnv confirms AWS_USE_DUALSTACK_ENDPOINT
+// is reflected in cfg.ConfigSources. Env-only — no AWSSessionSettings field.
+func TestGetAWSConfig_DualStackEndpointFromEnv(t *testing.T) {
+	isolateAWSEnv(t)
+	t.Setenv("AWS_USE_DUALSTACK_ENDPOINT", "true")
+
+	cfg, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{
+		Region:    testRegion,
+		LocalMode: true,
+	})
+	require.NoError(t, err)
+
+	state, found := getDualStackEndpointState(cfg)
+	require.True(t, found, "AWS_USE_DUALSTACK_ENDPOINT should be reflected in ConfigSources")
+	assert.Equal(t, aws.DualStackEndpointStateEnabled, state)
+}
+
+// TestGetAWSConfig_FIPSEndpointFromEnv confirms AWS_USE_FIPS_ENDPOINT is
+// reflected in cfg.ConfigSources. Env-only — no AWSSessionSettings field.
+func TestGetAWSConfig_FIPSEndpointFromEnv(t *testing.T) {
+	isolateAWSEnv(t)
+	t.Setenv("AWS_USE_FIPS_ENDPOINT", "true")
+
+	cfg, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{
+		Region:    testRegion,
+		LocalMode: true,
+	})
+	require.NoError(t, err)
+
+	state, found := getFIPSEndpointState(cfg)
+	require.True(t, found, "AWS_USE_FIPS_ENDPOINT should be reflected in ConfigSources")
+	assert.Equal(t, aws.FIPSEndpointStateEnabled, state)
+}
+
+// getDualStackEndpointState mirrors how AWS service clients resolve the flag at
+// request time.
+func getDualStackEndpointState(cfg aws.Config) (aws.DualStackEndpointState, bool) {
+	for _, src := range cfg.ConfigSources {
+		if v, ok := src.(interface {
+			GetUseDualStackEndpoint(context.Context) (aws.DualStackEndpointState, bool, error)
+		}); ok {
+			state, found, _ := v.GetUseDualStackEndpoint(context.Background())
+			if found {
+				return state, true
+			}
+		}
+	}
+	return aws.DualStackEndpointStateUnset, false
+}
+
+// getFIPSEndpointState mirrors how AWS service clients resolve the flag at
+// request time.
+func getFIPSEndpointState(cfg aws.Config) (aws.FIPSEndpointState, bool) {
+	for _, src := range cfg.ConfigSources {
+		if v, ok := src.(interface {
+			GetUseFIPSEndpoint(context.Context) (aws.FIPSEndpointState, bool, error)
+		}); ok {
+			state, found, _ := v.GetUseFIPSEndpoint(context.Background())
+			if found {
+				return state, true
+			}
+		}
+	}
+	return aws.FIPSEndpointStateUnset, false
 }

--- a/internal/aws/awsutilv2/mock_test.go
+++ b/internal/aws/awsutilv2/mock_test.go
@@ -59,12 +59,28 @@ func tempCredentialsFile(t *testing.T) string {
 	return path
 }
 
-// isolateSharedConfig prevents the v2 SDK from reading the host's shared credentials or config
-// files by overriding HOME, AWS_SHARED_CREDENTIALS_FILE, AWS_CONFIG_FILE, and AWS_PROFILE.
-func isolateSharedConfig(t *testing.T) {
+// isolateAWSEnv clears AWS-related env vars and points the SDK at fake config paths so GetAWSConfig
+// tests don't pick up state from the host.
+func isolateAWSEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/nonexistent")
 	t.Setenv("AWS_CONFIG_FILE", "/nonexistent")
 	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_REGION", "")
+	t.Setenv("AWS_DEFAULT_REGION", "")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	t.Setenv("AWS_CA_BUNDLE", "")
+	t.Setenv("HTTPS_PROXY", "")
+	t.Setenv("HTTP_PROXY", "")
+	t.Setenv("AWS_ENDPOINT_URL", "")
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_SESSION_TOKEN", "")
+	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "")
+	t.Setenv("AWS_ROLE_ARN", "")
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "")
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "")
+	t.Setenv("AWS_USE_DUALSTACK_ENDPOINT", "")
+	t.Setenv("AWS_USE_FIPS_ENDPOINT", "")
 }

--- a/internal/aws/awsutilv2/refreshable_test.go
+++ b/internal/aws/awsutilv2/refreshable_test.go
@@ -22,14 +22,14 @@ func TestSharedCredentialsProvider_MissingProfile(t *testing.T) {
 }
 
 func TestSharedCredentialsProvider_MissingFileDefaultProfile(t *testing.T) {
-	isolateSharedConfig(t)
+	isolateAWSEnv(t)
 	p := newSharedCredentialsProvider("/nonexistent", "default")
 	_, err := p.Retrieve(t.Context())
 	require.Error(t, err, "v2 SDK errors on missing file even for the default profile")
 }
 
 func TestSharedCredentialsProvider_MissingFileNonDefaultProfile(t *testing.T) {
-	isolateSharedConfig(t)
+	isolateAWSEnv(t)
 	p := newSharedCredentialsProvider("/nonexistent", "named-profile")
 	_, err := p.Retrieve(t.Context())
 	require.Error(t, err)


### PR DESCRIPTION
#### Description
Add `awsutilv2.CreateDefaultSessionConfig` (mirrors v1 `awsutil`) and `omitempty` on `AWSSessionSettings` fields to simplify marshaling.

`sigv4auth` Config embeds `AWSSessionSettings` and uses the default. Validate rejects `role_arn` and `assume_role.arn` both being set to prevent precedence confusion. It's one or the other.

#### Testing
Added unit tests to `awsutilv2` to verify that the setup supports both AWS SDK environment variables and the equivalent `AWSSessionSettings` fields.
