### PR TITLE
[extension/awscloudwatchlogsprovisioner] Fix data drop from concurrent log group provisioning

### DIFF
--- a/extension/awscloudwatchlogsprovisionerextension/README.md
+++ b/extension/awscloudwatchlogsprovisionerextension/README.md
@@ -16,7 +16,7 @@ This extension is designed for use with the `otlphttp` exporter to send logs to 
 |----------------------------------|------------|------------------------------------------------------------------|
 | `region`                         | (required) | AWS region for CloudWatch Logs API calls                         |
 | `additional_auth`                | (none)     | Inner auth extension for request signing (typically `sigv4auth`) |
-| `logs_provision_failure_backoff` | `30s`      | TTL for negative cache entries after a creation failure          |
+| `logs_provision_failure_backoff` | `5s`       | TTL for negative cache entries after a creation failure          |
 
 The extension also accepts the standard AWS session settings — `profile`, `shared_credentials_file`,
 `local_mode`, `role_arn`, `external_id`, `endpoint`, `proxy_address`, `certificate_file_path`,

--- a/extension/awscloudwatchlogsprovisionerextension/config.go
+++ b/extension/awscloudwatchlogsprovisionerextension/config.go
@@ -28,7 +28,7 @@ type Config struct {
 
 	// LogsProvisionFailureBackoff is the TTL for negative cache entries.
 	// During this period, the extension won't retry creation for the same (group, stream) pair.
-	// Default: 30s.
+	// Default: 5s.
 	LogsProvisionFailureBackoff time.Duration `mapstructure:"logs_provision_failure_backoff"`
 }
 

--- a/extension/awscloudwatchlogsprovisionerextension/config_test.go
+++ b/extension/awscloudwatchlogsprovisionerextension/config_test.go
@@ -15,7 +15,7 @@ func TestConfig_Defaults(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 
 	assert.Equal(t, 10, cfg.RequestTimeoutSeconds)
-	assert.Equal(t, 30*time.Second, cfg.LogsProvisionFailureBackoff)
+	assert.Equal(t, 5*time.Second, cfg.LogsProvisionFailureBackoff)
 	assert.Nil(t, cfg.AdditionalAuth)
 	assert.Empty(t, cfg.Region)
 }

--- a/extension/awscloudwatchlogsprovisionerextension/cwlogsclient.go
+++ b/extension/awscloudwatchlogsprovisionerextension/cwlogsclient.go
@@ -53,6 +53,11 @@ func isAlreadyExists(err error) bool {
 	return errors.As(err, &alreadyExists)
 }
 
+func isOperationAborted(err error) bool {
+	var aborted *types.OperationAbortedException
+	return errors.As(err, &aborted)
+}
+
 func isNotFound(err error) bool {
 	var notFound *types.ResourceNotFoundException
 	return errors.As(err, &notFound)

--- a/extension/awscloudwatchlogsprovisionerextension/cwlogsclient.go
+++ b/extension/awscloudwatchlogsprovisionerextension/cwlogsclient.go
@@ -31,7 +31,10 @@ func (c *defaultCWLogsClient) CreateLogGroup(ctx context.Context, logGroupName s
 	_, err := c.svc.CreateLogGroup(ctx, &cloudwatchlogs.CreateLogGroupInput{
 		LogGroupName: aws.String(logGroupName),
 	})
-	if err != nil && !isAlreadyExists(err) {
+	// AlreadyExists: group was created before us.
+	// OperationAborted: another concurrent create is in flight.
+	// Both mean the group exists or will exist momentarily.
+	if err != nil && !isAlreadyExists(err) && !isOperationAborted(err) {
 		return err
 	}
 	return nil

--- a/extension/awscloudwatchlogsprovisionerextension/cwlogsclient_test.go
+++ b/extension/awscloudwatchlogsprovisionerextension/cwlogsclient_test.go
@@ -9,19 +9,76 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
+	"io"
 	"math/big"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutilv2"
 )
+
+// newStubbedCWLogsClient returns a defaultCWLogsClient whose SDK client sends
+// requests to the given RoundTripper instead of the network. The SDK's real
+// serialization and error deserialization still run.
+func newStubbedCWLogsClient(rt roundTripperFunc) *defaultCWLogsClient {
+	svc := cloudwatchlogs.New(cloudwatchlogs.Options{
+		Region:           "us-east-1",
+		Credentials:      aws.AnonymousCredentials{},
+		HTTPClient:       &http.Client{Transport: rt},
+		RetryMaxAttempts: 1,
+	})
+	return &defaultCWLogsClient{svc: svc}
+}
+
+// awsJSONError builds an AWS JSON protocol error response.
+func awsJSONError(errType, message string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header: http.Header{
+			"Content-Type":     []string{"application/x-amz-json-1.1"},
+			"X-Amzn-Errortype": []string{errType},
+		},
+		Body: io.NopCloser(strings.NewReader(`{"__type":"` + errType + `","message":"` + message + `"}`)),
+	}
+}
+
+func TestDefaultClient_CreateLogGroup_PropagatesOperationAborted(t *testing.T) {
+	client := newStubbedCWLogsClient(func(*http.Request) (*http.Response, error) {
+		return awsJSONError("OperationAbortedException",
+			"Multiple concurrent requests to update the same resource were in conflict."), nil
+	})
+
+	err := client.CreateLogGroup(t.Context(), "/test/group")
+	require.Error(t, err)
+	assert.True(t, isOperationAborted(err))
+}
+
+func TestDefaultClient_CreateLogGroup_SwallowsAlreadyExists(t *testing.T) {
+	client := newStubbedCWLogsClient(func(*http.Request) (*http.Response, error) {
+		return awsJSONError("ResourceAlreadyExistsException", "The specified log group already exists"), nil
+	})
+
+	assert.NoError(t, client.CreateLogGroup(t.Context(), "/test/group"))
+}
+
+func TestDefaultClient_CreateLogGroup_PropagatesOtherErrors(t *testing.T) {
+	client := newStubbedCWLogsClient(func(*http.Request) (*http.Response, error) {
+		return awsJSONError("AccessDeniedException", "not authorized"), nil
+	})
+
+	assert.Error(t, client.CreateLogGroup(t.Context(), "/test/group"))
+}
 
 // TestNewDefaultCWLogsClient_CABundle verifies the CA bundle flows into the SDK CW Logs client's
 // HTTP transport from either CertificateFilePath or AWS_CA_BUNDLE.

--- a/extension/awscloudwatchlogsprovisionerextension/cwlogsclient_test.go
+++ b/extension/awscloudwatchlogsprovisionerextension/cwlogsclient_test.go
@@ -53,15 +53,13 @@ func awsJSONError(errType, message string) *http.Response {
 	}
 }
 
-func TestDefaultClient_CreateLogGroup_PropagatesOperationAborted(t *testing.T) {
+func TestDefaultClient_CreateLogGroup_SwallowsOperationAborted(t *testing.T) {
 	client := newStubbedCWLogsClient(func(*http.Request) (*http.Response, error) {
 		return awsJSONError("OperationAbortedException",
 			"Multiple concurrent requests to update the same resource were in conflict."), nil
 	})
 
-	err := client.CreateLogGroup(t.Context(), "/test/group")
-	require.Error(t, err)
-	assert.True(t, isOperationAborted(err))
+	assert.NoError(t, client.CreateLogGroup(t.Context(), "/test/group"))
 }
 
 func TestDefaultClient_CreateLogGroup_SwallowsAlreadyExists(t *testing.T) {

--- a/extension/awscloudwatchlogsprovisionerextension/extension.go
+++ b/extension/awscloudwatchlogsprovisionerextension/extension.go
@@ -5,7 +5,6 @@ package awscloudwatchlogsprovisionerextension // import "github.com/open-telemet
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -26,9 +25,17 @@ var (
 	_ extensioncapabilities.Dependent = (*provisionerExtension)(nil)
 )
 
+const streamRetryDelay = 150 * time.Millisecond
+
 type cacheEntry struct {
 	success   bool
 	expiresAt time.Time // only used for failed entries
+}
+
+// inFailureBackoff reports whether the entry is a failed entry whose backoff
+// has not yet expired.
+func (ce cacheEntry) inFailureBackoff() bool {
+	return !ce.success && time.Now().Before(ce.expiresAt)
 }
 
 // cwLogsClient abstracts the CloudWatch Logs API for testability.
@@ -46,14 +53,17 @@ type provisionerExtension struct {
 	host   component.Host
 	client cwLogsClient
 
-	cache   sync.Map
-	sfGroup singleflight.Group
+	cache            sync.Map
+	sfProvision      singleflight.Group
+	sfCreateGroup    singleflight.Group
+	streamRetryDelay time.Duration
 }
 
 func newExtension(logger *zap.Logger, cfg *Config) *provisionerExtension {
 	return &provisionerExtension{
-		logger: logger,
-		cfg:    cfg,
+		logger:           logger,
+		cfg:              cfg,
+		streamRetryDelay: streamRetryDelay,
 	}
 }
 
@@ -132,7 +142,7 @@ func (rt *provisionerRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	logStream := req.Header.Get("x-aws-log-stream")
 
 	if logGroup != "" && logStream != "" {
-		wasProvisioned := rt.ext.ensure(req.Context(), logGroup, logStream)
+		rt.ext.ensure(req.Context(), logGroup, logStream)
 
 		resp, err := rt.base.RoundTrip(req)
 		if err != nil {
@@ -140,17 +150,16 @@ func (rt *provisionerRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 		}
 
 		// If the CW OTLP endpoint returns 400 with "does not exist", evict the
-		// cache entry. If ensure() returned true (log group was previously known
-		// to exist), return an error to trigger the exporter's retry logic — on
-		// retry, ensure() re-provisions the log group/stream.
+		// success cache entry and return an error so the exporter retries
+		// instead of treating the 400 as a permanent failure and dropping the
+		// data. On a retry after the failure backoff expires, ensure()
+		// re-provisions the log group/stream.
 		if resp.StatusCode == http.StatusBadRequest {
 			body, readErr := io.ReadAll(resp.Body)
 			resp.Body.Close()
 			if readErr == nil && strings.Contains(string(body), "does not exist") {
 				rt.ext.evictSuccessfulEntry(logGroup, logStream)
-				if wasProvisioned {
-					return nil, errors.New("destination log group/stream (that did exist) does not exist, evicted cache entry for re-provisioning for next retry")
-				}
+				return nil, fmt.Errorf("destination log group %q/stream %q does not exist, will re-provision on next retry", logGroup, logStream)
 			}
 			resp.Body = io.NopCloser(strings.NewReader(string(body)))
 		}
@@ -178,16 +187,16 @@ func (e *provisionerExtension) ensure(ctx context.Context, logGroup, logStream s
 		if ce.success {
 			return true
 		}
-		if time.Now().Before(ce.expiresAt) {
+		if ce.inFailureBackoff() {
 			return false
 		}
 	}
 
-	_, _, _ = e.sfGroup.Do(key, func() (any, error) {
+	_, _, _ = e.sfProvision.Do(key, func() (any, error) {
 		// Double-check cache after acquiring singleflight.
 		if entry, ok := e.cache.Load(key); ok {
 			ce := entry.(cacheEntry)
-			if ce.success || time.Now().Before(ce.expiresAt) {
+			if ce.success || ce.inFailureBackoff() {
 				return nil, nil
 			}
 		}
@@ -240,14 +249,28 @@ func (e *provisionerExtension) provision(ctx context.Context, logGroup, logStrea
 		"Log group not found, creating",
 		zap.String("logGroup", logGroup),
 	)
-	if grpErr := e.client.CreateLogGroup(ctx, logGroup); grpErr != nil {
+	_, grpErr, _ := e.sfCreateGroup.Do(logGroup, func() (any, error) {
+		// Use Background so the shared create is not canceled when the winning
+		// request's context expires. The SDK HTTP client has its own timeout.
+		return nil, e.client.CreateLogGroup(context.Background(), logGroup)
+	})
+	switch {
+	case grpErr == nil:
+		// Group created or already exists.
+	case isOperationAborted(grpErr):
+		// Another process is creating the group. Wait briefly for it to land.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(e.streamRetryDelay):
+		}
+	default:
 		return fmt.Errorf("CreateLogGroup %q: %w", logGroup, grpErr)
 	}
 
 	if retryErr := e.client.CreateLogStream(ctx, logGroup, logStream); retryErr != nil {
 		return fmt.Errorf("CreateLogStream %q in %q (retry): %w", logStream, logGroup, retryErr)
 	}
-
 	return nil
 }
 

--- a/extension/awscloudwatchlogsprovisionerextension/extension.go
+++ b/extension/awscloudwatchlogsprovisionerextension/extension.go
@@ -254,18 +254,15 @@ func (e *provisionerExtension) provision(ctx context.Context, logGroup, logStrea
 		// request's context expires. The SDK HTTP client has its own timeout.
 		return nil, e.client.CreateLogGroup(context.Background(), logGroup)
 	})
-	switch {
-	case grpErr == nil:
-		// Group created or already exists.
-	case isOperationAborted(grpErr):
-		// Another process is creating the group. Wait briefly for it to land.
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(e.streamRetryDelay):
-		}
-	default:
+	if grpErr != nil {
 		return fmt.Errorf("CreateLogGroup %q: %w", logGroup, grpErr)
+	}
+
+	// Brief pause since the group may not be visible to CreateLogStream yet.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(e.streamRetryDelay):
 	}
 
 	if retryErr := e.client.CreateLogStream(ctx, logGroup, logStream); retryErr != nil {

--- a/extension/awscloudwatchlogsprovisionerextension/extension_test.go
+++ b/extension/awscloudwatchlogsprovisionerextension/extension_test.go
@@ -489,11 +489,9 @@ func TestFailureBackoff_ExpiresAndRetries(t *testing.T) {
 	assert.Equal(t, int32(2), mockClient.groupCalls.Load(), "should retry after backoff expires")
 }
 
-func TestProvision_StreamRetrySucceedsAfterOperationAborted(t *testing.T) {
+func TestProvision_StreamRetrySucceedsAfterGroupCreate(t *testing.T) {
 	notFoundErr := &types.ResourceNotFoundException{Message: aws.String("not found")}
-	abortedErr := &types.OperationAbortedException{Message: aws.String("concurrent operation")}
 	mockClient := &mockCWLogsClient{
-		createGroupErr: abortedErr,
 		// Initial CreateLogStream hits NotFound; the retry after the delay succeeds.
 		createStreamFn: func(call int32) error {
 			if call == 1 {
@@ -511,11 +509,9 @@ func TestProvision_StreamRetrySucceedsAfterOperationAborted(t *testing.T) {
 	assert.Equal(t, int32(1), mockClient.groupCalls.Load())
 }
 
-func TestProvision_StreamRetryFailsAfterOperationAborted(t *testing.T) {
+func TestProvision_StreamRetryFailsAfterGroupCreate(t *testing.T) {
 	notFoundErr := &types.ResourceNotFoundException{Message: aws.String("not found")}
-	abortedErr := &types.OperationAbortedException{Message: aws.String("concurrent operation")}
 	mockClient := &mockCWLogsClient{
-		createGroupErr:  abortedErr,
 		createStreamErr: notFoundErr,
 	}
 
@@ -526,22 +522,6 @@ func TestProvision_StreamRetryFailsAfterOperationAborted(t *testing.T) {
 
 	assert.False(t, result)
 	// 1 initial + 1 retry after delay
-	assert.Equal(t, int32(2), mockClient.streamCalls.Load())
-}
-
-func TestProvision_NoDelayWhenGroupCreateSucceeds(t *testing.T) {
-	notFoundErr := &types.ResourceNotFoundException{Message: aws.String("not found")}
-	mockClient := &mockCWLogsClient{
-		createStreamErr: notFoundErr,
-	}
-
-	ext := newTestExtension(t, &Config{
-		LogsProvisionFailureBackoff: 60 * time.Second,
-	}, mockClient)
-	result := ext.ensure(t.Context(), "/test/group", "stream-e")
-
-	assert.False(t, result)
-	// 1 initial + 1 immediate retry (no delay since group create succeeded)
 	assert.Equal(t, int32(2), mockClient.streamCalls.Load())
 }
 

--- a/extension/awscloudwatchlogsprovisionerextension/extension_test.go
+++ b/extension/awscloudwatchlogsprovisionerextension/extension_test.go
@@ -6,6 +6,7 @@ package awscloudwatchlogsprovisionerextension
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -32,15 +33,25 @@ type mockCWLogsClient struct {
 	createStreamErr error
 	groupCalls      atomic.Int32
 	streamCalls     atomic.Int32
+	// Optional hooks. When set they take precedence over the fixed errors
+	// and receive the 1-based call count.
+	createGroupFn  func(call int32) error
+	createStreamFn func(call int32) error
 }
 
 func (m *mockCWLogsClient) CreateLogGroup(_ context.Context, _ string) error {
-	m.groupCalls.Add(1)
+	call := m.groupCalls.Add(1)
+	if m.createGroupFn != nil {
+		return m.createGroupFn(call)
+	}
 	return m.createGroupErr
 }
 
 func (m *mockCWLogsClient) CreateLogStream(_ context.Context, _, _ string) error {
-	m.streamCalls.Add(1)
+	call := m.streamCalls.Add(1)
+	if m.createStreamFn != nil {
+		return m.createStreamFn(call)
+	}
 	return m.createStreamErr
 }
 
@@ -90,6 +101,7 @@ func newTestExtension(t *testing.T, cfg *Config, mockClient *mockCWLogsClient) *
 	}
 	ext := newExtension(zaptest.NewLogger(t), cfg)
 	ext.client = mockClient
+	ext.streamRetryDelay = 1 * time.Millisecond
 	return ext
 }
 
@@ -174,28 +186,38 @@ func TestRoundTripper_MissingStream_SkipsProvisioning(t *testing.T) {
 	assert.Equal(t, int32(0), mockClient.streamCalls.Load(), "should not provision when stream header missing")
 }
 
+// newTest400RoundTripper wraps ext around a base transport that always
+// returns 400 with the given body.
+func newTest400RoundTripper(t *testing.T, ext *provisionerExtension, respBody string) http.RoundTripper {
+	t.Helper()
+	ext.host = &mockHost{extensions: map[component.ID]component.Component{}}
+	rt, err := ext.RoundTripper(roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       io.NopCloser(strings.NewReader(respBody)),
+		}, nil
+	}))
+	require.NoError(t, err)
+	return rt
+}
+
+func newLogsRequest(logGroup string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "https://logs.us-east-1.amazonaws.com/v1/logs", nil)
+	req.Header.Set("x-aws-log-group", logGroup)
+	req.Header.Set("x-aws-log-stream", "default")
+	return req
+}
+
+const doesNotExistBody = `{"message":"The specified log group does not exist."}`
+
 // Test: 400 with "does not exist" evicts cache and returns error for retry
 func TestRoundTripper_400DoesNotExist_EvictsAndReturnsError(t *testing.T) {
 	mockClient := &mockCWLogsClient{}
 	ext := newTestExtension(t, &Config{}, mockClient)
-	ext.host = &mockHost{extensions: map[component.ID]component.Component{}}
+	rt := newTest400RoundTripper(t, ext, doesNotExistBody)
 
-	base := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       io.NopCloser(strings.NewReader(`{"message":"The specified log group does not exist."}`)),
-		}, nil
-	})
-
-	rt, err := ext.RoundTripper(base)
-	require.NoError(t, err)
-
-	req := httptest.NewRequest(http.MethodPost, "https://logs.us-east-1.amazonaws.com/v1/logs", nil)
-	req.Header.Set("x-aws-log-group", "/test/group")
-	req.Header.Set("x-aws-log-stream", "default")
-
-	// First call: provisions, gets 400, evicts, returns error for retry
-	resp, err := rt.RoundTrip(req)
+	// Provisions, gets 400, evicts, returns error for retry
+	resp, err := rt.RoundTrip(newLogsRequest("/test/group"))
 	assert.Nil(t, resp)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "does not exist")
@@ -206,31 +228,18 @@ func TestRoundTripper_400DoesNotExist_EvictsAndReturnsError(t *testing.T) {
 func TestRoundTripper_400OtherError_NoEviction(t *testing.T) {
 	mockClient := &mockCWLogsClient{}
 	ext := newTestExtension(t, &Config{}, mockClient)
-	ext.host = &mockHost{extensions: map[component.ID]component.Component{}}
+	rt := newTest400RoundTripper(t, ext, `{"message":"Invalid log format"}`)
 
-	base := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       io.NopCloser(strings.NewReader(`{"message":"Invalid log format"}`)),
-		}, nil
-	})
-
-	rt, err := ext.RoundTripper(base)
-	require.NoError(t, err)
-
-	req := httptest.NewRequest(http.MethodPost, "https://logs.us-east-1.amazonaws.com/v1/logs", nil)
-	req.Header.Set("x-aws-log-group", "/test/group")
-	req.Header.Set("x-aws-log-stream", "default")
-
-	_, err = rt.RoundTrip(req)
+	_, err := rt.RoundTrip(newLogsRequest("/test/group"))
 	require.NoError(t, err)
 
 	// Only initial provision, no re-provision
 	assert.Equal(t, int32(1), mockClient.streamCalls.Load(), "should not re-provision for non-existence 400")
 }
 
-// Test: 400 "does not exist" with a failed cache entry does NOT evict (preserves backoff)
-func TestRoundTripper_400DoesNotExist_FailedEntry_NoEviction(t *testing.T) {
+// Test: 400 "does not exist" with a failed cache entry returns an error for
+// retry but preserves the failure backoff (no immediate re-provision).
+func TestRoundTripper_400DoesNotExist_FailedEntry_PreservesBackoff(t *testing.T) {
 	notFoundErr := &types.ResourceNotFoundException{Message: aws.String("not found")}
 	mockClient := &mockCWLogsClient{
 		createStreamErr: notFoundErr,
@@ -239,32 +248,42 @@ func TestRoundTripper_400DoesNotExist_FailedEntry_NoEviction(t *testing.T) {
 	ext := newTestExtension(t, &Config{
 		LogsProvisionFailureBackoff: 60 * time.Second,
 	}, mockClient)
-	ext.host = &mockHost{extensions: map[component.ID]component.Component{}}
+	rt := newTest400RoundTripper(t, ext, doesNotExistBody)
 
-	base := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       io.NopCloser(strings.NewReader(`{"message":"The specified log group does not exist."}`)),
-		}, nil
-	})
-
-	rt, err := ext.RoundTripper(base)
-	require.NoError(t, err)
-
-	req := httptest.NewRequest(http.MethodPost, "https://logs.us-east-1.amazonaws.com/v1/logs", nil)
-	req.Header.Set("x-aws-log-group", "/test/group")
-	req.Header.Set("x-aws-log-stream", "default")
-
-	// First call: ensure fails (access denied), caches failure entry
-	_, err = rt.RoundTrip(req)
-	require.NoError(t, err)
+	// First call: ensure fails (access denied), caches failure entry. The 400
+	// returns an error so the exporter retries instead of dropping.
+	_, err := rt.RoundTrip(newLogsRequest("/test/group"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
 	assert.Equal(t, int32(1), mockClient.groupCalls.Load())
 
-	// Second call: gets 400 "does not exist" but cache has failed entry — should NOT evict
-	_, err = rt.RoundTrip(req)
-	require.NoError(t, err)
-	// Still only 1 group call — backoff preserved, no retry
-	assert.Equal(t, int32(1), mockClient.groupCalls.Load(), "should not evict failed entry")
+	// Second call (exporter retry during backoff): failure entry not evicted,
+	// no re-provision attempt, still an error for the next retry.
+	_, err = rt.RoundTrip(newLogsRequest("/test/group"))
+	require.Error(t, err)
+	assert.Equal(t, int32(1), mockClient.groupCalls.Load(), "backoff should suppress re-provisioning")
+}
+
+// Test: provisioning interrupted by context cancellation caches nothing, and
+// the resulting 400 "does not exist" still returns an error to trigger retry
+// (previously this state silently dropped the data).
+func TestRoundTripper_400DoesNotExist_NoCacheEntry_ReturnsError(t *testing.T) {
+	mockClient := &mockCWLogsClient{createStreamErr: context.Canceled}
+	ext := newTestExtension(t, &Config{}, mockClient)
+	rt := newTest400RoundTripper(t, ext, doesNotExistBody)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	req := newLogsRequest("/test/no-cache").WithContext(ctx)
+
+	resp, err := rt.RoundTrip(req)
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+
+	// The interrupted provision must not have cached anything.
+	_, cached := ext.cache.Load(cacheKey("/test/no-cache", "default"))
+	assert.False(t, cached, "canceled provision should not cache a failure entry")
 }
 
 func TestEvictSuccessfulEntry(t *testing.T) {
@@ -468,4 +487,93 @@ func TestFailureBackoff_ExpiresAndRetries(t *testing.T) {
 
 	ext.ensure(t.Context(), "/test/group", "default")
 	assert.Equal(t, int32(2), mockClient.groupCalls.Load(), "should retry after backoff expires")
+}
+
+func TestProvision_StreamRetrySucceedsAfterOperationAborted(t *testing.T) {
+	notFoundErr := &types.ResourceNotFoundException{Message: aws.String("not found")}
+	abortedErr := &types.OperationAbortedException{Message: aws.String("concurrent operation")}
+	mockClient := &mockCWLogsClient{
+		createGroupErr: abortedErr,
+		// Initial CreateLogStream hits NotFound; the retry after the delay succeeds.
+		createStreamFn: func(call int32) error {
+			if call == 1 {
+				return notFoundErr
+			}
+			return nil
+		},
+	}
+
+	ext := newTestExtension(t, &Config{}, mockClient)
+	result := ext.ensure(t.Context(), "/test/group", "stream-b")
+
+	assert.True(t, result)
+	assert.Equal(t, int32(2), mockClient.streamCalls.Load())
+	assert.Equal(t, int32(1), mockClient.groupCalls.Load())
+}
+
+func TestProvision_StreamRetryFailsAfterOperationAborted(t *testing.T) {
+	notFoundErr := &types.ResourceNotFoundException{Message: aws.String("not found")}
+	abortedErr := &types.OperationAbortedException{Message: aws.String("concurrent operation")}
+	mockClient := &mockCWLogsClient{
+		createGroupErr:  abortedErr,
+		createStreamErr: notFoundErr,
+	}
+
+	ext := newTestExtension(t, &Config{
+		LogsProvisionFailureBackoff: 60 * time.Second,
+	}, mockClient)
+	result := ext.ensure(t.Context(), "/test/group", "stream-c")
+
+	assert.False(t, result)
+	// 1 initial + 1 retry after delay
+	assert.Equal(t, int32(2), mockClient.streamCalls.Load())
+}
+
+func TestProvision_NoDelayWhenGroupCreateSucceeds(t *testing.T) {
+	notFoundErr := &types.ResourceNotFoundException{Message: aws.String("not found")}
+	mockClient := &mockCWLogsClient{
+		createStreamErr: notFoundErr,
+	}
+
+	ext := newTestExtension(t, &Config{
+		LogsProvisionFailureBackoff: 60 * time.Second,
+	}, mockClient)
+	result := ext.ensure(t.Context(), "/test/group", "stream-e")
+
+	assert.False(t, result)
+	// 1 initial + 1 immediate retry (no delay since group create succeeded)
+	assert.Equal(t, int32(2), mockClient.streamCalls.Load())
+}
+
+func TestProvision_CreateLogGroupSingleflighted(t *testing.T) {
+	notFoundErr := &types.ResourceNotFoundException{Message: aws.String("not found")}
+	var streamExists atomic.Bool
+	mockClient := &mockCWLogsClient{
+		createGroupFn: func(_ int32) error {
+			time.Sleep(50 * time.Millisecond)
+			streamExists.Store(true)
+			return nil
+		},
+		createStreamFn: func(_ int32) error {
+			if streamExists.Load() {
+				return nil
+			}
+			return notFoundErr
+		},
+	}
+
+	ext := newTestExtension(t, &Config{}, mockClient)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(stream string) {
+			defer wg.Done()
+			result := ext.ensure(t.Context(), "/test/group", stream)
+			assert.True(t, result)
+		}(fmt.Sprintf("stream-%d", i))
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), mockClient.groupCalls.Load(), "concurrent provisions for the same group should share one CreateLogGroup call")
 }

--- a/extension/awscloudwatchlogsprovisionerextension/factory.go
+++ b/extension/awscloudwatchlogsprovisionerextension/factory.go
@@ -28,7 +28,7 @@ func createDefaultConfig() component.Config {
 	settings.RequestTimeoutSeconds = 10
 	return &Config{
 		AWSSessionSettings:          settings,
-		LogsProvisionFailureBackoff: 30 * time.Second,
+		LogsProvisionFailureBackoff: 5 * time.Second,
 	}
 }
 

--- a/extension/awscloudwatchlogsprovisionerextension/factory_test.go
+++ b/extension/awscloudwatchlogsprovisionerextension/factory_test.go
@@ -22,7 +22,7 @@ func TestNewFactory(t *testing.T) {
 func TestCreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	assert.Equal(t, 10, cfg.RequestTimeoutSeconds)
-	assert.Equal(t, 30*time.Second, cfg.LogsProvisionFailureBackoff)
+	assert.Equal(t, 5*time.Second, cfg.LogsProvisionFailureBackoff)
 	assert.Nil(t, cfg.AdditionalAuth)
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
 }


### PR DESCRIPTION
#### Description
The provisioner supports deduplication of log stream creation using singleflight, but does not deduplicate log group creation. This means that if multiple log streams are being created concurrently for the same log group, only one call can succeed. The others will get the `OperationAbortedException`, which will cause them to fail provisioning and enter a failure backoff of 30s. During that period of time, the CW OTLP endpoint returns 400 "does not exist", which the otlphttp exporter treats as a permanent error resulting in dropped data.

```
2026-07-16T21:03:33Z E! {"caller":"internal/queue_sender.go:56","msg":"Exporting failed. Dropping data.","error":"not retryable error: Permanent error: rpc error: code = InvalidArgument desc = error exporting items, request to https://logs.us-east-1.amazonaws.com/v1/logs responded with HTTP Status Code 400, Message=The specified log stream does not exist., Details=[]","dropped_items":1}
```

This PR adds:
- **CreateLogGroup deduplication using singleflight**: Similar to the per-log-stream singleflight, the per-log-group singleflight collapses concurrent creates for the same group into a single API call. The shared call uses a `context.Background()` instead of the request context so it isn't aborted unintentionally if the initiating request context expires. The API call goes through the SDK client, so the timeout set there is still enforced.
- **Handles OperationAbortedException**: If CreateLogGroup still returns a `OperationAbortedException` (some other process is creating the log group), the provisioner will wait 150ms before retrying CreateLogStream. This attempts to prevent the CreateLogStream from being called until after the log group has been created.
- **Allow exporter's to retry on 400 "does not exist"**: Updates the RoundTripper to return an error for this specific response to allow the exporter's `retry_on_failure` to take over. This will reduce data drops by giving the exporter more chances to retry and more opportunities for the log provisioner to retry as well.
- **Lowered default `logs_provision_failure_backoff` to 5s**: The exporter's default retry schedule is 5s initial, exponential, and jittered. If the default failure backoff remained at 30s, the exporter retries would not have a chance to retry the provisioning at least with the default exporter configuration.

#### Testing
Added unit tests and tested E2E on EC2. Verified provisioning and successful sends across 5 concurrently-tailed files writing to 2 log groups.

```json
{
  "agent": { "debug": true },
  "opentelemetry": {
    "collect": {
      "files": {
        "collect_list": [
          { "file_path": "/tmp/test-logs/race-a.log", "log_group_name": "/test-provisioner-fix/shared-group", "log_stream_name": "stream-a" },
          { "file_path": "/tmp/test-logs/race-b.log", "log_group_name": "/test-provisioner-fix/shared-group", "log_stream_name": "stream-b" },
          { "file_path": "/tmp/test-logs/race-c.log", "log_group_name": "/test-provisioner-fix/shared-group", "log_stream_name": "stream-c" },
          { "file_path": "/tmp/test-logs/race-d.log", "log_group_name": "/test-provisioner-fix/group-2", "log_stream_name": "stream-d" },
          { "file_path": "/tmp/test-logs/race-e.log", "log_group_name": "/test-provisioner-fix/group-2", "log_stream_name": "stream-e" },
          { "file_path": "/tmp/test-logs/race-default.log" }
        ]
      }
    }
  }
}
```

Can see the log groups being created.
```
2026-07-17T16:07:07Z D! {"caller":"...extension.go:248","msg":"Log group not found, creating","logGroup":"/test-provisioner-fix/shared-group"}
2026-07-17T16:07:07Z D! {"caller":"...extension.go:248","msg":"Log group not found, creating","logGroup":"/test-provisioner-fix/group-2"}
2026-07-17T16:07:07Z D! {"caller":"...extension.go:220","msg":"Successfully provisioned log group/stream","logGroup":"/test-provisioner-fix/shared-group","logStream":"stream-a"}
2026-07-17T16:07:07Z D! {"caller":"...extension.go:220","msg":"Successfully provisioned log group/stream","logGroup":"/test-provisioner-fix/group-2","logStream":"stream-d"}
```

We actually do see a `CreateLogStream` failure for one of the streams after the log group is successfully created, but it retries instead of dropping data.
```
2026-07-17T16:07:07Z W! {"caller":"...extension.go:211","msg":"Failed to create log group/stream","logGroup":"/test-provisioner-fix/group-2","logStream":"stream-e","backoff":5000000000,"error":"CreateLogStream \"stream-e\" in \"/test-provisioner-fix/group-2\" (retry): operation error CloudWatch Logs: CreateLogStream, https response error StatusCode: 400, RequestID: a7c0c5c3-d610-4648-b3c6-1fbf8f4e559c, ResourceNotFoundException: The specified log group does not exist."}
2026-07-17T16:07:07Z I! {"caller":"internal/retry_sender.go:133","msg":"Exporting failed. Will retry the request after interval.","error":"failed to make an HTTP request: Post \"https://logs.us-east-1.amazonaws.com/v1/logs\": destination log group \"/test-provisioner-fix/group-2\"/stream \"stream-e\" does not exist, will re-provision on next retry","interval":"5.777504402s"}
```

Confirmed that all events made it into the correct log streams.


