### PR TITLE
[internal/awsutilv2] Add web identity support

### DIFF
--- a/extension/sigv4authextension/README.md
+++ b/extension/sigv4authextension/README.md
@@ -29,12 +29,14 @@ The configuration fields are as follows:
 The extension also accepts the standard AWS session settings — `region`, `profile`,
 `shared_credentials_file`, `local_mode`, `role_arn`, `external_id`, `endpoint`,
 `proxy_address`, `certificate_file_path`, `no_verify_ssl`, `request_timeout_seconds`,
-`imds_retries`. See [`AWSSessionSettings`](../../internal/aws/awsutilv2/awsconfig.go)
+`imds_retries`, `web_identity_token_file`. See [`AWSSessionSettings`](../../internal/aws/awsutilv2/awsconfig.go)
 for the full list.
 
 > Note that an attempt will be made to obtain a valid `region` from the endpoint of the service you are exporting to. `region` is differentiated from `assume_role.sts_region` to handle cross region authentication. See the [list of AWS regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html).
 
 > The role ARN can be set via either `role_arn` (inherited from session settings) or `assume_role.arn`, but not both.
+
+> The web identity token file can be set via either `web_identity_token_file` (inherited from session settings) or `assume_role.web_identity_token_file`, but not both. A `role_arn` or `assume_role.arn` must be provided when using web identity.
 
 
 ## Assume Role

--- a/extension/sigv4authextension/config.go
+++ b/extension/sigv4authextension/config.go
@@ -35,8 +35,11 @@ func (cfg *Config) Validate() error {
 	if cfg.AssumeRole.ARN != "" && cfg.RoleARN != "" {
 		return errors.New("role_arn and assume_role.arn cannot both be set")
 	}
-	if cfg.AssumeRole.WebIdentityTokenFile != "" && cfg.resolvedRoleARN() == "" {
-		return errors.New("must specify role_arn or assume_role.arn when using WebIdentityTokenFile")
+	if cfg.AssumeRole.WebIdentityTokenFile != "" && cfg.WebIdentityTokenFile != "" {
+		return errors.New("web_identity_token_file and assume_role.web_identity_token_file cannot both be set")
+	}
+	if cfg.resolvedWebIdentityTokenFile() != "" && cfg.resolvedRoleARN() == "" {
+		return errors.New("must specify role_arn or assume_role.arn when using web_identity_token_file")
 	}
 	return nil
 }
@@ -56,4 +59,14 @@ func (cfg *Config) resolvedSTSRegion() string {
 		return cfg.AssumeRole.STSRegion
 	}
 	return cfg.Region
+}
+
+// resolvedWebIdentityTokenFile returns whichever of cfg.AWSSessionSettings.WebIdentityTokenFile
+// (top-level) or cfg.AssumeRole.WebIdentityTokenFile is set. Validate guarantees they are not
+// both set; returns "" when neither is set.
+func (cfg *Config) resolvedWebIdentityTokenFile() string {
+	if cfg.AssumeRole.WebIdentityTokenFile != "" {
+		return cfg.AssumeRole.WebIdentityTokenFile
+	}
+	return cfg.WebIdentityTokenFile
 }

--- a/extension/sigv4authextension/config_test.go
+++ b/extension/sigv4authextension/config_test.go
@@ -94,6 +94,32 @@ func TestValidateRejectsBothRoleARNs(t *testing.T) {
 	assert.ErrorContains(t, err, "role_arn and assume_role.arn cannot both be set")
 }
 
+func TestValidateRejectsBothWebIdentityTokenFiles(t *testing.T) {
+	cfg := &Config{
+		AWSSessionSettings: awsutilv2.AWSSessionSettings{
+			RoleARN:              "arn:aws:iam::123456789012:role/role1",
+			WebIdentityTokenFile: "/path/to/token",
+		},
+		AssumeRole: AssumeRole{
+			WebIdentityTokenFile: "/other/path/to/token",
+		},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "web_identity_token_file and assume_role.web_identity_token_file cannot both be set")
+}
+
+func TestValidateRequiresRoleARNWithWebIdentity(t *testing.T) {
+	cfg := &Config{
+		AWSSessionSettings: awsutilv2.AWSSessionSettings{
+			WebIdentityTokenFile: "/path/to/token",
+		},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "must specify role_arn or assume_role.arn when using web_identity_token_file")
+}
+
 func TestResolvedRoleARN(t *testing.T) {
 	const sessionARN = "arn:aws:iam::123456789012:role/session"
 	const assumeARN = "arn:aws:iam::123456789012:role/assume"

--- a/extension/sigv4authextension/extension.go
+++ b/extension/sigv4authextension/extension.go
@@ -74,10 +74,14 @@ func resolveCredentialsProvider(ctx context.Context, logger *zap.Logger, cfg *Co
 	settings.WebIdentityTokenFile = cfg.resolvedWebIdentityTokenFile()
 	awscfg, err := awsutilv2.GetAWSConfig(ctx, logger, &settings)
 	if err != nil {
-		return nil, fmt.Errorf("could not retrieve credential provider: %w", err)
+		return nil, fmt.Errorf("could not retrieve credentials provider: %w", err)
 	}
-	if _, err = awscfg.Credentials.Retrieve(ctx); err != nil {
-		return nil, fmt.Errorf("could not retrieve credential: %w", err)
+	// Skip eager Retrieve for web identity: the token may not be available yet at startup
+	// (e.g., projected SA token in Kubernetes) and will be read on first use.
+	if settings.WebIdentityTokenFile == "" {
+		if _, err = awscfg.Credentials.Retrieve(ctx); err != nil {
+			return nil, fmt.Errorf("could not retrieve credentials: %w", err)
+		}
 	}
 	return &awscfg.Credentials, nil
 }

--- a/extension/sigv4authextension/extension.go
+++ b/extension/sigv4authextension/extension.go
@@ -10,9 +10,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	sigv4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/extension/extensionauth"
@@ -68,70 +65,19 @@ func newSigv4Extension(cfg *Config, credsProvider *aws.CredentialsProvider, awsS
 	}
 }
 
-// resolveCredentialsProvider dispatches to the appropriate credential source (web-identity or
-// the shared-credentials chain) and returns the resolved provider.
+// resolveCredentialsProvider builds an aws.CredentialsProvider by delegating to awsutilv2.GetAWSConfig
+// which handles shared credentials, web identity, and assume-role.
 func resolveCredentialsProvider(ctx context.Context, logger *zap.Logger, cfg *Config) (*aws.CredentialsProvider, error) {
-	var (
-		creds *aws.CredentialsProvider
-		err   error
-	)
-	if cfg.AssumeRole.WebIdentityTokenFile != "" {
-		creds, err = getCredsProviderFromWebIdentityConfig(ctx, logger, cfg)
-	} else {
-		creds, err = getCredsProviderFromConfig(ctx, logger, cfg)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("could not retrieve credential provider: %w", err)
-	}
-	return creds, nil
-}
-
-// getCredsProviderFromConfig builds an aws.CredentialsProvider from cfg: shared profile/file when
-// configured, otherwise the SDK default chain, optionally wrapped with regional/partitional assume-role.
-func getCredsProviderFromConfig(ctx context.Context, logger *zap.Logger, cfg *Config) (*aws.CredentialsProvider, error) {
 	settings := cfg.AWSSessionSettings
 	settings.Region = cfg.resolvedSTSRegion()
 	settings.RoleARN = cfg.resolvedRoleARN()
+	settings.WebIdentityTokenFile = cfg.resolvedWebIdentityTokenFile()
 	awscfg, err := awsutilv2.GetAWSConfig(ctx, logger, &settings)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not retrieve credential provider: %w", err)
 	}
 	if _, err = awscfg.Credentials.Retrieve(ctx); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not retrieve credential: %w", err)
 	}
-	return &awscfg.Credentials, nil
-}
-
-func getCredsProviderFromWebIdentityConfig(ctx context.Context, logger *zap.Logger, cfg *Config) (*aws.CredentialsProvider, error) {
-	tokenRetriever := stscreds.IdentityTokenRetriever(
-		stscreds.IdentityTokenFile(cfg.AssumeRole.WebIdentityTokenFile),
-	)
-	_, err := tokenRetriever.GetIdentityToken()
-	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve token file: %w", err)
-	}
-
-	stsRegion := cfg.resolvedSTSRegion()
-	roleARN := cfg.resolvedRoleARN()
-	awscfg, err := awsconfig.LoadDefaultConfig(ctx,
-		awsconfig.WithWebIdentityRoleCredentialOptions(
-			func(options *stscreds.WebIdentityRoleOptions) {
-				options.TokenRetriever = tokenRetriever
-				options.RoleARN = roleARN
-			},
-		),
-		awsconfig.WithRegion(stsRegion),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("unable to load AWS configuration: %w", err)
-	}
-	stsSvc := sts.NewFromConfig(awscfg)
-
-	provider := stscreds.NewWebIdentityRoleProvider(stsSvc, roleARN, tokenRetriever)
-	awscfg.Credentials = aws.NewCredentialsCache(provider)
-	logger.Debug("Web identity credentials provider configured",
-		zap.String("role-arn", roleARN),
-		zap.String("region", stsRegion))
-
 	return &awscfg.Credentials, nil
 }

--- a/extension/sigv4authextension/extension_test.go
+++ b/extension/sigv4authextension/extension_test.go
@@ -176,9 +176,9 @@ func TestResolveCredentialsProvider_WebIdentity(t *testing.T) {
 	defer mockServer.Close()
 
 	tests := []struct {
-		name        string
-		cfg         *Config
-		shouldError bool
+		name               string
+		cfg                *Config
+		retrieveShouldFail bool
 	}{
 		{
 			"valid_token_with_assume_role_arn",
@@ -225,24 +225,19 @@ func TestResolveCredentialsProvider_WebIdentity(t *testing.T) {
 			true,
 		},
 	}
-	// run tests
 	for _, testcase := range tests {
 		t.Run(testcase.name, func(t *testing.T) {
 			isolateAWSEnv(t)
 			credsProvider, err := resolveCredentialsProvider(t.Context(), zap.NewNop(), testcase.cfg)
-
-			if testcase.shouldError {
-				assert.Error(t, err)
-				assert.Nil(t, credsProvider)
-				return
-			}
-
 			require.NoError(t, err)
 			require.NotNil(t, credsProvider)
 
-			creds, err := (*credsProvider).Retrieve(t.Context())
-			require.NoError(t, err)
-			assert.Equal(t, "AKIAWEBIDENTITY", creds.AccessKeyID)
+			_, err = (*credsProvider).Retrieve(t.Context())
+			if testcase.retrieveShouldFail {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/extension/sigv4authextension/extension_test.go
+++ b/extension/sigv4authextension/extension_test.go
@@ -6,6 +6,7 @@ package sigv4authextension
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"testing"
 
@@ -57,7 +58,7 @@ func TestRoundTripper(t *testing.T) {
 	assert.Equal(t, awsCredsProvider, si.credsProvider)
 }
 
-func TestGetCredsProviderFromConfig(t *testing.T) {
+func TestResolveCredentialsProvider(t *testing.T) {
 	tests := []struct {
 		name            string
 		cfg             *Config
@@ -94,7 +95,7 @@ func TestGetCredsProviderFromConfig(t *testing.T) {
 			isolateAWSEnv(t)
 			t.Setenv("AWS_ACCESS_KEY_ID", testcase.AccessKeyID)
 			t.Setenv("AWS_SECRET_ACCESS_KEY", testcase.SecretAccessKey)
-			credsProvider, err := getCredsProviderFromConfig(t.Context(), zap.NewNop(), testcase.cfg)
+			credsProvider, err := resolveCredentialsProvider(t.Context(), zap.NewNop(), testcase.cfg)
 
 			if testcase.shouldError {
 				assert.Error(t, err)
@@ -112,7 +113,7 @@ func TestGetCredsProviderFromConfig(t *testing.T) {
 	}
 }
 
-func TestGetCredsProviderFromConfig_SharedCredentialsFile(t *testing.T) {
+func TestResolveCredentialsProvider_SharedCredentialsFile(t *testing.T) {
 	isolateAWSEnv(t)
 	cfg := &Config{
 		AWSSessionSettings: awsutilv2.AWSSessionSettings{
@@ -123,7 +124,7 @@ func TestGetCredsProviderFromConfig_SharedCredentialsFile(t *testing.T) {
 		AssumeRole: AssumeRole{STSRegion: "region"},
 	}
 
-	credsProvider, err := getCredsProviderFromConfig(t.Context(), zap.NewNop(), cfg)
+	credsProvider, err := resolveCredentialsProvider(t.Context(), zap.NewNop(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, credsProvider)
 
@@ -132,7 +133,7 @@ func TestGetCredsProviderFromConfig_SharedCredentialsFile(t *testing.T) {
 	assert.Equal(t, "FAKEAWSACCESSKEYID00", creds.AccessKeyID)
 }
 
-func TestGetCredsProviderFromConfig_Profile(t *testing.T) {
+func TestResolveCredentialsProvider_Profile(t *testing.T) {
 	isolateAWSEnv(t)
 	cfg := &Config{
 		AWSSessionSettings: awsutilv2.AWSSessionSettings{
@@ -144,7 +145,7 @@ func TestGetCredsProviderFromConfig_Profile(t *testing.T) {
 		AssumeRole: AssumeRole{STSRegion: "region"},
 	}
 
-	credsProvider, err := getCredsProviderFromConfig(t.Context(), zap.NewNop(), cfg)
+	credsProvider, err := resolveCredentialsProvider(t.Context(), zap.NewNop(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, credsProvider)
 
@@ -153,7 +154,7 @@ func TestGetCredsProviderFromConfig_Profile(t *testing.T) {
 	assert.Equal(t, "FAKEAWSACCESSKEYID01", creds.AccessKeyID)
 }
 
-func TestGetCredsProviderFromConfig_LocalMode(t *testing.T) {
+func TestResolveCredentialsProvider_LocalMode(t *testing.T) {
 	isolateAWSEnv(t)
 	cfg := &Config{
 		AWSSessionSettings: awsutilv2.AWSSessionSettings{
@@ -165,12 +166,15 @@ func TestGetCredsProviderFromConfig_LocalMode(t *testing.T) {
 		AssumeRole: AssumeRole{STSRegion: "region"},
 	}
 
-	credsProvider, err := getCredsProviderFromConfig(t.Context(), zap.NewNop(), cfg)
+	credsProvider, err := resolveCredentialsProvider(t.Context(), zap.NewNop(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, credsProvider)
 }
 
-func TestGetCredsProviderFromWebIdentityConfig(t *testing.T) {
+func TestResolveCredentialsProvider_WebIdentity(t *testing.T) {
+	mockServer := mockAssumeRoleWithWebIdentityServer()
+	defer mockServer.Close()
+
 	tests := []struct {
 		name        string
 		cfg         *Config
@@ -179,7 +183,7 @@ func TestGetCredsProviderFromWebIdentityConfig(t *testing.T) {
 		{
 			"valid_token_with_assume_role_arn",
 			&Config{
-				AWSSessionSettings: awsutilv2.AWSSessionSettings{Region: "region"},
+				AWSSessionSettings: awsutilv2.AWSSessionSettings{Region: "region", Endpoint: mockServer.URL},
 				Service:            "service",
 				AssumeRole:         AssumeRole{ARN: "arn:aws:iam::123456789012:role/my_role", WebIdentityTokenFile: "testdata/token_file"},
 			},
@@ -189,8 +193,9 @@ func TestGetCredsProviderFromWebIdentityConfig(t *testing.T) {
 			"valid_token_with_role_arn",
 			&Config{
 				AWSSessionSettings: awsutilv2.AWSSessionSettings{
-					Region:  "region",
-					RoleARN: "arn:aws:iam::123456789012:role/my_role",
+					Region:   "region",
+					RoleARN:  "arn:aws:iam::123456789012:role/my_role",
+					Endpoint: mockServer.URL,
 				},
 				Service:    "service",
 				AssumeRole: AssumeRole{WebIdentityTokenFile: "testdata/token_file"},
@@ -198,9 +203,22 @@ func TestGetCredsProviderFromWebIdentityConfig(t *testing.T) {
 			false,
 		},
 		{
+			"valid_token_with_top_level_web_identity_token_file",
+			&Config{
+				AWSSessionSettings: awsutilv2.AWSSessionSettings{
+					Region:               "region",
+					RoleARN:              "arn:aws:iam::123456789012:role/my_role",
+					WebIdentityTokenFile: "testdata/token_file",
+					Endpoint:             mockServer.URL,
+				},
+				Service: "service",
+			},
+			false,
+		},
+		{
 			"missing_token_file",
 			&Config{
-				AWSSessionSettings: awsutilv2.AWSSessionSettings{Region: "region"},
+				AWSSessionSettings: awsutilv2.AWSSessionSettings{Region: "region", Endpoint: mockServer.URL},
 				Service:            "service",
 				AssumeRole:         AssumeRole{ARN: "arn:aws:iam::123456789012:role/my_role", WebIdentityTokenFile: "testdata/no_token_file"},
 			},
@@ -211,7 +229,7 @@ func TestGetCredsProviderFromWebIdentityConfig(t *testing.T) {
 	for _, testcase := range tests {
 		t.Run(testcase.name, func(t *testing.T) {
 			isolateAWSEnv(t)
-			credsProvider, err := getCredsProviderFromWebIdentityConfig(t.Context(), zap.NewNop(), testcase.cfg)
+			credsProvider, err := resolveCredentialsProvider(t.Context(), zap.NewNop(), testcase.cfg)
 
 			if testcase.shouldError {
 				assert.Error(t, err)
@@ -222,9 +240,9 @@ func TestGetCredsProviderFromWebIdentityConfig(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, credsProvider)
 
-			// Should always error out as we are not providing a real token.
-			_, err = (*credsProvider).Retrieve(t.Context())
-			assert.Error(t, err)
+			creds, err := (*credsProvider).Retrieve(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, "AKIAWEBIDENTITY", creds.AccessKeyID)
 		})
 	}
 }
@@ -258,6 +276,18 @@ func TestCloneRequest(t *testing.T) {
 			assert.Equal(t, testcase.request.Body, r2.Body)
 		})
 	}
+}
+
+func mockAssumeRoleWithWebIdentityServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = w.Write([]byte(`<AssumeRoleWithWebIdentityResponse><AssumeRoleWithWebIdentityResult><Credentials>` +
+			`<AccessKeyId>AKIAWEBIDENTITY</AccessKeyId>` +
+			`<SecretAccessKey>web-identity-secret</SecretAccessKey>` +
+			`<SessionToken>web-identity-token</SessionToken>` +
+			`<Expiration>2099-01-01T00:00:00Z</Expiration>` +
+			`</Credentials></AssumeRoleWithWebIdentityResult></AssumeRoleWithWebIdentityResponse>`))
+	}))
 }
 
 func mockCredentials() *aws.CredentialsProvider {

--- a/extension/sigv4authextension/go.mod
+++ b/extension/sigv4authextension/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.12
 	github.com/aws/aws-sdk-go-v2/config v1.32.23
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.22
-	github.com/aws/aws-sdk-go-v2/service/sts v1.43.2
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutilv2 v0.124.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.30.0
@@ -32,6 +31,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.31.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.5 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.43.2 // indirect
 	github.com/aws/smithy-go v1.27.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/internal/aws/awsutilv2/awsconfig.go
+++ b/internal/aws/awsutilv2/awsconfig.go
@@ -37,6 +37,9 @@ type AWSSessionSettings struct {
 	IMDSRetries int `mapstructure:"imds_retries"`
 	// ExternalID is used to verify third party role assumption.
 	ExternalID string `mapstructure:"external_id,omitempty"`
+	// WebIdentityTokenFile is the path to a file containing an OIDC token used with
+	// STS AssumeRoleWithWebIdentity. When set, RoleARN must also be set.
+	WebIdentityTokenFile string `mapstructure:"web_identity_token_file,omitempty"`
 }
 
 // httpClientSettings is the subset of AWSSessionSettings that determines the HTTP transport

--- a/internal/aws/awsutilv2/conn.go
+++ b/internal/aws/awsutilv2/conn.go
@@ -47,9 +47,6 @@ type loadConfigFn func(ctx context.Context, optFns ...func(*config.LoadOptions) 
 // endpoint is used (cached for subsequent calls). When AMZ_SOURCE_ARN and AMZ_SOURCE_ACCOUNT
 // are both set in the environment, confused-deputy headers are injected on assume-role calls.
 //
-// When settings.WebIdentityTokenFile is set, a missing or unreadable token file does NOT cause
-// GetAWSConfig to return an error; the failure surfaces on the first Credentials.Retrieve call.
-//
 // Returns an error if the HTTP client cannot be built, the region cannot be resolved, the
 // initial config load fails after a retry, or WebIdentityTokenFile is set without RoleARN.
 func GetAWSConfig(ctx context.Context, logger *zap.Logger, settings *AWSSessionSettings) (aws.Config, error) {
@@ -89,13 +86,10 @@ func getAWSConfig(ctx context.Context, logger *zap.Logger, settings *AWSSessionS
 		if settings.RoleARN == "" {
 			return aws.Config{}, errors.New("role_arn must be set when web_identity_token_file is configured")
 		}
-		tokenRetriever := stscreds.IdentityTokenFile(settings.WebIdentityTokenFile)
-		if _, err = tokenRetriever.GetIdentityToken(); err != nil {
-			logger.Error("Unable to read web identity token file", zap.String("file", settings.WebIdentityTokenFile), zap.Error(err))
-		}
 		cfg.Credentials = aws.NewCredentialsCache(
-			stscreds.NewWebIdentityRoleProvider(newWebIdentityClient(cfg), settings.RoleARN, tokenRetriever),
+			newWebIdentityCredentialsProvider(cfg, settings.RoleARN, region, stscreds.IdentityTokenFile(settings.WebIdentityTokenFile)),
 		)
+		logger.Debug("Using web identity credentials provider")
 	} else {
 		// Eagerly retrieve credentials so the source can be logged and an IMDS-fallback warning
 		// surfaced when applicable. A successful return does not guarantee credentials are valid.
@@ -103,17 +97,18 @@ func getAWSConfig(ctx context.Context, logger *zap.Logger, settings *AWSSessionS
 		cred, err = cfg.Credentials.Retrieve(ctx)
 		if err != nil {
 			logger.Error("Failed to get credential from session", zap.Error(err))
-		} else {
-			logger.Debug("Using credential", zap.String("access-key", cred.AccessKeyID), zap.String("source", cred.Source))
-			if cred.Source == ec2rolecreds.ProviderName {
-				warnIfUnusedSharedConfigFiles(logger)
-			}
 		}
 
 		if settings.RoleARN != "" {
 			cfg.Credentials = aws.NewCredentialsCache(
-				newStsCredentialsProvider(cfg, settings.RoleARN, region, settings.ExternalID),
+				newAssumeRoleCredentialsProvider(cfg, settings.RoleARN, region, settings.ExternalID),
 			)
+			logger.Debug("Using assume role credentials provider")
+		} else if err == nil {
+			logger.Debug("Using credential", zap.String("access-key", cred.AccessKeyID), zap.String("source", cred.Source))
+			if cred.Source == ec2rolecreds.ProviderName {
+				warnIfUnusedSharedConfigFiles(logger)
+			}
 		}
 	}
 

--- a/internal/aws/awsutilv2/conn.go
+++ b/internal/aws/awsutilv2/conn.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"go.uber.org/zap"
 )
@@ -46,8 +47,11 @@ type loadConfigFn func(ctx context.Context, optFns ...func(*config.LoadOptions) 
 // endpoint is used (cached for subsequent calls). When AMZ_SOURCE_ARN and AMZ_SOURCE_ACCOUNT
 // are both set in the environment, confused-deputy headers are injected on assume-role calls.
 //
-// Returns an error if the HTTP client cannot be built, the region cannot be resolved, or the
-// initial config load fails after a retry.
+// When settings.WebIdentityTokenFile is set, a missing or unreadable token file does NOT cause
+// GetAWSConfig to return an error; the failure surfaces on the first Credentials.Retrieve call.
+//
+// Returns an error if the HTTP client cannot be built, the region cannot be resolved, the
+// initial config load fails after a retry, or WebIdentityTokenFile is set without RoleARN.
 func GetAWSConfig(ctx context.Context, logger *zap.Logger, settings *AWSSessionSettings) (aws.Config, error) {
 	return getAWSConfig(ctx, logger, settings, initialLoadRetryDelay, config.LoadDefaultConfig)
 }
@@ -81,22 +85,36 @@ func getAWSConfig(ctx context.Context, logger *zap.Logger, settings *AWSSessionS
 		return aws.Config{}, err
 	}
 
-	// Eagerly retrieve credentials so the source can be logged and an IMDS-fallback warning
-	// surfaced when applicable. A successful return does not guarantee credentials are valid.
-	cred, err := cfg.Credentials.Retrieve(ctx)
-	if err != nil {
-		logger.Error("Failed to get credential from session", zap.Error(err))
-	} else {
-		logger.Debug("Using credential", zap.String("access-key", cred.AccessKeyID), zap.String("source", cred.Source))
-		if cred.Source == ec2rolecreds.ProviderName {
-			warnIfUnusedSharedConfigFiles(logger)
+	if settings.WebIdentityTokenFile != "" {
+		if settings.RoleARN == "" {
+			return aws.Config{}, errors.New("role_arn must be set when web_identity_token_file is configured")
 		}
-	}
-
-	if settings.RoleARN != "" {
+		tokenRetriever := stscreds.IdentityTokenFile(settings.WebIdentityTokenFile)
+		if _, err = tokenRetriever.GetIdentityToken(); err != nil {
+			logger.Error("Unable to read web identity token file", zap.String("file", settings.WebIdentityTokenFile), zap.Error(err))
+		}
 		cfg.Credentials = aws.NewCredentialsCache(
-			newStsCredentialsProvider(cfg, settings.RoleARN, region, settings.ExternalID),
+			stscreds.NewWebIdentityRoleProvider(newWebIdentityClient(cfg), settings.RoleARN, tokenRetriever),
 		)
+	} else {
+		// Eagerly retrieve credentials so the source can be logged and an IMDS-fallback warning
+		// surfaced when applicable. A successful return does not guarantee credentials are valid.
+		var cred aws.Credentials
+		cred, err = cfg.Credentials.Retrieve(ctx)
+		if err != nil {
+			logger.Error("Failed to get credential from session", zap.Error(err))
+		} else {
+			logger.Debug("Using credential", zap.String("access-key", cred.AccessKeyID), zap.String("source", cred.Source))
+			if cred.Source == ec2rolecreds.ProviderName {
+				warnIfUnusedSharedConfigFiles(logger)
+			}
+		}
+
+		if settings.RoleARN != "" {
+			cfg.Credentials = aws.NewCredentialsCache(
+				newStsCredentialsProvider(cfg, settings.RoleARN, region, settings.ExternalID),
+			)
+		}
 	}
 
 	return cfg, nil

--- a/internal/aws/awsutilv2/conn_test.go
+++ b/internal/aws/awsutilv2/conn_test.go
@@ -571,6 +571,63 @@ func TestGetAWSConfig_WebIdentityFromEnv(t *testing.T) {
 		"web identity provider should have attempted to read the configured token file")
 }
 
+// TestGetAWSConfig_WebIdentityFromSettings confirms that an explicit WebIdentityTokenFile in settings
+// configures a web identity provider.
+func TestGetAWSConfig_WebIdentityFromSettings(t *testing.T) {
+	isolateAWSEnv(t)
+	stubWebIdentityClient(t)
+
+	cfg, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{
+		Region:               testRegion,
+		LocalMode:            true,
+		RoleARN:              testRoleARN,
+		WebIdentityTokenFile: "testdata/token_file",
+	})
+	require.NoError(t, err)
+
+	creds, err := cfg.Credentials.Retrieve(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "AKIAWEBIDENTITY", creds.AccessKeyID)
+	assert.Equal(t, "web-identity-secret", creds.SecretAccessKey)
+	assert.Equal(t, "web-identity-token", creds.SessionToken)
+}
+
+// TestGetAWSConfig_WebIdentityFromSettings_MissingFile confirms that a non-existent token file
+// logs an error but still returns a config (fails lazily on Retrieve).
+func TestGetAWSConfig_WebIdentityFromSettings_MissingFile(t *testing.T) {
+	isolateAWSEnv(t)
+	stubWebIdentityClient(t)
+
+	core, observed := observer.New(zap.ErrorLevel)
+	cfg, err := GetAWSConfig(t.Context(), zap.New(core), &AWSSessionSettings{
+		Region:               testRegion,
+		LocalMode:            true,
+		RoleARN:              testRoleARN,
+		WebIdentityTokenFile: "/nonexistent/token_file",
+	})
+	require.NoError(t, err)
+
+	logs := observed.FilterMessage("Unable to read web identity token file")
+	assert.Equal(t, 1, logs.Len(), "expected a log entry for unreadable token file")
+
+	_, retrieveErr := cfg.Credentials.Retrieve(t.Context())
+	require.Error(t, retrieveErr)
+}
+
+// TestGetAWSConfig_WebIdentityFromSettings_MissingRoleARN confirms that WebIdentityTokenFile
+// without RoleARN returns a clear configuration error.
+func TestGetAWSConfig_WebIdentityFromSettings_MissingRoleARN(t *testing.T) {
+	isolateAWSEnv(t)
+
+	_, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{
+		Region:               testRegion,
+		LocalMode:            true,
+		WebIdentityTokenFile: "testdata/token_file",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "role_arn")
+}
+
 // TestGetAWSConfig_ContainerCredentialsFromEnv confirms AWS_CONTAINER_CREDENTIALS_FULL_URI activates the
 // container provider, using a local httptest server that returns synthetic credentials.
 func TestGetAWSConfig_ContainerCredentialsFromEnv(t *testing.T) {

--- a/internal/aws/awsutilv2/conn_test.go
+++ b/internal/aws/awsutilv2/conn_test.go
@@ -593,22 +593,17 @@ func TestGetAWSConfig_WebIdentityFromSettings(t *testing.T) {
 }
 
 // TestGetAWSConfig_WebIdentityFromSettings_MissingFile confirms that a non-existent token file
-// logs an error but still returns a config (fails lazily on Retrieve).
+// does not fail GetAWSConfig but fails lazily on Retrieve.
 func TestGetAWSConfig_WebIdentityFromSettings_MissingFile(t *testing.T) {
 	isolateAWSEnv(t)
-	stubWebIdentityClient(t)
 
-	core, observed := observer.New(zap.ErrorLevel)
-	cfg, err := GetAWSConfig(t.Context(), zap.New(core), &AWSSessionSettings{
+	cfg, err := GetAWSConfig(t.Context(), zap.NewNop(), &AWSSessionSettings{
 		Region:               testRegion,
 		LocalMode:            true,
 		RoleARN:              testRoleARN,
 		WebIdentityTokenFile: "/nonexistent/token_file",
 	})
 	require.NoError(t, err)
-
-	logs := observed.FilterMessage("Unable to read web identity token file")
-	assert.Equal(t, 1, logs.Len(), "expected a log entry for unreadable token file")
 
 	_, retrieveErr := cfg.Credentials.Retrieve(t.Context())
 	require.Error(t, retrieveErr)

--- a/internal/aws/awsutilv2/mock_test.go
+++ b/internal/aws/awsutilv2/mock_test.go
@@ -10,9 +10,13 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -69,6 +73,31 @@ func tempCredentialsFile(t *testing.T) string {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(path, content, 0o600))
 	return path
+}
+
+var _ stscreds.AssumeRoleWithWebIdentityAPIClient = (*mockWebIdentityAPIClient)(nil)
+
+func stubWebIdentityClient(t *testing.T) {
+	t.Helper()
+	orig := newWebIdentityClient
+	newWebIdentityClient = func(aws.Config) stscreds.AssumeRoleWithWebIdentityAPIClient {
+		return mockWebIdentityAPIClient{}
+	}
+	t.Cleanup(func() { newWebIdentityClient = orig })
+}
+
+type mockWebIdentityAPIClient struct{}
+
+func (mockWebIdentityAPIClient) AssumeRoleWithWebIdentity(context.Context, *sts.AssumeRoleWithWebIdentityInput, ...func(*sts.Options)) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+	expiry := time.Now().Add(time.Hour)
+	return &sts.AssumeRoleWithWebIdentityOutput{
+		Credentials: &types.Credentials{
+			AccessKeyId:     aws.String("AKIAWEBIDENTITY"),
+			SecretAccessKey: aws.String("web-identity-secret"),
+			SessionToken:    aws.String("web-identity-token"),
+			Expiration:      &expiry,
+		},
+	}, nil
 }
 
 // isolateAWSEnv clears AWS-related env vars and points the SDK at fake config paths so GetAWSConfig

--- a/internal/aws/awsutilv2/sts.go
+++ b/internal/aws/awsutilv2/sts.go
@@ -56,19 +56,13 @@ func (p *stsCredentialsProvider) Retrieve(ctx context.Context) (aws.Credentials,
 
 var getPartitionPrimaryRegion = awsv2.GetPartitionPrimaryRegion
 
-// newStsCredentialsProvider returns a credentials provider that assumes roleARN at the regional
-// STS endpoint. When the region's partition primary is known, the provider falls back to that
-// primary on RegionDisabledException; otherwise the bare regional provider is returned and no
-// fallback is attempted.
-func newStsCredentialsProvider(cfg aws.Config, roleARN, region, externalID string) aws.CredentialsProvider {
+// newRegionalFallbackCredentialsProvider builds a credentials provider from the given builder function,
+// with fallback to the partition's primary STS endpoint on RegionDisabledException. The builder
+// receives a regional aws.Config and returns a provider for that region.
+func newRegionalFallbackCredentialsProvider(cfg aws.Config, region string, build func(aws.Config) aws.CredentialsProvider) aws.CredentialsProvider {
 	regionalCfg := cfg.Copy()
 	regionalCfg.Region = region
-	opts := func(o *stscreds.AssumeRoleOptions) {
-		if externalID != "" {
-			o.ExternalID = &externalID
-		}
-	}
-	regional := stscreds.NewAssumeRoleProvider(newAssumeRoleClient(regionalCfg), roleARN, opts)
+	regional := build(regionalCfg)
 
 	fallback := getPartitionPrimaryRegion(region)
 	if fallback == "" {
@@ -78,7 +72,7 @@ func newStsCredentialsProvider(cfg aws.Config, roleARN, region, externalID strin
 	partitionalCfg.Region = fallback
 	return &stsCredentialsProvider{
 		regional:    regional,
-		partitional: stscreds.NewAssumeRoleProvider(newAssumeRoleClient(partitionalCfg), roleARN, opts),
+		partitional: build(partitionalCfg),
 	}
 }
 
@@ -87,9 +81,31 @@ var newAssumeRoleClient = func(cfg aws.Config) stscreds.AssumeRoleAPIClient {
 	return newStsClient(cfg)
 }
 
+// newAssumeRoleCredentialsProvider returns a credentials provider that assumes roleARN via STS
+// AssumeRole, with regional/partitional fallback on RegionDisabledException.
+func newAssumeRoleCredentialsProvider(cfg aws.Config, roleARN, region, externalID string) aws.CredentialsProvider {
+	return newRegionalFallbackCredentialsProvider(cfg, region, func(regionalCfg aws.Config) aws.CredentialsProvider {
+		opts := func(o *stscreds.AssumeRoleOptions) {
+			if externalID != "" {
+				o.ExternalID = &externalID
+			}
+		}
+		return stscreds.NewAssumeRoleProvider(newAssumeRoleClient(regionalCfg), roleARN, opts)
+	})
+}
+
 // newWebIdentityClient is overrideable in tests.
 var newWebIdentityClient = func(cfg aws.Config) stscreds.AssumeRoleWithWebIdentityAPIClient {
 	return newStsClient(cfg)
+}
+
+// newWebIdentityCredentialsProvider returns a credentials provider that exchanges a web identity
+// token for temporary credentials via STS AssumeRoleWithWebIdentity, with regional/partitional
+// fallback on RegionDisabledException.
+func newWebIdentityCredentialsProvider(cfg aws.Config, roleARN, region string, tokenRetriever stscreds.IdentityTokenRetriever) aws.CredentialsProvider {
+	return newRegionalFallbackCredentialsProvider(cfg, region, func(regionalCfg aws.Config) aws.CredentialsProvider {
+		return stscreds.NewWebIdentityRoleProvider(newWebIdentityClient(regionalCfg), roleARN, tokenRetriever)
+	})
 }
 
 // newStsClient creates an STS client and, when both confused-deputy environment variables are set, appends

--- a/internal/aws/awsutilv2/sts.go
+++ b/internal/aws/awsutilv2/sts.go
@@ -83,12 +83,19 @@ func newStsCredentialsProvider(cfg aws.Config, roleARN, region, externalID strin
 }
 
 // newAssumeRoleClient is overrideable in tests.
-var newAssumeRoleClient = newStsClient
+var newAssumeRoleClient = func(cfg aws.Config) stscreds.AssumeRoleAPIClient {
+	return newStsClient(cfg)
+}
+
+// newWebIdentityClient is overrideable in tests.
+var newWebIdentityClient = func(cfg aws.Config) stscreds.AssumeRoleWithWebIdentityAPIClient {
+	return newStsClient(cfg)
+}
 
 // newStsClient creates an STS client and, when both confused-deputy environment variables are set, appends
 // headers that let resource-based policies limit the service's permissions to a specific resource.
 // See https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html
-func newStsClient(cfg aws.Config) stscreds.AssumeRoleAPIClient {
+func newStsClient(cfg aws.Config) *sts.Client {
 	var optFns []func(*sts.Options)
 	sourceAccount := os.Getenv(envSourceAccount)
 	sourceArn := os.Getenv(envSourceArn)

--- a/internal/aws/awsutilv2/sts_test.go
+++ b/internal/aws/awsutilv2/sts_test.go
@@ -84,7 +84,9 @@ func TestStsCredentialsProvider_Retrieve(t *testing.T) {
 		t.Cleanup(func() { getPartitionPrimaryRegion = orig })
 		getPartitionPrimaryRegion = func(string) string { return "" }
 
-		provider := newStsCredentialsProvider(aws.Config{}, testRoleARN, testRegion, "")
+		provider := newRegionalFallbackCredentialsProvider(aws.Config{}, testRegion, func(cfg aws.Config) aws.CredentialsProvider {
+			return stscreds.NewAssumeRoleProvider(newAssumeRoleClient(cfg), testRoleARN)
+		})
 		require.NotNil(t, provider)
 		_, wrapped := provider.(*stsCredentialsProvider)
 		assert.False(t, wrapped)
@@ -93,8 +95,10 @@ func TestStsCredentialsProvider_Retrieve(t *testing.T) {
 	})
 }
 
-func TestNewStsCredentialsProvider(t *testing.T) {
-	provider := newStsCredentialsProvider(aws.Config{}, testRoleARN, testRegion, "")
+func TestNewRegionalCredentialsProvider(t *testing.T) {
+	provider := newRegionalFallbackCredentialsProvider(aws.Config{}, testRegion, func(cfg aws.Config) aws.CredentialsProvider {
+		return stscreds.NewAssumeRoleProvider(newAssumeRoleClient(cfg), testRoleARN)
+	})
 
 	assert.NotNil(t, provider)
 	stsProvider, ok := provider.(*stsCredentialsProvider)

--- a/internal/aws/awsutilv2/testdata/token_file
+++ b/internal/aws/awsutilv2/testdata/token_file
@@ -1,0 +1,1 @@
+fake-oidc-token


### PR DESCRIPTION
#### Description
Adds web identity token file support to `awsutilv2.AWSSessionSettings` and simplifies `sigv4auth` extension to delegate web identity credential resolution to `awsutilv2` instead of maintaining its own implementation.

When configured, replaces the credential provider with the WebIdentityRoleProvider. By centralizing the support into the shared credential chain, other AWS components like `awscloudwatchlogsprovisioner` extension can benefit from it.

#### Testing
Added unit tests to both packages with mock STS servers to isolate the tests. Built CWA and deployed RPM. `sigv4auth` with a fake token results in an attempted `AssumeRoleWithWebIdentity` with an `InvalidIdentityToken` rejection.