### PR TITLE
remove super user filter since explains isn't needed

### DIFF
--- a/receiver/postgresqlreceiver/templates/topQueryTemplate.tmpl
+++ b/receiver/postgresqlreceiver/templates/topQueryTemplate.tmpl
@@ -25,6 +25,5 @@ WHERE
   query != '<insufficient privilege>'
   AND query NOT LIKE '/* otel-collector-ignore */%'
   AND rolname != current_user
-  AND NOT rolsuper
 ORDER BY calls DESC
 LIMIT {{ .limit }};

--- a/receiver/postgresqlreceiver/testdata/scraper/top-query/expectedSql.sql
+++ b/receiver/postgresqlreceiver/testdata/scraper/top-query/expectedSql.sql
@@ -25,6 +25,5 @@ WHERE
   query != '<insufficient privilege>'
   AND query NOT LIKE '/* otel-collector-ignore */%'
   AND rolname != current_user
-  AND NOT rolsuper
 ORDER BY calls DESC
 LIMIT 31;


### PR DESCRIPTION
#### Description

AND NOT rolsuper filter from the top query template

#### Testing

- Updated testdata/scraper/top-query/expectedSql.sql
- E2E validated: top SQL metrics now include queries from all users

#### Documentation

N/A