### PR TITLE
filter monitoring agent and superuser queries from topsql executions

### DIFF
--- a/receiver/postgresqlreceiver/client_factory_test.go
+++ b/receiver/postgresqlreceiver/client_factory_test.go
@@ -86,7 +86,7 @@ func TestConnectionStringWithPassfile(t *testing.T) {
 
 	connStr, err := cfg.ConnectionString()
 	require.NoError(t, err)
-	require.Contains(t, connStr, "passfile=/tmp/pgpass")
+	require.Contains(t, connStr, "passfile='/tmp/pgpass'")
 }
 
 func TestConnectionStringWithoutPassfile(t *testing.T) {

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -696,10 +696,12 @@ func TestScrapeTopQueriesCollectsOnlyWhenIntervalHasElapsed(t *testing.T) {
 	cfg.Databases = []string{}
 	cfg.Events.DbServerTopQuery.Enabled = true
 	cfg.TopQueryCollection.CollectionInterval = 600 * time.Second
-	db, _, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	assert.NoError(t, err)
 
 	defer db.Close()
+
+	mock.ExpectQuery(expectedScrapeTopQuery).WillReturnRows(sqlmock.NewRows([]string{"calls", "datname", "shared_blks_dirtied", "shared_blks_hit", "shared_blks_read", "shared_blks_written", "local_blks_hit", "local_blks_read", "local_blks_dirtied", "local_blks_written", "temp_blks_read", "temp_blks_written", "query", "queryid", "rolname", "rows", "total_exec_time", "total_plan_time"}))
 
 	factory := mockSimpleClientFactory{
 		db: db,

--- a/receiver/postgresqlreceiver/templates/topQueryTemplate.tmpl
+++ b/receiver/postgresqlreceiver/templates/topQueryTemplate.tmpl
@@ -24,5 +24,7 @@ FROM
 WHERE
   query != '<insufficient privilege>'
   AND query NOT LIKE '/* otel-collector-ignore */%'
+  AND rolname != current_user
+  AND NOT rolsuper
 ORDER BY calls DESC
 LIMIT {{ .limit }};

--- a/receiver/postgresqlreceiver/testdata/scraper/top-query/expectedSql.sql
+++ b/receiver/postgresqlreceiver/testdata/scraper/top-query/expectedSql.sql
@@ -24,5 +24,7 @@ FROM
 WHERE
   query != '<insufficient privilege>'
   AND query NOT LIKE '/* otel-collector-ignore */%'
+  AND rolname != current_user
+  AND NOT rolsuper
 ORDER BY calls DESC
 LIMIT 31;


### PR DESCRIPTION
#### Description

Filter monitoring user and superuser queries from top SQL results to prevent unnecessary EXPLAIN failures.

The top query scraper attempts to EXPLAIN all queries in pg_stat_statements. This causes two issues when the monitoring user is not a superuser:

1. The agent's own monitoring queries appear in results and fail EXPLAIN with syntax errors (parameterized queries with $N in non-value positions)
2. Superuser queries (e.g., pg_reload_conf()) fail EXPLAIN with permission denied since PREPARE checks execution permissions

Both are resolved by filtering at the SQL level:
- AND rolname != current_user — excludes the monitoring user's own queries
- AND NOT rolsuper — excludes superuser queries which cannot be EXPLAIN'd by a non-superuser

Also fixes a test assertion for quoted passfile values in connection strings.

#### Testing

- Updated testdata/scraper/top-query/expectedSql.sql to match new WHERE clause
- Updated mock expectations in TestScrapeTopQueriesCollectsOnlyWhenIntervalHasElapsed
- Fixed TestConnectionStringWithPassfile assertion to expect quoted passfile path
- Validated E2E on EC2: EXPLAIN errors for monitoring user and superuser queries no longer appear

#### Documentation

No documentation changes needed — filtering is internal to the receiver's SQL template.