### PR TITLE
feat(mysqlreceiver): add InnoDB deadlocks and transaction metrics

### DIFF
--- a/.chloggen/mysqlreceiver-deadlocks.yaml
+++ b/.chloggen/mysqlreceiver-deadlocks.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mysqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add the `mysql.deadlocks` metric, sourced from `INFORMATION_SCHEMA.INNODB_METRICS` (`lock_deadlocks`).
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39217]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: The metric is disabled by default.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/mysqlreceiver-deadlocks.yaml
+++ b/.chloggen/mysqlreceiver-deadlocks.yaml
@@ -10,7 +10,7 @@ component: mysqlreceiver
 note: Add the `mysql.deadlocks` metric, sourced from `INFORMATION_SCHEMA.INNODB_METRICS` (`lock_deadlocks`).
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [XXXXX]
+issues: [617]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/mysqlreceiver-deadlocks.yaml
+++ b/.chloggen/mysqlreceiver-deadlocks.yaml
@@ -10,7 +10,7 @@ component: mysqlreceiver
 note: Add the `mysql.deadlocks` metric, sourced from `INFORMATION_SCHEMA.INNODB_METRICS` (`lock_deadlocks`).
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [39217]
+issues: [XXXXX]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/mysqlreceiver-innodb-trx-metrics.yaml
+++ b/.chloggen/mysqlreceiver-innodb-trx-metrics.yaml
@@ -10,7 +10,7 @@ component: mysqlreceiver
 note: Add the `mysql.history_list_length` and `mysql.active_transactions` metrics.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [39217]
+issues: [XXXXX]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/mysqlreceiver-innodb-trx-metrics.yaml
+++ b/.chloggen/mysqlreceiver-innodb-trx-metrics.yaml
@@ -10,7 +10,7 @@ component: mysqlreceiver
 note: Add the `mysql.history_list_length` and `mysql.active_transactions` metrics.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [XXXXX]
+issues: [617]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/mysqlreceiver-innodb-trx-metrics.yaml
+++ b/.chloggen/mysqlreceiver-innodb-trx-metrics.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mysqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add the `mysql.history_list_length` and `mysql.active_transactions` metrics.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39217]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  mysql.history_list_length is sourced from INFORMATION_SCHEMA.INNODB_METRICS (trx_rseg_history_len);
+  mysql.active_transactions from COUNT(*) of INFORMATION_SCHEMA.INNODB_TRX. Both are disabled by default.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/mysqlreceiver/client.go
+++ b/receiver/mysqlreceiver/client.go
@@ -25,6 +25,7 @@ type client interface {
 	getVersion() (*version.Version, error)
 	getGlobalStats() (map[string]string, error)
 	getInnodbStats() (map[string]string, error)
+	getInnodbTrxStats() (map[string]string, error)
 	getTableStats() ([]tableStats, error)
 	getTableIoWaitsStats() ([]tableIoWaitsStats, error)
 	getIndexIoWaitsStats() ([]indexIoWaitsStats, error)
@@ -319,7 +320,13 @@ func (c *mySQLClient) getGlobalStats() (map[string]string, error) {
 
 // getInnodbStats queries the db for innodb metrics.
 func (c *mySQLClient) getInnodbStats() (map[string]string, error) {
-	q := "SELECT name, count FROM information_schema.innodb_metrics WHERE name LIKE '%buffer_pool_size%' OR name = 'lock_deadlocks';"
+	q := "SELECT name, count FROM information_schema.innodb_metrics WHERE name LIKE '%buffer_pool_size%' OR name = 'lock_deadlocks' OR name = 'trx_rseg_history_len';"
+	return query(*c, q)
+}
+
+// getInnodbTrxStats queries the db for the number of currently active InnoDB transactions.
+func (c *mySQLClient) getInnodbTrxStats() (map[string]string, error) {
+	q := "SELECT 'active_transactions' AS name, COUNT(*) AS count FROM information_schema.innodb_trx;"
 	return query(*c, q)
 }
 

--- a/receiver/mysqlreceiver/client.go
+++ b/receiver/mysqlreceiver/client.go
@@ -319,7 +319,7 @@ func (c *mySQLClient) getGlobalStats() (map[string]string, error) {
 
 // getInnodbStats queries the db for innodb metrics.
 func (c *mySQLClient) getInnodbStats() (map[string]string, error) {
-	q := "SELECT name, count FROM information_schema.innodb_metrics WHERE name LIKE '%buffer_pool_size%';"
+	q := "SELECT name, count FROM information_schema.innodb_metrics WHERE name LIKE '%buffer_pool_size%' OR name = 'lock_deadlocks';"
 	return query(*c, q)
 }
 

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -366,6 +366,14 @@ metrics:
     enabled: true
 ```
 
+### mysql.active_transactions
+
+The number of currently active InnoDB transactions, from COUNT(*) of INFORMATION_SCHEMA.INNODB_TRX.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | false | Development |
+
 ### mysql.client.network.io
 
 The number of transmitted bytes between server and clients.
@@ -423,6 +431,14 @@ The number of InnoDB deadlocks.
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
 | 1 | Sum | Int | Cumulative | true | Development |
+
+### mysql.history_list_length
+
+The InnoDB history list length — the number of undo log records not yet purged, from INFORMATION_SCHEMA.INNODB_METRICS (trx_rseg_history_len). A persistently high or growing value indicates long-running or abandoned transactions delaying purge.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | false | Development |
 
 ### mysql.joins
 

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -416,6 +416,14 @@ Errors that occur during the client connection process.
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | error | The connection error type. | Str: ``accept``, ``internal``, ``max_connections``, ``peer_address``, ``select``, ``tcpwrap``, ``aborted``, ``aborted_clients``, ``locked`` | Recommended | - |
 
+### mysql.deadlocks
+
+The number of InnoDB deadlocks.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | true | Development |
+
 ### mysql.joins
 
 The number of joins that perform table scans.

--- a/receiver/mysqlreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/mysqlreceiver/internal/metadata/config.schema.yaml
@@ -186,6 +186,13 @@ $defs:
                 - "error"
             default:
               - "error"
+      mysql.deadlocks:
+        description: "MysqlDeadlocksMetricConfig provides config for the mysql.deadlocks metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
       mysql.double_writes:
         description: "MysqlDoubleWritesMetricConfig provides config for the mysql.double_writes metric."
         type: object

--- a/receiver/mysqlreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/mysqlreceiver/internal/metadata/config.schema.yaml
@@ -4,6 +4,13 @@ $defs:
     description: MetricsConfig provides config for mysql metrics.
     type: object
     properties:
+      mysql.active_transactions:
+        description: "MysqlActiveTransactionsMetricConfig provides config for the mysql.active_transactions metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
       mysql.buffer_pool.data_pages:
         description: "MysqlBufferPoolDataPagesMetricConfig provides config for the mysql.buffer_pool.data_pages metric."
         type: object
@@ -239,6 +246,13 @@ $defs:
                 - "kind"
             default:
               - "kind"
+      mysql.history_list_length:
+        description: "MysqlHistoryListLengthMetricConfig provides config for the mysql.history_list_length metric."
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
       mysql.index.io.wait.count:
         description: "MysqlIndexIoWaitCountMetricConfig provides config for the mysql.index.io.wait.count metric."
         type: object

--- a/receiver/mysqlreceiver/internal/metadata/generated_config.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config.go
@@ -405,6 +405,26 @@ func (ms *MysqlConnectionErrorsMetricConfig) Validate() error {
 	return nil
 }
 
+// MysqlDeadlocksMetricConfig provides config for the mysql.deadlocks metric.
+type MysqlDeadlocksMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MysqlDeadlocksMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // MysqlDoubleWritesMetricAttributeKey specifies the key of an attribute for the mysql.double_writes metric.
 type MysqlDoubleWritesMetricAttributeKey string
 
@@ -2064,6 +2084,7 @@ type MetricsConfig struct {
 	MysqlCommands                MysqlCommandsMetricConfig                `mapstructure:"mysql.commands"`
 	MysqlConnectionCount         MysqlConnectionCountMetricConfig         `mapstructure:"mysql.connection.count"`
 	MysqlConnectionErrors        MysqlConnectionErrorsMetricConfig        `mapstructure:"mysql.connection.errors"`
+	MysqlDeadlocks               MysqlDeadlocksMetricConfig               `mapstructure:"mysql.deadlocks"`
 	MysqlDoubleWrites            MysqlDoubleWritesMetricConfig            `mapstructure:"mysql.double_writes"`
 	MysqlHandlers                MysqlHandlersMetricConfig                `mapstructure:"mysql.handlers"`
 	MysqlIndexIoWaitCount        MysqlIndexIoWaitCountMetricConfig        `mapstructure:"mysql.index.io.wait.count"`
@@ -2150,6 +2171,9 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []MysqlConnectionErrorsMetricAttributeKey{MysqlConnectionErrorsMetricAttributeKeyConnectionError},
+		},
+		MysqlDeadlocks: MysqlDeadlocksMetricConfig{
+			Enabled: false,
 		},
 		MysqlDoubleWrites: MysqlDoubleWritesMetricConfig{
 			Enabled:             true,

--- a/receiver/mysqlreceiver/internal/metadata/generated_config.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config.go
@@ -9,6 +9,26 @@ import (
 	"go.opentelemetry.io/collector/filter"
 )
 
+// MysqlActiveTransactionsMetricConfig provides config for the mysql.active_transactions metric.
+type MysqlActiveTransactionsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MysqlActiveTransactionsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // MysqlBufferPoolDataPagesMetricAttributeKey specifies the key of an attribute for the mysql.buffer_pool.data_pages metric.
 type MysqlBufferPoolDataPagesMetricAttributeKey string
 
@@ -518,6 +538,26 @@ func (ms *MysqlHandlersMetricConfig) Validate() error {
 		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
 	}
 
+	return nil
+}
+
+// MysqlHistoryListLengthMetricConfig provides config for the mysql.history_list_length metric.
+type MysqlHistoryListLengthMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MysqlHistoryListLengthMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
 }
 
@@ -2074,6 +2114,7 @@ func (ms *MysqlUptimeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for mysql metrics.
 type MetricsConfig struct {
+	MysqlActiveTransactions      MysqlActiveTransactionsMetricConfig      `mapstructure:"mysql.active_transactions"`
 	MysqlBufferPoolDataPages     MysqlBufferPoolDataPagesMetricConfig     `mapstructure:"mysql.buffer_pool.data_pages"`
 	MysqlBufferPoolLimit         MysqlBufferPoolLimitMetricConfig         `mapstructure:"mysql.buffer_pool.limit"`
 	MysqlBufferPoolOperations    MysqlBufferPoolOperationsMetricConfig    `mapstructure:"mysql.buffer_pool.operations"`
@@ -2087,6 +2128,7 @@ type MetricsConfig struct {
 	MysqlDeadlocks               MysqlDeadlocksMetricConfig               `mapstructure:"mysql.deadlocks"`
 	MysqlDoubleWrites            MysqlDoubleWritesMetricConfig            `mapstructure:"mysql.double_writes"`
 	MysqlHandlers                MysqlHandlersMetricConfig                `mapstructure:"mysql.handlers"`
+	MysqlHistoryListLength       MysqlHistoryListLengthMetricConfig       `mapstructure:"mysql.history_list_length"`
 	MysqlIndexIoWaitCount        MysqlIndexIoWaitCountMetricConfig        `mapstructure:"mysql.index.io.wait.count"`
 	MysqlIndexIoWaitTime         MysqlIndexIoWaitTimeMetricConfig         `mapstructure:"mysql.index.io.wait.time"`
 	MysqlJoins                   MysqlJoinsMetricConfig                   `mapstructure:"mysql.joins"`
@@ -2128,6 +2170,9 @@ type MetricsConfig struct {
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
+		MysqlActiveTransactions: MysqlActiveTransactionsMetricConfig{
+			Enabled: false,
+		},
 		MysqlBufferPoolDataPages: MysqlBufferPoolDataPagesMetricConfig{
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,
@@ -2184,6 +2229,9 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled:             true,
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []MysqlHandlersMetricAttributeKey{MysqlHandlersMetricAttributeKeyHandler},
+		},
+		MysqlHistoryListLength: MysqlHistoryListLengthMetricConfig{
+			Enabled: false,
 		},
 		MysqlIndexIoWaitCount: MysqlIndexIoWaitCountMetricConfig{
 			Enabled:             true,

--- a/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
@@ -70,6 +70,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlConnectionErrorsMetricAttributeKey{MysqlConnectionErrorsMetricAttributeKeyConnectionError},
 					},
+					MysqlDeadlocks: MysqlDeadlocksMetricConfig{
+						Enabled: true,
+					},
 					MysqlDoubleWrites: MysqlDoubleWritesMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
@@ -302,6 +305,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlConnectionErrorsMetricAttributeKey{MysqlConnectionErrorsMetricAttributeKeyConnectionError},
 					},
+					MysqlDeadlocks: MysqlDeadlocksMetricConfig{
+						Enabled: false,
+					},
 					MysqlDoubleWrites: MysqlDoubleWritesMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
@@ -490,7 +496,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MysqlBufferPoolDataPagesMetricConfig{}, MysqlBufferPoolLimitMetricConfig{}, MysqlBufferPoolOperationsMetricConfig{}, MysqlBufferPoolPageFlushesMetricConfig{}, MysqlBufferPoolPagesMetricConfig{}, MysqlBufferPoolUsageMetricConfig{}, MysqlClientNetworkIoMetricConfig{}, MysqlCommandsMetricConfig{}, MysqlConnectionCountMetricConfig{}, MysqlConnectionErrorsMetricConfig{}, MysqlDoubleWritesMetricConfig{}, MysqlHandlersMetricConfig{}, MysqlIndexIoWaitCountMetricConfig{}, MysqlIndexIoWaitTimeMetricConfig{}, MysqlJoinsMetricConfig{}, MysqlLocksMetricConfig{}, MysqlLogOperationsMetricConfig{}, MysqlMaxUsedConnectionsMetricConfig{}, MysqlMysqlxConnectionsMetricConfig{}, MysqlMysqlxWorkerThreadsMetricConfig{}, MysqlOpenedResourcesMetricConfig{}, MysqlOperationsMetricConfig{}, MysqlPageOperationsMetricConfig{}, MysqlPageSizeMetricConfig{}, MysqlPreparedStatementsMetricConfig{}, MysqlQueryClientCountMetricConfig{}, MysqlQueryCountMetricConfig{}, MysqlQuerySlowCountMetricConfig{}, MysqlReplicaSQLDelayMetricConfig{}, MysqlReplicaTimeBehindSourceMetricConfig{}, MysqlRowLocksMetricConfig{}, MysqlRowOperationsMetricConfig{}, MysqlSessionsMetricConfig{}, MysqlSortsMetricConfig{}, MysqlStatementEventCountMetricConfig{}, MysqlStatementEventWaitTimeMetricConfig{}, MysqlTableAverageRowLengthMetricConfig{}, MysqlTableIoWaitCountMetricConfig{}, MysqlTableIoWaitTimeMetricConfig{}, MysqlTableLockWaitReadCountMetricConfig{}, MysqlTableLockWaitReadTimeMetricConfig{}, MysqlTableLockWaitWriteCountMetricConfig{}, MysqlTableLockWaitWriteTimeMetricConfig{}, MysqlTableRowsMetricConfig{}, MysqlTableSizeMetricConfig{}, MysqlTableOpenCacheMetricConfig{}, MysqlThreadsMetricConfig{}, MysqlTmpResourcesMetricConfig{}, MysqlUptimeMetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MysqlBufferPoolDataPagesMetricConfig{}, MysqlBufferPoolLimitMetricConfig{}, MysqlBufferPoolOperationsMetricConfig{}, MysqlBufferPoolPageFlushesMetricConfig{}, MysqlBufferPoolPagesMetricConfig{}, MysqlBufferPoolUsageMetricConfig{}, MysqlClientNetworkIoMetricConfig{}, MysqlCommandsMetricConfig{}, MysqlConnectionCountMetricConfig{}, MysqlConnectionErrorsMetricConfig{}, MysqlDeadlocksMetricConfig{}, MysqlDoubleWritesMetricConfig{}, MysqlHandlersMetricConfig{}, MysqlIndexIoWaitCountMetricConfig{}, MysqlIndexIoWaitTimeMetricConfig{}, MysqlJoinsMetricConfig{}, MysqlLocksMetricConfig{}, MysqlLogOperationsMetricConfig{}, MysqlMaxUsedConnectionsMetricConfig{}, MysqlMysqlxConnectionsMetricConfig{}, MysqlMysqlxWorkerThreadsMetricConfig{}, MysqlOpenedResourcesMetricConfig{}, MysqlOperationsMetricConfig{}, MysqlPageOperationsMetricConfig{}, MysqlPageSizeMetricConfig{}, MysqlPreparedStatementsMetricConfig{}, MysqlQueryClientCountMetricConfig{}, MysqlQueryCountMetricConfig{}, MysqlQuerySlowCountMetricConfig{}, MysqlReplicaSQLDelayMetricConfig{}, MysqlReplicaTimeBehindSourceMetricConfig{}, MysqlRowLocksMetricConfig{}, MysqlRowOperationsMetricConfig{}, MysqlSessionsMetricConfig{}, MysqlSortsMetricConfig{}, MysqlStatementEventCountMetricConfig{}, MysqlStatementEventWaitTimeMetricConfig{}, MysqlTableAverageRowLengthMetricConfig{}, MysqlTableIoWaitCountMetricConfig{}, MysqlTableIoWaitTimeMetricConfig{}, MysqlTableLockWaitReadCountMetricConfig{}, MysqlTableLockWaitReadTimeMetricConfig{}, MysqlTableLockWaitWriteCountMetricConfig{}, MysqlTableLockWaitWriteTimeMetricConfig{}, MysqlTableRowsMetricConfig{}, MysqlTableSizeMetricConfig{}, MysqlTableOpenCacheMetricConfig{}, MysqlThreadsMetricConfig{}, MysqlTmpResourcesMetricConfig{}, MysqlUptimeMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
@@ -26,6 +26,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
+					MysqlActiveTransactions: MysqlActiveTransactionsMetricConfig{
+						Enabled: true,
+					},
 					MysqlBufferPoolDataPages: MysqlBufferPoolDataPagesMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
@@ -82,6 +85,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlHandlersMetricAttributeKey{MysqlHandlersMetricAttributeKeyHandler},
+					},
+					MysqlHistoryListLength: MysqlHistoryListLengthMetricConfig{
+						Enabled: true,
 					},
 					MysqlIndexIoWaitCount: MysqlIndexIoWaitCountMetricConfig{
 						Enabled:             true,
@@ -261,6 +267,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
+					MysqlActiveTransactions: MysqlActiveTransactionsMetricConfig{
+						Enabled: false,
+					},
 					MysqlBufferPoolDataPages: MysqlBufferPoolDataPagesMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
@@ -317,6 +326,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MysqlHandlersMetricAttributeKey{MysqlHandlersMetricAttributeKeyHandler},
+					},
+					MysqlHistoryListLength: MysqlHistoryListLengthMetricConfig{
+						Enabled: false,
 					},
 					MysqlIndexIoWaitCount: MysqlIndexIoWaitCountMetricConfig{
 						Enabled:             false,
@@ -496,7 +508,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MysqlBufferPoolDataPagesMetricConfig{}, MysqlBufferPoolLimitMetricConfig{}, MysqlBufferPoolOperationsMetricConfig{}, MysqlBufferPoolPageFlushesMetricConfig{}, MysqlBufferPoolPagesMetricConfig{}, MysqlBufferPoolUsageMetricConfig{}, MysqlClientNetworkIoMetricConfig{}, MysqlCommandsMetricConfig{}, MysqlConnectionCountMetricConfig{}, MysqlConnectionErrorsMetricConfig{}, MysqlDeadlocksMetricConfig{}, MysqlDoubleWritesMetricConfig{}, MysqlHandlersMetricConfig{}, MysqlIndexIoWaitCountMetricConfig{}, MysqlIndexIoWaitTimeMetricConfig{}, MysqlJoinsMetricConfig{}, MysqlLocksMetricConfig{}, MysqlLogOperationsMetricConfig{}, MysqlMaxUsedConnectionsMetricConfig{}, MysqlMysqlxConnectionsMetricConfig{}, MysqlMysqlxWorkerThreadsMetricConfig{}, MysqlOpenedResourcesMetricConfig{}, MysqlOperationsMetricConfig{}, MysqlPageOperationsMetricConfig{}, MysqlPageSizeMetricConfig{}, MysqlPreparedStatementsMetricConfig{}, MysqlQueryClientCountMetricConfig{}, MysqlQueryCountMetricConfig{}, MysqlQuerySlowCountMetricConfig{}, MysqlReplicaSQLDelayMetricConfig{}, MysqlReplicaTimeBehindSourceMetricConfig{}, MysqlRowLocksMetricConfig{}, MysqlRowOperationsMetricConfig{}, MysqlSessionsMetricConfig{}, MysqlSortsMetricConfig{}, MysqlStatementEventCountMetricConfig{}, MysqlStatementEventWaitTimeMetricConfig{}, MysqlTableAverageRowLengthMetricConfig{}, MysqlTableIoWaitCountMetricConfig{}, MysqlTableIoWaitTimeMetricConfig{}, MysqlTableLockWaitReadCountMetricConfig{}, MysqlTableLockWaitReadTimeMetricConfig{}, MysqlTableLockWaitWriteCountMetricConfig{}, MysqlTableLockWaitWriteTimeMetricConfig{}, MysqlTableRowsMetricConfig{}, MysqlTableSizeMetricConfig{}, MysqlTableOpenCacheMetricConfig{}, MysqlThreadsMetricConfig{}, MysqlTmpResourcesMetricConfig{}, MysqlUptimeMetricConfig{}, ResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MysqlActiveTransactionsMetricConfig{}, MysqlBufferPoolDataPagesMetricConfig{}, MysqlBufferPoolLimitMetricConfig{}, MysqlBufferPoolOperationsMetricConfig{}, MysqlBufferPoolPageFlushesMetricConfig{}, MysqlBufferPoolPagesMetricConfig{}, MysqlBufferPoolUsageMetricConfig{}, MysqlClientNetworkIoMetricConfig{}, MysqlCommandsMetricConfig{}, MysqlConnectionCountMetricConfig{}, MysqlConnectionErrorsMetricConfig{}, MysqlDeadlocksMetricConfig{}, MysqlDoubleWritesMetricConfig{}, MysqlHandlersMetricConfig{}, MysqlHistoryListLengthMetricConfig{}, MysqlIndexIoWaitCountMetricConfig{}, MysqlIndexIoWaitTimeMetricConfig{}, MysqlJoinsMetricConfig{}, MysqlLocksMetricConfig{}, MysqlLogOperationsMetricConfig{}, MysqlMaxUsedConnectionsMetricConfig{}, MysqlMysqlxConnectionsMetricConfig{}, MysqlMysqlxWorkerThreadsMetricConfig{}, MysqlOpenedResourcesMetricConfig{}, MysqlOperationsMetricConfig{}, MysqlPageOperationsMetricConfig{}, MysqlPageSizeMetricConfig{}, MysqlPreparedStatementsMetricConfig{}, MysqlQueryClientCountMetricConfig{}, MysqlQueryCountMetricConfig{}, MysqlQuerySlowCountMetricConfig{}, MysqlReplicaSQLDelayMetricConfig{}, MysqlReplicaTimeBehindSourceMetricConfig{}, MysqlRowLocksMetricConfig{}, MysqlRowOperationsMetricConfig{}, MysqlSessionsMetricConfig{}, MysqlSortsMetricConfig{}, MysqlStatementEventCountMetricConfig{}, MysqlStatementEventWaitTimeMetricConfig{}, MysqlTableAverageRowLengthMetricConfig{}, MysqlTableIoWaitCountMetricConfig{}, MysqlTableIoWaitTimeMetricConfig{}, MysqlTableLockWaitReadCountMetricConfig{}, MysqlTableLockWaitReadTimeMetricConfig{}, MysqlTableLockWaitWriteCountMetricConfig{}, MysqlTableLockWaitWriteTimeMetricConfig{}, MysqlTableRowsMetricConfig{}, MysqlTableSizeMetricConfig{}, MysqlTableOpenCacheMetricConfig{}, MysqlThreadsMetricConfig{}, MysqlTmpResourcesMetricConfig{}, MysqlUptimeMetricConfig{}, ResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -1115,6 +1115,9 @@ var MapAttributeWriteLockType = map[string]AttributeWriteLockType{
 }
 
 var MetricsInfo = metricsInfo{
+	MysqlActiveTransactions: metricInfo{
+		Name: "mysql.active_transactions",
+	},
 	MysqlBufferPoolDataPages: metricInfo{
 		Name: "mysql.buffer_pool.data_pages",
 	},
@@ -1153,6 +1156,9 @@ var MetricsInfo = metricsInfo{
 	},
 	MysqlHandlers: metricInfo{
 		Name: "mysql.handlers",
+	},
+	MysqlHistoryListLength: metricInfo{
+		Name: "mysql.history_list_length",
 	},
 	MysqlIndexIoWaitCount: metricInfo{
 		Name: "mysql.index.io.wait.count",
@@ -1265,6 +1271,7 @@ var MetricsInfo = metricsInfo{
 }
 
 type metricsInfo struct {
+	MysqlActiveTransactions      metricInfo
 	MysqlBufferPoolDataPages     metricInfo
 	MysqlBufferPoolLimit         metricInfo
 	MysqlBufferPoolOperations    metricInfo
@@ -1278,6 +1285,7 @@ type metricsInfo struct {
 	MysqlDeadlocks               metricInfo
 	MysqlDoubleWrites            metricInfo
 	MysqlHandlers                metricInfo
+	MysqlHistoryListLength       metricInfo
 	MysqlIndexIoWaitCount        metricInfo
 	MysqlIndexIoWaitTime         metricInfo
 	MysqlJoins                   metricInfo
@@ -1318,6 +1326,58 @@ type metricsInfo struct {
 
 type metricInfo struct {
 	Name string
+}
+
+type metricMysqlActiveTransactions struct {
+	data     pmetric.Metric                      // data buffer for generated metric.
+	config   MysqlActiveTransactionsMetricConfig // metric config provided by user.
+	capacity int                                 // max observed number of data points added to the metric.
+}
+
+// init fills mysql.active_transactions metric with initial data.
+func (m *metricMysqlActiveTransactions) init() {
+	m.data.SetName("mysql.active_transactions")
+	m.data.SetDescription("The number of currently active InnoDB transactions, from COUNT(*) of INFORMATION_SCHEMA.INNODB_TRX.")
+	m.data.SetUnit("1")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricMysqlActiveTransactions) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMysqlActiveTransactions) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMysqlActiveTransactions) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMysqlActiveTransactions(cfg MysqlActiveTransactionsMetricConfig) metricMysqlActiveTransactions {
+	m := metricMysqlActiveTransactions{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
 }
 
 type metricMysqlBufferPoolDataPages struct {
@@ -2339,6 +2399,58 @@ func (m *metricMysqlHandlers) emit(metrics pmetric.MetricSlice) {
 
 func newMetricMysqlHandlers(cfg MysqlHandlersMetricConfig) metricMysqlHandlers {
 	m := metricMysqlHandlers{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMysqlHistoryListLength struct {
+	data     pmetric.Metric                     // data buffer for generated metric.
+	config   MysqlHistoryListLengthMetricConfig // metric config provided by user.
+	capacity int                                // max observed number of data points added to the metric.
+}
+
+// init fills mysql.history_list_length metric with initial data.
+func (m *metricMysqlHistoryListLength) init() {
+	m.data.SetName("mysql.history_list_length")
+	m.data.SetDescription("The InnoDB history list length — the number of undo log records not yet purged, from INFORMATION_SCHEMA.INNODB_METRICS (trx_rseg_history_len). A persistently high or growing value indicates long-running or abandoned transactions delaying purge.")
+	m.data.SetUnit("1")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricMysqlHistoryListLength) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMysqlHistoryListLength) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMysqlHistoryListLength) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMysqlHistoryListLength(cfg MysqlHistoryListLengthMetricConfig) metricMysqlHistoryListLength {
+	m := metricMysqlHistoryListLength{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -5453,6 +5565,7 @@ type MetricsBuilder struct {
 	buildInfo                          component.BuildInfo  // contains version information.
 	resourceAttributeIncludeFilter     map[string]filter.Filter
 	resourceAttributeExcludeFilter     map[string]filter.Filter
+	metricMysqlActiveTransactions      metricMysqlActiveTransactions
 	metricMysqlBufferPoolDataPages     metricMysqlBufferPoolDataPages
 	metricMysqlBufferPoolLimit         metricMysqlBufferPoolLimit
 	metricMysqlBufferPoolOperations    metricMysqlBufferPoolOperations
@@ -5466,6 +5579,7 @@ type MetricsBuilder struct {
 	metricMysqlDeadlocks               metricMysqlDeadlocks
 	metricMysqlDoubleWrites            metricMysqlDoubleWrites
 	metricMysqlHandlers                metricMysqlHandlers
+	metricMysqlHistoryListLength       metricMysqlHistoryListLength
 	metricMysqlIndexIoWaitCount        metricMysqlIndexIoWaitCount
 	metricMysqlIndexIoWaitTime         metricMysqlIndexIoWaitTime
 	metricMysqlJoins                   metricMysqlJoins
@@ -5528,6 +5642,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		startTime:                          pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                      pmetric.NewMetrics(),
 		buildInfo:                          settings.BuildInfo,
+		metricMysqlActiveTransactions:      newMetricMysqlActiveTransactions(mbc.Metrics.MysqlActiveTransactions),
 		metricMysqlBufferPoolDataPages:     newMetricMysqlBufferPoolDataPages(mbc.Metrics.MysqlBufferPoolDataPages),
 		metricMysqlBufferPoolLimit:         newMetricMysqlBufferPoolLimit(mbc.Metrics.MysqlBufferPoolLimit),
 		metricMysqlBufferPoolOperations:    newMetricMysqlBufferPoolOperations(mbc.Metrics.MysqlBufferPoolOperations),
@@ -5541,6 +5656,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricMysqlDeadlocks:               newMetricMysqlDeadlocks(mbc.Metrics.MysqlDeadlocks),
 		metricMysqlDoubleWrites:            newMetricMysqlDoubleWrites(mbc.Metrics.MysqlDoubleWrites),
 		metricMysqlHandlers:                newMetricMysqlHandlers(mbc.Metrics.MysqlHandlers),
+		metricMysqlHistoryListLength:       newMetricMysqlHistoryListLength(mbc.Metrics.MysqlHistoryListLength),
 		metricMysqlIndexIoWaitCount:        newMetricMysqlIndexIoWaitCount(mbc.Metrics.MysqlIndexIoWaitCount),
 		metricMysqlIndexIoWaitTime:         newMetricMysqlIndexIoWaitTime(mbc.Metrics.MysqlIndexIoWaitTime),
 		metricMysqlJoins:                   newMetricMysqlJoins(mbc.Metrics.MysqlJoins),
@@ -5656,6 +5772,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	ils.Scope().SetName(ScopeName)
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricMysqlActiveTransactions.emit(ils.Metrics())
 	mb.metricMysqlBufferPoolDataPages.emit(ils.Metrics())
 	mb.metricMysqlBufferPoolLimit.emit(ils.Metrics())
 	mb.metricMysqlBufferPoolOperations.emit(ils.Metrics())
@@ -5669,6 +5786,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricMysqlDeadlocks.emit(ils.Metrics())
 	mb.metricMysqlDoubleWrites.emit(ils.Metrics())
 	mb.metricMysqlHandlers.emit(ils.Metrics())
+	mb.metricMysqlHistoryListLength.emit(ils.Metrics())
 	mb.metricMysqlIndexIoWaitCount.emit(ils.Metrics())
 	mb.metricMysqlIndexIoWaitTime.emit(ils.Metrics())
 	mb.metricMysqlJoins.emit(ils.Metrics())
@@ -5735,6 +5853,16 @@ func (mb *MetricsBuilder) Emit(options ...ResourceMetricsOption) pmetric.Metrics
 	metrics := mb.metricsBuffer
 	mb.metricsBuffer = pmetric.NewMetrics()
 	return metrics
+}
+
+// RecordMysqlActiveTransactionsDataPoint adds a data point to mysql.active_transactions metric.
+func (mb *MetricsBuilder) RecordMysqlActiveTransactionsDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for MysqlActiveTransactions, value was %s: %w", inputVal, err)
+	}
+	mb.metricMysqlActiveTransactions.recordDataPoint(mb.startTime, ts, val)
+	return nil
 }
 
 // RecordMysqlBufferPoolDataPagesDataPoint adds a data point to mysql.buffer_pool.data_pages metric.
@@ -5854,6 +5982,16 @@ func (mb *MetricsBuilder) RecordMysqlHandlersDataPoint(ts pcommon.Timestamp, inp
 		return fmt.Errorf("failed to parse int64 for MysqlHandlers, value was %s: %w", inputVal, err)
 	}
 	mb.metricMysqlHandlers.recordDataPoint(mb.startTime, ts, val, handlerAttributeValue.String())
+	return nil
+}
+
+// RecordMysqlHistoryListLengthDataPoint adds a data point to mysql.history_list_length metric.
+func (mb *MetricsBuilder) RecordMysqlHistoryListLengthDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for MysqlHistoryListLength, value was %s: %w", inputVal, err)
+	}
+	mb.metricMysqlHistoryListLength.recordDataPoint(mb.startTime, ts, val)
 	return nil
 }
 

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -1145,6 +1145,9 @@ var MetricsInfo = metricsInfo{
 	MysqlConnectionErrors: metricInfo{
 		Name: "mysql.connection.errors",
 	},
+	MysqlDeadlocks: metricInfo{
+		Name: "mysql.deadlocks",
+	},
 	MysqlDoubleWrites: metricInfo{
 		Name: "mysql.double_writes",
 	},
@@ -1272,6 +1275,7 @@ type metricsInfo struct {
 	MysqlCommands                metricInfo
 	MysqlConnectionCount         metricInfo
 	MysqlConnectionErrors        metricInfo
+	MysqlDeadlocks               metricInfo
 	MysqlDoubleWrites            metricInfo
 	MysqlHandlers                metricInfo
 	MysqlIndexIoWaitCount        metricInfo
@@ -2101,6 +2105,58 @@ func (m *metricMysqlConnectionErrors) emit(metrics pmetric.MetricSlice) {
 
 func newMetricMysqlConnectionErrors(cfg MysqlConnectionErrorsMetricConfig) metricMysqlConnectionErrors {
 	m := metricMysqlConnectionErrors{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMysqlDeadlocks struct {
+	data     pmetric.Metric             // data buffer for generated metric.
+	config   MysqlDeadlocksMetricConfig // metric config provided by user.
+	capacity int                        // max observed number of data points added to the metric.
+}
+
+// init fills mysql.deadlocks metric with initial data.
+func (m *metricMysqlDeadlocks) init() {
+	m.data.SetName("mysql.deadlocks")
+	m.data.SetDescription("The number of InnoDB deadlocks.")
+	m.data.SetUnit("1")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricMysqlDeadlocks) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMysqlDeadlocks) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMysqlDeadlocks) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMysqlDeadlocks(cfg MysqlDeadlocksMetricConfig) metricMysqlDeadlocks {
+	m := metricMysqlDeadlocks{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -5407,6 +5463,7 @@ type MetricsBuilder struct {
 	metricMysqlCommands                metricMysqlCommands
 	metricMysqlConnectionCount         metricMysqlConnectionCount
 	metricMysqlConnectionErrors        metricMysqlConnectionErrors
+	metricMysqlDeadlocks               metricMysqlDeadlocks
 	metricMysqlDoubleWrites            metricMysqlDoubleWrites
 	metricMysqlHandlers                metricMysqlHandlers
 	metricMysqlIndexIoWaitCount        metricMysqlIndexIoWaitCount
@@ -5481,6 +5538,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricMysqlCommands:                newMetricMysqlCommands(mbc.Metrics.MysqlCommands),
 		metricMysqlConnectionCount:         newMetricMysqlConnectionCount(mbc.Metrics.MysqlConnectionCount),
 		metricMysqlConnectionErrors:        newMetricMysqlConnectionErrors(mbc.Metrics.MysqlConnectionErrors),
+		metricMysqlDeadlocks:               newMetricMysqlDeadlocks(mbc.Metrics.MysqlDeadlocks),
 		metricMysqlDoubleWrites:            newMetricMysqlDoubleWrites(mbc.Metrics.MysqlDoubleWrites),
 		metricMysqlHandlers:                newMetricMysqlHandlers(mbc.Metrics.MysqlHandlers),
 		metricMysqlIndexIoWaitCount:        newMetricMysqlIndexIoWaitCount(mbc.Metrics.MysqlIndexIoWaitCount),
@@ -5608,6 +5666,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricMysqlCommands.emit(ils.Metrics())
 	mb.metricMysqlConnectionCount.emit(ils.Metrics())
 	mb.metricMysqlConnectionErrors.emit(ils.Metrics())
+	mb.metricMysqlDeadlocks.emit(ils.Metrics())
 	mb.metricMysqlDoubleWrites.emit(ils.Metrics())
 	mb.metricMysqlHandlers.emit(ils.Metrics())
 	mb.metricMysqlIndexIoWaitCount.emit(ils.Metrics())
@@ -5765,6 +5824,16 @@ func (mb *MetricsBuilder) RecordMysqlConnectionErrorsDataPoint(ts pcommon.Timest
 		return fmt.Errorf("failed to parse int64 for MysqlConnectionErrors, value was %s: %w", inputVal, err)
 	}
 	mb.metricMysqlConnectionErrors.recordDataPoint(mb.startTime, ts, val, connectionErrorAttributeValue.String())
+	return nil
+}
+
+// RecordMysqlDeadlocksDataPoint adds a data point to mysql.deadlocks metric.
+func (mb *MetricsBuilder) RecordMysqlDeadlocksDataPoint(ts pcommon.Timestamp, inputVal string) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for MysqlDeadlocks, value was %s: %w", inputVal, err)
+	}
+	mb.metricMysqlDeadlocks.recordDataPoint(mb.startTime, ts, val)
 	return nil
 }
 

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
@@ -170,6 +170,9 @@ func TestMetricsBuilder(t *testing.T) {
 				mb.RecordMysqlConnectionErrorsDataPoint(ts, "3", AttributeConnectionErrorInternal)
 			}
 
+			allMetricsCount++
+			mb.RecordMysqlDeadlocksDataPoint(ts, "1")
+
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMysqlDoubleWritesDataPoint(ts, "1", AttributeDoubleWritesPagesWritten)
@@ -812,6 +815,20 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok := dp.Attributes().Get("error")
 						assert.False(t, ok)
 					}
+				case "mysql.deadlocks":
+					assert.False(t, validatedMetrics["mysql.deadlocks"], "Found a duplicate in the metrics slice: mysql.deadlocks")
+					validatedMetrics["mysql.deadlocks"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "The number of InnoDB deadlocks.", mi.Description())
+					assert.Equal(t, "1", mi.Unit())
+					assert.True(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
 				case "mysql.double_writes":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["mysql.double_writes"], "Found a duplicate in the metrics slice: mysql.double_writes")

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
@@ -113,6 +113,9 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount := 0
 			allMetricsCount := 0
 
+			allMetricsCount++
+			mb.RecordMysqlActiveTransactionsDataPoint(ts, "1")
+
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMysqlBufferPoolDataPagesDataPoint(ts, 1, AttributeBufferPoolDataDirty)
@@ -186,6 +189,9 @@ func TestMetricsBuilder(t *testing.T) {
 			if tt.name == "reaggregate_set" {
 				mb.RecordMysqlHandlersDataPoint(ts, "3", AttributeHandlerDelete)
 			}
+
+			allMetricsCount++
+			mb.RecordMysqlHistoryListLengthDataPoint(ts, "1")
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -465,6 +471,20 @@ func TestMetricsBuilder(t *testing.T) {
 			validatedMetrics := make(map[string]bool)
 			for _, mi := range allMetricsList {
 				switch mi.Name() {
+				case "mysql.active_transactions":
+					assert.False(t, validatedMetrics["mysql.active_transactions"], "Found a duplicate in the metrics slice: mysql.active_transactions")
+					validatedMetrics["mysql.active_transactions"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "The number of currently active InnoDB transactions, from COUNT(*) of INFORMATION_SCHEMA.INNODB_TRX.", mi.Description())
+					assert.Equal(t, "1", mi.Unit())
+					assert.False(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
 				case "mysql.buffer_pool.data_pages":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["mysql.buffer_pool.data_pages"], "Found a duplicate in the metrics slice: mysql.buffer_pool.data_pages")
@@ -917,6 +937,20 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok := dp.Attributes().Get("kind")
 						assert.False(t, ok)
 					}
+				case "mysql.history_list_length":
+					assert.False(t, validatedMetrics["mysql.history_list_length"], "Found a duplicate in the metrics slice: mysql.history_list_length")
+					validatedMetrics["mysql.history_list_length"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "The InnoDB history list length — the number of undo log records not yet purged, from INFORMATION_SCHEMA.INNODB_METRICS (trx_rseg_history_len). A persistently high or growing value indicates long-running or abandoned transactions delaying purge.", mi.Description())
+					assert.Equal(t, "1", mi.Unit())
+					assert.False(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
 				case "mysql.index.io.wait.count":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["mysql.index.io.wait.count"], "Found a duplicate in the metrics slice: mysql.index.io.wait.count")

--- a/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
@@ -1,6 +1,8 @@
 default:
 all_set:
   metrics:
+    mysql.active_transactions:
+      enabled: true
     mysql.buffer_pool.data_pages:
       enabled: true
       attributes: ["status"]
@@ -36,6 +38,8 @@ all_set:
     mysql.handlers:
       enabled: true
       attributes: ["kind"]
+    mysql.history_list_length:
+      enabled: true
     mysql.index.io.wait.count:
       enabled: true
       attributes: ["operation","table","schema","index"]
@@ -150,6 +154,8 @@ all_set:
       enabled: true
 reaggregate_set:
   metrics:
+    mysql.active_transactions:
+      enabled: true
     mysql.buffer_pool.data_pages:
       enabled: true
       attributes: []
@@ -185,6 +191,8 @@ reaggregate_set:
     mysql.handlers:
       enabled: true
       attributes: []
+    mysql.history_list_length:
+      enabled: true
     mysql.index.io.wait.count:
       enabled: true
       attributes: []
@@ -299,6 +307,8 @@ reaggregate_set:
       enabled: true
 none_set:
   metrics:
+    mysql.active_transactions:
+      enabled: false
     mysql.buffer_pool.data_pages:
       enabled: false
       attributes: ["status"]
@@ -334,6 +344,8 @@ none_set:
     mysql.handlers:
       enabled: false
       attributes: ["kind"]
+    mysql.history_list_length:
+      enabled: false
     mysql.index.io.wait.count:
       enabled: false
       attributes: ["operation","table","schema","index"]

--- a/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
@@ -28,6 +28,8 @@ all_set:
     mysql.connection.errors:
       enabled: true
       attributes: ["error"]
+    mysql.deadlocks:
+      enabled: true
     mysql.double_writes:
       enabled: true
       attributes: ["kind"]
@@ -175,6 +177,8 @@ reaggregate_set:
     mysql.connection.errors:
       enabled: true
       attributes: []
+    mysql.deadlocks:
+      enabled: true
     mysql.double_writes:
       enabled: true
       attributes: []
@@ -322,6 +326,8 @@ none_set:
     mysql.connection.errors:
       enabled: false
       attributes: ["error"]
+    mysql.deadlocks:
+      enabled: false
     mysql.double_writes:
       enabled: false
       attributes: ["kind"]

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -388,6 +388,16 @@ events:
       - mysql.events_statements_summary_by_digest.sum_sort_range
 
 metrics:
+  mysql.active_transactions:
+    enabled: false
+    description: The number of currently active InnoDB transactions, from COUNT(*) of INFORMATION_SCHEMA.INNODB_TRX.
+    stability: development
+    unit: "1"
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: false
+      aggregation_temporality: cumulative
   mysql.buffer_pool.data_pages:
     enabled: true
     description: The number of data pages in the InnoDB buffer pool.
@@ -525,6 +535,16 @@ metrics:
       monotonic: true
       aggregation_temporality: cumulative
     attributes: [handler]
+  mysql.history_list_length:
+    enabled: false
+    description: The InnoDB history list length — the number of undo log records not yet purged, from INFORMATION_SCHEMA.INNODB_METRICS (trx_rseg_history_len). A persistently high or growing value indicates long-running or abandoned transactions delaying purge.
+    stability: development
+    unit: "1"
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: false
+      aggregation_temporality: cumulative
   mysql.index.io.wait.count:
     enabled: true
     description: The total count of I/O wait events for an index.

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -493,6 +493,16 @@ metrics:
       monotonic: true
       aggregation_temporality: cumulative
     attributes: [connection_error]
+  mysql.deadlocks:
+    enabled: false
+    description: The number of InnoDB deadlocks.
+    stability: development
+    unit: "1"
+    sum:
+      value_type: int
+      input_type: string
+      monotonic: true
+      aggregation_temporality: cumulative
   mysql.double_writes:
     enabled: true
     description: The number of writes to the InnoDB doublewrite buffer.

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -127,6 +127,19 @@ func (m *mySQLScraper) scrape(context.Context) (pmetric.Metrics, error) {
 			addPartialIfError(errs, m.mb.RecordMysqlBufferPoolLimitDataPoint(now, v))
 		case "lock_deadlocks":
 			addPartialIfError(errs, m.mb.RecordMysqlDeadlocksDataPoint(now, v))
+		case "trx_rseg_history_len":
+			addPartialIfError(errs, m.mb.RecordMysqlHistoryListLengthDataPoint(now, v))
+		}
+	}
+
+	// collect active transaction count.
+	trxStats, trxErr := m.sqlclient.getInnodbTrxStats()
+	if trxErr != nil {
+		m.logger.Error("Failed to fetch InnoDB transaction stats", zap.Error(trxErr))
+	}
+	for k, v := range trxStats {
+		if k == "active_transactions" {
+			addPartialIfError(errs, m.mb.RecordMysqlActiveTransactionsDataPoint(now, v))
 		}
 	}
 

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -122,10 +122,12 @@ func (m *mySQLScraper) scrape(context.Context) (pmetric.Metrics, error) {
 
 	errs := &scrapererror.ScrapeErrors{}
 	for k, v := range innodbStats {
-		if k != "buffer_pool_size" {
-			continue
+		switch k {
+		case "buffer_pool_size":
+			addPartialIfError(errs, m.mb.RecordMysqlBufferPoolLimitDataPoint(now, v))
+		case "lock_deadlocks":
+			addPartialIfError(errs, m.mb.RecordMysqlDeadlocksDataPoint(now, v))
 		}
-		addPartialIfError(errs, m.mb.RecordMysqlBufferPoolLimitDataPoint(now, v))
 	}
 
 	// collect io_waits metrics.

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -66,6 +66,7 @@ func TestScrape(t *testing.T) {
 		cfg.MetricsBuilderConfig.Metrics.MysqlReplicaTimeBehindSource.Enabled = true
 
 		cfg.MetricsBuilderConfig.Metrics.MysqlConnectionCount.Enabled = true
+		cfg.MetricsBuilderConfig.Metrics.MysqlDeadlocks.Enabled = true
 
 		cfg.LogsBuilderConfig.Events.DbServerQuerySample.Enabled = true
 		cfg.LogsBuilderConfig.Events.DbServerTopQuery.Enabled = true

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -67,6 +67,8 @@ func TestScrape(t *testing.T) {
 
 		cfg.MetricsBuilderConfig.Metrics.MysqlConnectionCount.Enabled = true
 		cfg.MetricsBuilderConfig.Metrics.MysqlDeadlocks.Enabled = true
+		cfg.MetricsBuilderConfig.Metrics.MysqlActiveTransactions.Enabled = true
+		cfg.MetricsBuilderConfig.Metrics.MysqlHistoryListLength.Enabled = true
 
 		cfg.LogsBuilderConfig.Events.DbServerQuerySample.Enabled = true
 		cfg.LogsBuilderConfig.Events.DbServerTopQuery.Enabled = true
@@ -75,6 +77,7 @@ func TestScrape(t *testing.T) {
 		scraper.sqlclient = &mockClient{
 			globalStatsFile:             "global_stats",
 			innodbStatsFile:             "innodb_stats",
+			innodbTrxStatsFile:          "innodb_trx_stats",
 			tableIoWaitsFile:            "table_io_waits_stats",
 			indexIoWaitsFile:            "index_io_waits_stats",
 			tableStatsFile:              "table_stats",
@@ -143,6 +146,7 @@ func TestScrape(t *testing.T) {
 		scraper.sqlclient = &mockClient{
 			globalStatsFile:             "global_stats_partial",
 			innodbStatsFile:             "innodb_stats_empty",
+			innodbTrxStatsFile:          "innodb_trx_stats_empty",
 			tableIoWaitsFile:            "table_io_waits_stats_empty",
 			indexIoWaitsFile:            "index_io_waits_stats_empty",
 			tableStatsFile:              "table_stats_empty",
@@ -184,6 +188,7 @@ func TestScrapeBufferPoolPagesMiscOutOfBounds(t *testing.T) {
 	scraper.sqlclient = &mockClient{
 		globalStatsFile:             "global_stats_oob",
 		innodbStatsFile:             "innodb_stats_empty",
+		innodbTrxStatsFile:          "innodb_trx_stats_empty",
 		tableIoWaitsFile:            "table_io_waits_stats_empty",
 		indexIoWaitsFile:            "index_io_waits_stats_empty",
 		tableStatsFile:              "table_stats_empty",
@@ -296,6 +301,7 @@ var _ client = (*mockClient)(nil)
 type mockClient struct {
 	globalStatsFile             string
 	innodbStatsFile             string
+	innodbTrxStatsFile          string
 	tableIoWaitsFile            string
 	indexIoWaitsFile            string
 	tableStatsFile              string
@@ -337,6 +343,10 @@ func (c *mockClient) getGlobalStats() (map[string]string, error) {
 
 func (c *mockClient) getInnodbStats() (map[string]string, error) {
 	return readFile(c.innodbStatsFile)
+}
+
+func (c *mockClient) getInnodbTrxStats() (map[string]string, error) {
+	return readFile(c.innodbTrxStatsFile)
 }
 
 func (c *mockClient) getTableStats() ([]tableStats, error) {
@@ -666,6 +676,7 @@ func TestCollectSessionStates(t *testing.T) {
 	scraper.sqlclient = &mockClient{
 		globalStatsFile:             "global_stats",
 		innodbStatsFile:             "innodb_stats",
+		innodbTrxStatsFile:          "innodb_trx_stats",
 		tableIoWaitsFile:            "table_io_waits_stats",
 		indexIoWaitsFile:            "index_io_waits_stats",
 		tableStatsFile:              "table_stats",

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -9,6 +9,15 @@ resourceMetrics:
             stringValue: localhost:3306
     scopeMetrics:
       - metrics:
+          - description: The number of currently active InnoDB transactions, from COUNT(*) of INFORMATION_SCHEMA.INNODB_TRX.
+            name: mysql.active_transactions
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
           - description: The number of data pages in the InnoDB buffer pool.
             name: mysql.buffer_pool.data_pages
             sum:
@@ -471,6 +480,15 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
+            unit: "1"
+          - description: The InnoDB history list length — the number of undo log records not yet purged, from INFORMATION_SCHEMA.INNODB_METRICS (trx_rseg_history_len). A persistently high or growing value indicates long-running or abandoned transactions delaying purge.
+            name: mysql.history_list_length
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "42"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: "1"
           - description: The total count of I/O wait events for an index.
             name: mysql.index.io.wait.count

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -308,6 +308,16 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
+          - description: The number of InnoDB deadlocks.
+            name: mysql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "5"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
           - description: The number of writes to the InnoDB doublewrite buffer.
             name: mysql.double_writes
             sum:

--- a/receiver/mysqlreceiver/testdata/scraper/innodb_stats.txt
+++ b/receiver/mysqlreceiver/testdata/scraper/innodb_stats.txt
@@ -1,2 +1,3 @@
 name	count
 buffer_pool_size	134217728
+lock_deadlocks	5

--- a/receiver/mysqlreceiver/testdata/scraper/innodb_stats.txt
+++ b/receiver/mysqlreceiver/testdata/scraper/innodb_stats.txt
@@ -1,3 +1,4 @@
 name	count
 buffer_pool_size	134217728
 lock_deadlocks	5
+trx_rseg_history_len	42

--- a/receiver/mysqlreceiver/testdata/scraper/innodb_trx_stats.txt
+++ b/receiver/mysqlreceiver/testdata/scraper/innodb_trx_stats.txt
@@ -1,0 +1,2 @@
+name	count
+active_transactions	3

--- a/receiver/mysqlreceiver/testdata/scraper/innodb_trx_stats_empty.txt
+++ b/receiver/mysqlreceiver/testdata/scraper/innodb_trx_stats_empty.txt
@@ -1,0 +1,1 @@
+name	count


### PR DESCRIPTION
## Description

This PR adds three new InnoDB metrics to the MySQL receiver to improve database monitoring capabilities:

1. **mysql.deadlocks** - Deadlock count from INFORMATION_SCHEMA.INNODB_METRICS (lock_deadlocks)
2. **mysql.history_list_length** - InnoDB history list length from INFORMATION_SCHEMA.INNODB_METRICS (trx_rseg_history_len)  
3. **mysql.active_transactions** - Count of active InnoDB transactions from INFORMATION_SCHEMA.INNODB_TRX

All three metrics are disabled by default.

## Changes

- Added new metric definitions to metadata.yaml
- Updated client.go to query INNODB_METRICS and INNODB_TRX tables
- Added scraper logic to collect and record the new metrics
- Generated metadata files and documentation
- Added test coverage for the new metrics
- Created changelog entries for both changes

## Testing

- All existing tests pass
- Added new test cases for the metrics collection
- Verified metrics are disabled by default

## Link to tracking Issue(s)

Issue #[617] 
## Documentation

Updated receiver documentation with the new metrics.
