### PR TITLE
[internal/awsutilv2] Use shared HTTP clients

### DIFF
--- a/internal/aws/awsutilv2/awsconfig.go
+++ b/internal/aws/awsutilv2/awsconfig.go
@@ -39,6 +39,29 @@ type AWSSessionSettings struct {
 	ExternalID string `mapstructure:"external_id,omitempty"`
 }
 
+// httpClientSettings is the subset of AWSSessionSettings that determines the HTTP transport
+// configuration. Callers with identical settings share a single BuildableClient (and its
+// connection pool).
+type httpClientSettings struct {
+	ProxyAddress          string
+	CertificateFilePath   string
+	NoVerifySSL           bool
+	RequestTimeoutSeconds int
+	NumberOfWorkers       int
+}
+
+// httpClientSettings returns the transport-relevant subset of settings used as
+// a cache key for shared HTTP clients.
+func (s *AWSSessionSettings) httpClientSettings() httpClientSettings {
+	return httpClientSettings{
+		ProxyAddress:          s.ProxyAddress,
+		CertificateFilePath:   s.CertificateFilePath,
+		NoVerifySSL:           s.NoVerifySSL,
+		RequestTimeoutSeconds: s.RequestTimeoutSeconds,
+		NumberOfWorkers:       s.NumberOfWorkers,
+	}
+}
+
 // CreateDefaultSessionConfig returns AWSSessionSettings with sensible defaults. Mirrors v1
 // awsutil.CreateDefaultSessionConfig.
 func CreateDefaultSessionConfig() AWSSessionSettings {

--- a/internal/aws/awsutilv2/client.go
+++ b/internal/aws/awsutilv2/client.go
@@ -11,17 +11,41 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sync"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
 )
 
-// buildHTTPClient builds an HTTP client from settings for use via config.WithHTTPClient. Returns
-// *awshttp.BuildableClient so the SDK can still apply AWS_CA_BUNDLE / config.WithCustomCABundle
-// (which type-asserts the registered client).
-func buildHTTPClient(logger *zap.Logger, settings *AWSSessionSettings) (*awshttp.BuildableClient, error) {
+var (
+	httpClientsMu sync.Mutex
+	httpClients   = map[httpClientSettings]aws.HTTPClient{}
+)
+
+// getHTTPClient returns a shared HTTP client for the given settings. Sharing the client enables connection pooling
+// and reuse across all AWS API calls, which reduces memory and file descriptor usage. Callers with identical
+// transport-relevant settings share a single client.
+func getHTTPClient(logger *zap.Logger, settings *AWSSessionSettings) (aws.HTTPClient, error) {
+	key := settings.httpClientSettings()
+	httpClientsMu.Lock()
+	defer httpClientsMu.Unlock()
+	if c, ok := httpClients[key]; ok {
+		return c, nil
+	}
+	c, err := buildHTTPClient(logger, key)
+	if err != nil {
+		return nil, err
+	}
+	httpClients[key] = c
+	return c, nil
+}
+
+// buildHTTPClient builds an HTTP client for AWS SDK operations. Returns a BuildableClient because the SDK will only
+// append custom CA bundles if the client is of that type. https://github.com/aws/aws-sdk-go-v2/blob/v1.41.12/config/resolve.go#L57
+func buildHTTPClient(logger *zap.Logger, settings httpClientSettings) (*awshttp.BuildableClient, error) {
 	if settings.ProxyAddress != "" {
 		logger.Debug("Using proxy address", zap.String("proxyAddr", settings.ProxyAddress))
 	}

--- a/internal/aws/awsutilv2/client_test.go
+++ b/internal/aws/awsutilv2/client_test.go
@@ -16,9 +16,11 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +30,7 @@ import (
 )
 
 func TestBuildHTTPClient_Defaults(t *testing.T) {
-	client, err := buildHTTPClient(zap.NewNop(), &AWSSessionSettings{})
+	client, err := buildHTTPClient(zap.NewNop(), httpClientSettings{})
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
@@ -51,7 +53,7 @@ func TestBuildHTTPClient_Defaults(t *testing.T) {
 }
 
 func TestBuildHTTPClient_TimeoutAndWorkers(t *testing.T) {
-	client, err := buildHTTPClient(zap.NewNop(), &AWSSessionSettings{
+	client, err := buildHTTPClient(zap.NewNop(), httpClientSettings{
 		RequestTimeoutSeconds: 5,
 		NumberOfWorkers:       42,
 	})
@@ -62,14 +64,14 @@ func TestBuildHTTPClient_TimeoutAndWorkers(t *testing.T) {
 }
 
 func TestBuildHTTPClient_NoVerifySSL(t *testing.T) {
-	client, err := buildHTTPClient(zap.NewNop(), &AWSSessionSettings{NoVerifySSL: true})
+	client, err := buildHTTPClient(zap.NewNop(), httpClientSettings{NoVerifySSL: true})
 	require.NoError(t, err)
 	assert.True(t, client.GetTransport().TLSClientConfig.InsecureSkipVerify)
 }
 
 func TestBuildHTTPClient_ExplicitProxy(t *testing.T) {
 	t.Setenv("HTTPS_PROXY", "")
-	client, err := buildHTTPClient(zap.NewNop(), &AWSSessionSettings{ProxyAddress: "http://proxy.example.com:3128"})
+	client, err := buildHTTPClient(zap.NewNop(), httpClientSettings{ProxyAddress: "http://proxy.example.com:3128"})
 	require.NoError(t, err)
 
 	got := resolvedProxy(t, client.GetTransport())
@@ -78,7 +80,7 @@ func TestBuildHTTPClient_ExplicitProxy(t *testing.T) {
 }
 
 func TestBuildHTTPClient_InvalidProxyURL(t *testing.T) {
-	_, err := buildHTTPClient(zap.NewNop(), &AWSSessionSettings{ProxyAddress: "://invalid"})
+	_, err := buildHTTPClient(zap.NewNop(), httpClientSettings{ProxyAddress: "://invalid"})
 	require.Error(t, err)
 }
 
@@ -87,7 +89,7 @@ func TestBuildHTTPClient_CertificateFilePath(t *testing.T) {
 		certPath := writeSelfSignedCert(t)
 
 		core, observed := observer.New(zap.WarnLevel)
-		client, err := buildHTTPClient(zap.New(core), &AWSSessionSettings{CertificateFilePath: certPath})
+		client, err := buildHTTPClient(zap.New(core), httpClientSettings{CertificateFilePath: certPath})
 		require.NoError(t, err)
 
 		assert.NotNil(t, client.GetTransport().TLSClientConfig.RootCAs)
@@ -96,7 +98,7 @@ func TestBuildHTTPClient_CertificateFilePath(t *testing.T) {
 
 	t.Run("MissingFile", func(t *testing.T) {
 		core, observed := observer.New(zap.WarnLevel)
-		client, err := buildHTTPClient(zap.New(core), &AWSSessionSettings{CertificateFilePath: "/nonexistent/ca.pem"})
+		client, err := buildHTTPClient(zap.New(core), httpClientSettings{CertificateFilePath: "/nonexistent/ca.pem"})
 		require.NoError(t, err, "missing CA file is non-fatal")
 
 		assert.Nil(t, client.GetTransport().TLSClientConfig.RootCAs)
@@ -109,7 +111,7 @@ func TestBuildHTTPClient_CertificateFilePath(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte("not a real PEM"), 0o600))
 
 		core, observed := observer.New(zap.WarnLevel)
-		client, err := buildHTTPClient(zap.New(core), &AWSSessionSettings{CertificateFilePath: path})
+		client, err := buildHTTPClient(zap.New(core), httpClientSettings{CertificateFilePath: path})
 		require.NoError(t, err, "malformed PEM is non-fatal")
 
 		assert.Nil(t, client.GetTransport().TLSClientConfig.RootCAs)
@@ -126,7 +128,7 @@ func TestBuildHTTPClient_AWSCABundleCompatibility(t *testing.T) {
 	t.Setenv("AWS_CA_BUNDLE", certPath)
 	t.Setenv("AWS_EC2_METADATA_DISABLED", "true") // avoid IMDS attempts on EC2 hosts
 
-	client, err := buildHTTPClient(zap.NewNop(), &AWSSessionSettings{})
+	client, err := buildHTTPClient(zap.NewNop(), httpClientSettings{})
 	require.NoError(t, err)
 
 	cfg, err := config.LoadDefaultConfig(t.Context(),
@@ -174,4 +176,65 @@ func writeSelfSignedCert(t *testing.T) string {
 	path := filepath.Join(t.TempDir(), "ca.pem")
 	require.NoError(t, os.WriteFile(path, pemBytes, 0o600))
 	return path
+}
+
+func TestGetOrBuildHTTPClient_CachesByConfig(t *testing.T) {
+	// Reset the cache for test isolation.
+	httpClientsMu.Lock()
+	httpClients = map[httpClientSettings]aws.HTTPClient{}
+	httpClientsMu.Unlock()
+	t.Cleanup(func() {
+		httpClientsMu.Lock()
+		httpClients = map[httpClientSettings]aws.HTTPClient{}
+		httpClientsMu.Unlock()
+	})
+
+	settingsA := &AWSSessionSettings{RequestTimeoutSeconds: 30, NumberOfWorkers: 8}
+	settingsB := &AWSSessionSettings{RequestTimeoutSeconds: 30, NumberOfWorkers: 8}
+	settingsC := &AWSSessionSettings{RequestTimeoutSeconds: 60, NumberOfWorkers: 8}
+
+	clientA, err := getHTTPClient(zap.NewNop(), settingsA)
+	require.NoError(t, err)
+
+	clientB, err := getHTTPClient(zap.NewNop(), settingsB)
+	require.NoError(t, err)
+
+	clientC, err := getHTTPClient(zap.NewNop(), settingsC)
+	require.NoError(t, err)
+
+	assert.Same(t, clientA, clientB, "identical settings should return the same client")
+	assert.NotSame(t, clientA, clientC, "different settings should return different clients")
+}
+
+func TestGetHTTPClient_Concurrent(t *testing.T) {
+	httpClientsMu.Lock()
+	httpClients = map[httpClientSettings]aws.HTTPClient{}
+	httpClientsMu.Unlock()
+	t.Cleanup(func() {
+		httpClientsMu.Lock()
+		httpClients = map[httpClientSettings]aws.HTTPClient{}
+		httpClientsMu.Unlock()
+	})
+
+	settings := &AWSSessionSettings{RequestTimeoutSeconds: 30, NumberOfWorkers: 8}
+	const count = 50
+	clients := make([]aws.HTTPClient, count)
+	var wg sync.WaitGroup
+
+	for i := range count {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			c, err := getHTTPClient(zap.NewNop(), settings)
+			assert.NoError(t, err)
+			clients[index] = c
+		}(i)
+	}
+	wg.Wait()
+
+	first := clients[0]
+	assert.NotNil(t, first)
+	for i := 1; i < count; i++ {
+		assert.Same(t, first, clients[i])
+	}
 }

--- a/internal/aws/awsutilv2/conn.go
+++ b/internal/aws/awsutilv2/conn.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/amazon-contributing/opentelemetry-collector-contrib/override/awsv2"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
@@ -56,7 +55,7 @@ func GetAWSConfig(ctx context.Context, logger *zap.Logger, settings *AWSSessionS
 // getAWSConfig is the orchestration with retryDelay and the LoadDefaultConfig function as injectable
 // parameters so tests can shorten the retry wait and simulate load failures.
 func getAWSConfig(ctx context.Context, logger *zap.Logger, settings *AWSSessionSettings, retryDelay time.Duration, load loadConfigFn) (aws.Config, error) {
-	httpClient, err := buildHTTPClient(logger, settings)
+	httpClient, err := getHTTPClient(logger, settings)
 	if err != nil {
 		logger.Error("Failed to build HTTP client", zap.Error(err))
 		return aws.Config{}, err
@@ -197,7 +196,7 @@ func warnIfUnusedSharedConfigFiles(logger *zap.Logger) {
 }
 
 // buildLoadOptions assembles the SDK LoadOptions used by getAWSConfig.
-func buildLoadOptions(settings *AWSSessionSettings, region string, credentialsFiles, configFiles []string, httpClient *awshttp.BuildableClient, provider aws.CredentialsProvider) []func(*config.LoadOptions) error {
+func buildLoadOptions(settings *AWSSessionSettings, region string, credentialsFiles, configFiles []string, httpClient aws.HTTPClient, provider aws.CredentialsProvider) []func(*config.LoadOptions) error {
 	// v2 SDK's RetryMaxAttempts counts the initial attempt. The +1 keeps the v1 contract
 	// where MaxRetries=N means N retries beyond the initial. Negative values clamp to 0.
 	retries := max(settings.MaxRetries, 0)

--- a/internal/aws/awsutilv2/conn_test.go
+++ b/internal/aws/awsutilv2/conn_test.go
@@ -51,12 +51,12 @@ func TestResolveRegion(t *testing.T) {
 	t.Run("IMDSDisabledError", func(t *testing.T) {
 		t.Setenv("AWS_REGION", "")
 		t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
-		client, err := buildHTTPClient(zap.NewNop(), &AWSSessionSettings{})
-		require.NoError(t, err)
+		client := &mockHTTPClient{}
 		got, err := resolveRegion(t.Context(), zap.NewNop(), &AWSSessionSettings{}, client)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "failed to resolve region from EC2 metadata")
 		assert.Empty(t, got)
+		client.AssertNotCalled(t, "Do")
 	})
 }
 

--- a/internal/aws/awsutilv2/conn_test.go
+++ b/internal/aws/awsutilv2/conn_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -468,14 +469,18 @@ func TestGetAWSConfig_Proxy(t *testing.T) {
 
 	t.Run("FromEnv", func(t *testing.T) {
 		isolateAWSEnv(t)
-		t.Setenv("HTTPS_PROXY", proxy)
 
 		cfg, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{
 			Region:    testRegion,
 			LocalMode: true,
 		})
 		require.NoError(t, err)
-		assert.Equal(t, proxy, resolvedProxyAddr(t, cfg.HTTPClient))
+		bc, ok := cfg.HTTPClient.(*awshttp.BuildableClient)
+		require.True(t, ok)
+		assert.Equal(t,
+			reflect.ValueOf(http.ProxyFromEnvironment).Pointer(),
+			reflect.ValueOf(bc.GetTransport().Proxy).Pointer(),
+			"expected http.ProxyFromEnvironment when no explicit proxy is set")
 	})
 
 	t.Run("FromSettings", func(t *testing.T) {

--- a/internal/aws/awsutilv2/mock_test.go
+++ b/internal/aws/awsutilv2/mock_test.go
@@ -6,6 +6,7 @@ package awsutilv2
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,6 +38,17 @@ var (
 		Credentials: credentials.NewStaticCredentialsProvider(testCredentials.AccessKeyID, testCredentials.SecretAccessKey, testCredentials.SessionToken),
 	}
 )
+
+type mockHTTPClient struct {
+	mock.Mock
+}
+
+var _ aws.HTTPClient = (*mockHTTPClient)(nil)
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	args := m.Called(req)
+	return args.Get(0).(*http.Response), args.Error(1)
+}
 
 type mockCredentialsProvider struct {
 	mock.Mock

--- a/internal/buildscripts/ocb-add-replaces.sh
+++ b/internal/buildscripts/ocb-add-replaces.sh
@@ -16,4 +16,14 @@ for mod_path in $local_mods; do
     mod=${mod_path#"."} # remove initial dot
     echo "  - github.com/open-telemetry/opentelemetry-collector-contrib$mod => ../..$mod" >> "$CONFIG_OUT"
 done
+
+# Also add replaces for amazon-contributing modules that use a different module path prefix.
+for mod_path in $local_mods; do
+    mod=${mod_path#"."} # remove initial dot
+    mod_file="$mod_path/go.mod"
+    if grep -q '^module github.com/amazon-contributing/' "$mod_file" 2>/dev/null; then
+        amazon_mod=$(head -1 "$mod_file" | sed 's/^module //')
+        echo "  - $amazon_mod => ../..$mod" >> "$CONFIG_OUT"
+    fi
+done
 echo "Wrote replace statements to $CONFIG_OUT"


### PR DESCRIPTION
#### Description
Same issue as https://github.com/aws/amazon-cloudwatch-agent/pull/2009 with a similar fix.

From the Go docs (https://pkg.go.dev/net/http#Client)
>  The [Client.Transport] typically has internal state (cached TCP connections), so Clients should be reused instead of created as needed. Clients are safe for concurrent use by multiple goroutines. 

With SDK v2, the agent must use the `awshttp.BuildableClient` for the SDK to support setting the CA bundle (https://github.com/aws/aws-sdk-go-v2/blob/v1.41.12/config/resolve.go#L57). This client creates a new `Transport` for each instance (https://github.com/aws/aws-sdk-go-v2/blob/v1.41.12/aws/transport/http/client.go#L181), so the connection pools are no longer shared, which results in file descriptor usage increasing.

Adds a shared cache of `aws.HTTPClient`s that are created and keyed off of the client specific settings in `AWSSessionSettings`.

#### Testing
Updated unit tests.
