### PR TITLE
[processor/attributestocontext] Split logs by context metadata

### DIFF
--- a/processor/attributestocontextprocessor/internal/actions/actions.go
+++ b/processor/attributestocontextprocessor/internal/actions/actions.go
@@ -19,19 +19,16 @@ type KeyValue struct {
 // Actions copies resource attributes to client metadata.
 type Actions struct {
 	actions []KeyValue
-	keys    []string
 }
 
 // NewActions creates Actions with keys pre-normalized to lowercase to match client.NewMetadata behavior.
 // - https://github.com/open-telemetry/opentelemetry-collector/blob/client/v1.30.0/client/client.go#L146
 func NewActions(keyValues []KeyValue) Actions {
-	keys := make([]string, len(keyValues))
 	normalized := make([]KeyValue, len(keyValues))
 	for i, kv := range keyValues {
-		keys[i] = strings.ToLower(kv.Key)
-		normalized[i] = KeyValue{Key: keys[i], FromResourceAttribute: kv.FromResourceAttribute}
+		normalized[i] = KeyValue{Key: strings.ToLower(kv.Key), FromResourceAttribute: kv.FromResourceAttribute}
 	}
-	return Actions{actions: normalized, keys: keys}
+	return Actions{actions: normalized}
 }
 
 // ProcessResource copies configured resource attributes into the metadata map.
@@ -49,13 +46,13 @@ const groupKeySeparator = '|'
 // Values are %q-quoted so the separator cannot cause collisions.
 func (a *Actions) GroupKey(metadata map[string][]string) string {
 	var b strings.Builder
-	for i, k := range a.keys {
+	for i, action := range a.actions {
 		if i > 0 {
 			b.WriteByte(groupKeySeparator)
 		}
-		b.WriteString(k)
+		b.WriteString(action.Key)
 		b.WriteByte('=')
-		_, _ = fmt.Fprintf(&b, "%q", metadata[k])
+		_, _ = fmt.Fprintf(&b, "%q", metadata[action.Key])
 	}
 	return b.String()
 }

--- a/processor/attributestocontextprocessor/internal/actions/actions.go
+++ b/processor/attributestocontextprocessor/internal/actions/actions.go
@@ -4,6 +4,7 @@
 package actions // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributestocontextprocessor/internal/actions"
 
 import (
+	"fmt"
 	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -18,19 +19,43 @@ type KeyValue struct {
 // Actions copies resource attributes to client metadata.
 type Actions struct {
 	actions []KeyValue
+	keys    []string
 }
 
+// NewActions creates Actions with keys pre-normalized to lowercase to match client.NewMetadata behavior.
+// - https://github.com/open-telemetry/opentelemetry-collector/blob/client/v1.30.0/client/client.go#L146
 func NewActions(keyValues []KeyValue) Actions {
-	return Actions{actions: keyValues}
+	keys := make([]string, len(keyValues))
+	normalized := make([]KeyValue, len(keyValues))
+	for i, kv := range keyValues {
+		keys[i] = strings.ToLower(kv.Key)
+		normalized[i] = KeyValue{Key: keys[i], FromResourceAttribute: kv.FromResourceAttribute}
+	}
+	return Actions{actions: normalized, keys: keys}
 }
 
 // ProcessResource copies configured resource attributes into the metadata map.
-// Keys are lowercased to match client.NewMetadata behavior.
-// - https://github.com/open-telemetry/opentelemetry-collector/blob/client/v1.30.0/client/client.go#L146
 func (a *Actions) ProcessResource(metadata map[string][]string, attrs pcommon.Map) {
 	for _, action := range a.actions {
 		if val, found := attrs.Get(action.FromResourceAttribute); found {
-			metadata[strings.ToLower(action.Key)] = []string{val.AsString()}
+			metadata[action.Key] = []string{val.AsString()}
 		}
 	}
+}
+
+const groupKeySeparator = '|'
+
+// GroupKey returns a deterministic string key for the metadata values in config order.
+// Values are %q-quoted so the separator cannot cause collisions.
+func (a *Actions) GroupKey(metadata map[string][]string) string {
+	var b strings.Builder
+	for i, k := range a.keys {
+		if i > 0 {
+			b.WriteByte(groupKeySeparator)
+		}
+		b.WriteString(k)
+		b.WriteByte('=')
+		_, _ = fmt.Fprintf(&b, "%q", metadata[k])
+	}
+	return b.String()
 }

--- a/processor/attributestocontextprocessor/internal/actions/actions_test.go
+++ b/processor/attributestocontextprocessor/internal/actions/actions_test.go
@@ -69,3 +69,59 @@ func TestProcessResource_MissingAttribute(t *testing.T) {
 
 	assert.Empty(t, metadata)
 }
+
+func TestGroupKey(t *testing.T) {
+	a := NewActions([]KeyValue{
+		{Key: "cwlogs.log_group", FromResourceAttribute: "aws.log.group.name"},
+		{Key: "cwlogs.log_stream", FromResourceAttribute: "aws.log.stream.name"},
+	})
+
+	metadata := map[string][]string{
+		"cwlogs.log_group":  {"/aws/cwagent/cluster/app"},
+		"cwlogs.log_stream": {"prod/checkout"},
+	}
+
+	key := a.GroupKey(metadata)
+	assert.Equal(t, `cwlogs.log_group=["/aws/cwagent/cluster/app"]|cwlogs.log_stream=["prod/checkout"]`, key)
+}
+
+func TestGroupKey_MissingKey(t *testing.T) {
+	a := NewActions([]KeyValue{
+		{Key: "cwlogs.log_group", FromResourceAttribute: "aws.log.group.name"},
+		{Key: "cwlogs.log_stream", FromResourceAttribute: "aws.log.stream.name"},
+	})
+
+	metadata := map[string][]string{
+		"cwlogs.log_group": {"/app"},
+	}
+
+	key := a.GroupKey(metadata)
+	assert.Equal(t, `cwlogs.log_group=["/app"]|cwlogs.log_stream=[]`, key)
+}
+
+func TestGroupKey_SameValuesDifferentKeys(t *testing.T) {
+	a := NewActions([]KeyValue{
+		{Key: "group", FromResourceAttribute: "g"},
+		{Key: "stream", FromResourceAttribute: "s"},
+	})
+
+	// Values swapped between keys should produce different group keys
+	meta1 := map[string][]string{"group": {"a"}, "stream": {"b"}}
+	meta2 := map[string][]string{"group": {"b"}, "stream": {"a"}}
+
+	assert.NotEqual(t, a.GroupKey(meta1), a.GroupKey(meta2))
+}
+
+func TestGroupKey_CaseNormalized(t *testing.T) {
+	a := NewActions([]KeyValue{
+		{Key: "CWLogs.Log_Group", FromResourceAttribute: "aws.log.group.name"},
+	})
+
+	metadata := map[string][]string{
+		"cwlogs.log_group": {"/app"},
+	}
+
+	key := a.GroupKey(metadata)
+	assert.Contains(t, key, "cwlogs.log_group=")
+	assert.NotContains(t, key, "CWLogs")
+}

--- a/processor/attributestocontextprocessor/logs.go
+++ b/processor/attributestocontextprocessor/logs.go
@@ -5,6 +5,8 @@ package attributestocontextprocessor // import "github.com/open-telemetry/opente
 
 import (
 	"context"
+	"errors"
+	"maps"
 
 	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
@@ -28,20 +30,64 @@ func newLogsProcessor(cfg *Config, next consumer.Logs) processor.Logs {
 }
 
 func (p *logsProcessor) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
-	clientInfo := client.FromContext(ctx)
-	metadataMap := make(map[string][]string)
-	for key := range clientInfo.Metadata.Keys() {
-		metadataMap[key] = clientInfo.Metadata.Get(key)
-	}
-
 	resourceLogs := ld.ResourceLogs()
-	for i := 0; i < resourceLogs.Len(); i++ {
-		p.actions.ProcessResource(metadataMap, resourceLogs.At(i).Resource().Attributes())
+	if resourceLogs.Len() == 0 {
+		return p.next.ConsumeLogs(ctx, ld)
 	}
 
-	clientInfo.Metadata = client.NewMetadata(metadataMap)
-	newCtx := client.NewContext(ctx, clientInfo)
-	return p.next.ConsumeLogs(newCtx, ld)
+	clientInfo := client.FromContext(ctx)
+	baseMetadata := make(map[string][]string)
+	for key := range clientInfo.Metadata.Keys() {
+		baseMetadata[key] = clientInfo.Metadata.Get(key)
+	}
+
+	// Fast path: single ResourceLogs, no grouping needed.
+	if resourceLogs.Len() == 1 {
+		p.actions.ProcessResource(baseMetadata, resourceLogs.At(0).Resource().Attributes())
+		clientInfo.Metadata = client.NewMetadata(baseMetadata)
+		return p.next.ConsumeLogs(client.NewContext(ctx, clientInfo), ld)
+	}
+
+	type group struct {
+		metadata map[string][]string
+		indices  []int
+	}
+	groups := map[string]*group{}
+
+	for i := 0; i < resourceLogs.Len(); i++ {
+		metadataMap := maps.Clone(baseMetadata)
+		p.actions.ProcessResource(metadataMap, resourceLogs.At(i).Resource().Attributes())
+
+		groupKey := p.actions.GroupKey(metadataMap)
+		g, ok := groups[groupKey]
+		if !ok {
+			g = &group{metadata: metadataMap}
+			groups[groupKey] = g
+		}
+		g.indices = append(g.indices, i)
+	}
+
+	// All ResourceLogs share the same metadata, pass original data without copying.
+	if len(groups) == 1 {
+		for _, g := range groups {
+			clientInfo.Metadata = client.NewMetadata(g.metadata)
+			return p.next.ConsumeLogs(client.NewContext(ctx, clientInfo), ld)
+		}
+	}
+
+	var errs []error
+	for _, g := range groups {
+		clientInfo.Metadata = client.NewMetadata(g.metadata)
+		newCtx := client.NewContext(ctx, clientInfo)
+		logs := plog.NewLogs()
+		for _, idx := range g.indices {
+			resourceLogs.At(idx).CopyTo(logs.ResourceLogs().AppendEmpty())
+		}
+		if err := p.next.ConsumeLogs(newCtx, logs); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func (*logsProcessor) Capabilities() consumer.Capabilities {

--- a/processor/attributestocontextprocessor/logs_test.go
+++ b/processor/attributestocontextprocessor/logs_test.go
@@ -5,6 +5,7 @@ package attributestocontextprocessor
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,12 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/plog"
 )
+
+var singleKeyCfg = &Config{
+	Actions: []ActionKeyValue{
+		{Key: "cwlogs.log_group", FromResourceAttribute: "cwlogs.log_group"},
+	},
+}
 
 func TestLogsProcessor(t *testing.T) {
 	cfg := &Config{
@@ -58,21 +65,15 @@ func (*mockLogsConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{}
 }
 
-func TestLogsProcessor_MultipleResourceLogs_LastWins(t *testing.T) {
-	cfg := &Config{
-		Actions: []ActionKeyValue{
-			{Key: "cwlogs.log_group", FromResourceAttribute: "cwlogs.log_group"},
-		},
-	}
-
-	var capturedCtx context.Context
+func TestLogsProcessor_MultipleResourceLogs_PerResourceContext(t *testing.T) {
+	var calls []context.Context
 	next := &mockLogsConsumer{
 		consumeFunc: func(ctx context.Context, _ plog.Logs) error {
-			capturedCtx = ctx
+			calls = append(calls, ctx)
 			return nil
 		},
 	}
-	processor := newLogsProcessor(cfg, next)
+	processor := newLogsProcessor(singleKeyCfg, next)
 
 	logs := plog.NewLogs()
 	rl1 := logs.ResourceLogs().AppendEmpty()
@@ -84,17 +85,51 @@ func TestLogsProcessor_MultipleResourceLogs_LastWins(t *testing.T) {
 	err := processor.ConsumeLogs(ctx, logs)
 
 	assert.NoError(t, err)
-	clientInfo := client.FromContext(capturedCtx)
-	assert.Equal(t, []string{"/second"}, clientInfo.Metadata.Get("cwlogs.log_group"))
+	assert.Len(t, calls, 2)
+	groups := map[string]bool{}
+	for _, c := range calls {
+		groups[client.FromContext(c).Metadata.Get("cwlogs.log_group")[0]] = true
+	}
+	assert.True(t, groups["/first"])
+	assert.True(t, groups["/second"])
+}
+
+func TestLogsProcessor_GroupsByMetadata(t *testing.T) {
+	var callLogs []plog.Logs
+	next := &mockLogsConsumer{
+		consumeFunc: func(_ context.Context, ld plog.Logs) error {
+			callLogs = append(callLogs, ld)
+			return nil
+		},
+	}
+	processor := newLogsProcessor(singleKeyCfg, next)
+
+	logs := plog.NewLogs()
+	rl1 := logs.ResourceLogs().AppendEmpty()
+	rl1.Resource().Attributes().PutStr("cwlogs.log_group", "/app")
+	rl1.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("log1")
+	rl2 := logs.ResourceLogs().AppendEmpty()
+	rl2.Resource().Attributes().PutStr("cwlogs.log_group", "/platform")
+	rl2.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("log2")
+	rl3 := logs.ResourceLogs().AppendEmpty()
+	rl3.Resource().Attributes().PutStr("cwlogs.log_group", "/app")
+	rl3.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("log3")
+
+	ctx := client.NewContext(t.Context(), client.Info{})
+	err := processor.ConsumeLogs(ctx, logs)
+
+	assert.NoError(t, err)
+	assert.Len(t, callLogs, 2)
+	// One group has 2 ResourceLogs, the other has 1
+	counts := map[int]int{}
+	for _, ld := range callLogs {
+		counts[ld.ResourceLogs().Len()]++
+	}
+	assert.Equal(t, 1, counts[2]) // /app group
+	assert.Equal(t, 1, counts[1]) // /platform group
 }
 
 func TestLogsProcessor_PreservesUpstreamMetadata(t *testing.T) {
-	cfg := &Config{
-		Actions: []ActionKeyValue{
-			{Key: "cwlogs.log_group", FromResourceAttribute: "cwlogs.log_group"},
-		},
-	}
-
 	var capturedCtx context.Context
 	next := &mockLogsConsumer{
 		consumeFunc: func(ctx context.Context, _ plog.Logs) error {
@@ -102,7 +137,7 @@ func TestLogsProcessor_PreservesUpstreamMetadata(t *testing.T) {
 			return nil
 		},
 	}
-	processor := newLogsProcessor(cfg, next)
+	processor := newLogsProcessor(singleKeyCfg, next)
 
 	logs := plog.NewLogs()
 	rl := logs.ResourceLogs().AppendEmpty()
@@ -121,12 +156,6 @@ func TestLogsProcessor_PreservesUpstreamMetadata(t *testing.T) {
 }
 
 func TestLogsProcessor_MissingAttribute_SkipsSilently(t *testing.T) {
-	cfg := &Config{
-		Actions: []ActionKeyValue{
-			{Key: "cwlogs.log_group", FromResourceAttribute: "cwlogs.log_group"},
-		},
-	}
-
 	var capturedCtx context.Context
 	next := &mockLogsConsumer{
 		consumeFunc: func(ctx context.Context, _ plog.Logs) error {
@@ -134,7 +163,7 @@ func TestLogsProcessor_MissingAttribute_SkipsSilently(t *testing.T) {
 			return nil
 		},
 	}
-	processor := newLogsProcessor(cfg, next)
+	processor := newLogsProcessor(singleKeyCfg, next)
 
 	logs := plog.NewLogs()
 	logs.ResourceLogs().AppendEmpty() // no attributes
@@ -145,6 +174,108 @@ func TestLogsProcessor_MissingAttribute_SkipsSilently(t *testing.T) {
 	assert.NoError(t, err)
 	clientInfo := client.FromContext(capturedCtx)
 	assert.Nil(t, clientInfo.Metadata.Get("cwlogs.log_group"))
+}
+
+func TestLogsProcessor_ErrorsAreJoined(t *testing.T) {
+	errFirst := errors.New("first failed")
+	errSecond := errors.New("second failed")
+	var callCount int
+	next := &mockLogsConsumer{
+		consumeFunc: func(_ context.Context, _ plog.Logs) error {
+			callCount++
+			if callCount == 1 {
+				return errFirst
+			}
+			return errSecond
+		},
+	}
+	processor := newLogsProcessor(singleKeyCfg, next)
+
+	logs := plog.NewLogs()
+	rl1 := logs.ResourceLogs().AppendEmpty()
+	rl1.Resource().Attributes().PutStr("cwlogs.log_group", "/first")
+	rl2 := logs.ResourceLogs().AppendEmpty()
+	rl2.Resource().Attributes().PutStr("cwlogs.log_group", "/second")
+
+	ctx := client.NewContext(t.Context(), client.Info{})
+	err := processor.ConsumeLogs(ctx, logs)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, errFirst)
+	assert.ErrorIs(t, err, errSecond)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestLogsProcessor_PartialError(t *testing.T) {
+	errFail := errors.New("downstream failed")
+	var callCount int
+	next := &mockLogsConsumer{
+		consumeFunc: func(_ context.Context, _ plog.Logs) error {
+			callCount++
+			if callCount == 1 {
+				return errFail
+			}
+			return nil
+		},
+	}
+	processor := newLogsProcessor(singleKeyCfg, next)
+
+	logs := plog.NewLogs()
+	rl1 := logs.ResourceLogs().AppendEmpty()
+	rl1.Resource().Attributes().PutStr("cwlogs.log_group", "/first")
+	rl2 := logs.ResourceLogs().AppendEmpty()
+	rl2.Resource().Attributes().PutStr("cwlogs.log_group", "/second")
+
+	ctx := client.NewContext(t.Context(), client.Info{})
+	err := processor.ConsumeLogs(ctx, logs)
+
+	assert.ErrorIs(t, err, errFail)
+	assert.Equal(t, 2, callCount, "should still call next for all groups")
+}
+
+func TestLogsProcessor_MultipleResourceLogs_SameMetadata(t *testing.T) {
+	var callLogs []plog.Logs
+	next := &mockLogsConsumer{
+		consumeFunc: func(_ context.Context, ld plog.Logs) error {
+			callLogs = append(callLogs, ld)
+			return nil
+		},
+	}
+	processor := newLogsProcessor(singleKeyCfg, next)
+
+	logs := plog.NewLogs()
+	rl1 := logs.ResourceLogs().AppendEmpty()
+	rl1.Resource().Attributes().PutStr("cwlogs.log_group", "/app")
+	rl1.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("log1")
+	rl2 := logs.ResourceLogs().AppendEmpty()
+	rl2.Resource().Attributes().PutStr("cwlogs.log_group", "/app")
+	rl2.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("log2")
+
+	ctx := client.NewContext(t.Context(), client.Info{})
+	err := processor.ConsumeLogs(ctx, logs)
+
+	assert.NoError(t, err)
+	assert.Len(t, callLogs, 1)
+	// Should pass original data (both ResourceLogs) in a single call.
+	assert.Equal(t, 2, callLogs[0].ResourceLogs().Len())
+}
+
+func TestLogsProcessor_EmptyInput(t *testing.T) {
+	var called bool
+	next := &mockLogsConsumer{
+		consumeFunc: func(_ context.Context, ld plog.Logs) error {
+			called = true
+			assert.Equal(t, 0, ld.ResourceLogs().Len())
+			return nil
+		},
+	}
+	processor := newLogsProcessor(singleKeyCfg, next)
+
+	ctx := client.NewContext(t.Context(), client.Info{})
+	err := processor.ConsumeLogs(ctx, plog.NewLogs())
+
+	assert.NoError(t, err)
+	assert.True(t, called, "should still call next with empty payload")
 }
 
 func TestLogsProcessorStart(t *testing.T) {

--- a/processor/attributestocontextprocessor/logs_test.go
+++ b/processor/attributestocontextprocessor/logs_test.go
@@ -129,7 +129,7 @@ func TestLogsProcessor_GroupsByMetadata(t *testing.T) {
 	assert.Equal(t, 1, counts[1]) // /platform group
 }
 
-func TestLogsProcessor_PreservesUpstreamMetadata(t *testing.T) {
+func TestLogsProcessor_PreservesExistingMetadata(t *testing.T) {
 	var capturedCtx context.Context
 	next := &mockLogsConsumer{
 		consumeFunc: func(ctx context.Context, _ plog.Logs) error {
@@ -143,16 +143,45 @@ func TestLogsProcessor_PreservesUpstreamMetadata(t *testing.T) {
 	rl := logs.ResourceLogs().AppendEmpty()
 	rl.Resource().Attributes().PutStr("cwlogs.log_group", "/my/group")
 
-	upstream := client.NewMetadata(map[string][]string{
+	existing := client.NewMetadata(map[string][]string{
 		"existing-key": {"existing-value"},
 	})
-	ctx := client.NewContext(t.Context(), client.Info{Metadata: upstream})
+	ctx := client.NewContext(t.Context(), client.Info{Metadata: existing})
 	err := processor.ConsumeLogs(ctx, logs)
 
 	assert.NoError(t, err)
 	clientInfo := client.FromContext(capturedCtx)
 	assert.Equal(t, []string{"/my/group"}, clientInfo.Metadata.Get("cwlogs.log_group"))
 	assert.Equal(t, []string{"existing-value"}, clientInfo.Metadata.Get("existing-key"))
+}
+
+func TestLogsProcessor_PreservesExistingMetadata_MultiGroup(t *testing.T) {
+	var calls []context.Context
+	next := &mockLogsConsumer{
+		consumeFunc: func(ctx context.Context, _ plog.Logs) error {
+			calls = append(calls, ctx)
+			return nil
+		},
+	}
+	processor := newLogsProcessor(singleKeyCfg, next)
+
+	logs := plog.NewLogs()
+	rl1 := logs.ResourceLogs().AppendEmpty()
+	rl1.Resource().Attributes().PutStr("cwlogs.log_group", "/first")
+	rl2 := logs.ResourceLogs().AppendEmpty()
+	rl2.Resource().Attributes().PutStr("cwlogs.log_group", "/second")
+
+	existing := client.NewMetadata(map[string][]string{
+		"x-forwarded-for": {"10.0.0.1"},
+	})
+	ctx := client.NewContext(t.Context(), client.Info{Metadata: existing})
+	err := processor.ConsumeLogs(ctx, logs)
+
+	assert.NoError(t, err)
+	assert.Len(t, calls, 2)
+	for _, c := range calls {
+		assert.Equal(t, []string{"10.0.0.1"}, client.FromContext(c).Metadata.Get("x-forwarded-for"))
+	}
 }
 
 func TestLogsProcessor_MissingAttribute_SkipsSilently(t *testing.T) {


### PR DESCRIPTION
#### Description
When a single `plog.Logs` contains multiple `ResourceLog`s with different attribute sets, the processor iterates all `ResourceLog`s and overwrites a single metadata map. Only the last `ResourceLog`'s values are on the context that gets passed to the next consumer. If the context controls destination routing, this can cause logs to be sent to the wrong destination.

The change groups `ResourceLog`s by their computed metadata values. The processor now makes one `ConsumeLogs` call per group with a new context for each. If there's a failure for one of the groups, the processor will still attempt the others.

#### Testing
Added unit tests for the grouping.
