### PR TITLE
[receiver/postgresqlreceiver] Skip EXPLAIN for superuser queries

### DIFF
--- a/receiver/postgresqlreceiver/integration_test.go
+++ b/receiver/postgresqlreceiver/integration_test.go
@@ -194,13 +194,21 @@ func TestScrapeLogsFromContainer(t *testing.T) {
 	defer testcontainers.CleanupContainer(t, ci)
 	p, err := ci.MappedPort(t.Context(), postgresqlPort)
 	assert.NoError(t, err)
-	connStr := fmt.Sprintf("postgres://root:otel@localhost:%s/otel2?sslmode=disable", p.Port())
+	// Run the query under test as a non-superuser so the EXPLAIN path is exercised.
+	connStr := fmt.Sprintf("postgres://appuser:apppass@localhost:%s/otel2?sslmode=disable", p.Port())
 	db, err := sql.Open("postgres", connStr)
 	assert.NoError(t, err)
 
 	_, err = db.Exec("Select * from test2 where id = 67")
 	assert.NoError(t, err)
 	defer db.Close()
+
+	superConnStr := fmt.Sprintf("postgres://root:otel@localhost:%s/otel2?sslmode=disable", p.Port())
+	superDB, err := sql.Open("postgres", superConnStr)
+	assert.NoError(t, err)
+	_, err = superDB.Exec("Select count(*) from test2")
+	assert.NoError(t, err)
+	defer superDB.Close()
 
 	cfg := Config{
 		Databases: []string{"postgres"},
@@ -254,11 +262,20 @@ func TestScrapeLogsFromContainer(t *testing.T) {
 	assert.NoError(t, err)
 	logRecords = firstTimeTopQueryPLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
 	found = false
+	foundSuperuserQuery := false
 	for _, record := range logRecords.All() {
 		attributes := record.Attributes().AsRaw()
 		queryAttribute, ok := attributes["db.query.text"]
 		query := strings.ToLower(queryAttribute.(string))
 		assert.True(t, ok)
+		if strings.HasPrefix(query, "select count ( * ) from test2") {
+			// Owned by the superuser: still reported, but with no execution plan.
+			assert.Equal(t, "root", attributes["postgresql.rolname"])
+			assert.Empty(t, attributes["postgresql.query_plan"],
+				"no EXPLAIN should be attempted for a superuser-owned query")
+			foundSuperuserQuery = true
+			continue
+		}
 		if !strings.HasPrefix(query, "select * from test2 where") {
 			continue
 		}
@@ -273,6 +290,7 @@ func TestScrapeLogsFromContainer(t *testing.T) {
 		found = true
 	}
 	assert.True(t, found, "Expected to find a log record with the query text from the first time top query")
+	assert.True(t, foundSuperuserQuery, "Expected the superuser-owned query to still be reported as a top query")
 
 	_, err = db.Exec("Select * from test2 where id = 67")
 	assert.NoError(t, err)

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -364,7 +364,10 @@ func (p *postgreSQLScraper) collectTopQuery(ctx context.Context, clientFactory p
 		queryID := item.Value[dbAttributePrefix+queryidColumnName].(string)
 		rawQuery, _ := item.Value[dbAttributePrefix+"raw_query"].(string)
 		plan, ok := p.queryPlanCache.Get(queryID + "-plan")
-		if !ok && explained < maxExplainEachInterval {
+		// EXPLAIN can fail for superuser-owned queries, which often reference objects the
+		// monitoring user cannot read. Skip the attempt; the query is still reported.
+		isSuperuser, _ := item.Value[dbAttributePrefix+"rolsuper"].(string)
+		if !ok && isSuperuser != "true" && explained < maxExplainEachInterval {
 			database := item.Value[string(semconv.DBNamespaceKey)].(string)
 			dbClient, err := clientFactory.getClient(database)
 			if err == nil {

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -574,6 +574,7 @@ func TestScrapeTopQueries(t *testing.T) {
 		"query":               "select * from pg_stat_activity where id = 32",
 		"queryid":             queryid,
 		"rolname":             "master",
+		"rolsuper":            "false",
 		"rows":                "30",
 		"total_exec_time":     "11000",
 		"total_plan_time":     "12000",
@@ -622,6 +623,75 @@ func TestScrapeTopQueries(t *testing.T) {
 	planTime, planTimeExists := scraper.cache.Get(queryid + totalPlanTimeColumnName)
 	assert.True(t, planTimeExists)
 	assert.Equal(t, float64(12), planTime)
+}
+
+func TestScrapeTopQueriesSkipsExplainForSuperuserQueries(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Databases = []string{}
+	cfg.Events.DbServerTopQuery.Enabled = true
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	assert.NoError(t, err)
+
+	defer db.Close()
+
+	factory := mockSimpleClientFactory{db: db}
+
+	settings := receivertest.NewNopSettings(metadata.Type)
+	logger, err := zap.NewProduction()
+	assert.NoError(t, err)
+	settings.TelemetrySettings = component.TelemetrySettings{Logger: logger}
+
+	queryid := "114514"
+	returnedValues := map[string]string{
+		"calls":               "123",
+		"datname":             "postgres",
+		"shared_blks_dirtied": "1111",
+		"shared_blks_hit":     "1112",
+		"shared_blks_read":    "1113",
+		"shared_blks_written": "1114",
+		"local_blks_hit":      "2001",
+		"local_blks_read":     "2002",
+		"local_blks_dirtied":  "2003",
+		"local_blks_written":  "2004",
+		"temp_blks_read":      "1115",
+		"temp_blks_written":   "1116",
+		"query":               "select * from pg_stat_activity where id = 32",
+		"queryid":             queryid,
+		"rolname":             "postgres",
+		"rolsuper":            "true",
+		"rows":                "30",
+		"total_exec_time":     "11000",
+		"total_plan_time":     "12000",
+	}
+
+	rowNames := make([]string, 0, len(returnedValues))
+	var valuesBuilder strings.Builder
+	for k, v := range returnedValues {
+		rowNames = append(rowNames, k)
+		valuesBuilder.WriteString(fmt.Sprintf("%s,", v))
+	}
+	values := valuesBuilder.String()
+
+	scraper := newPostgreSQLScraper(settings, cfg, factory, newCache(30), newTTLCache[string](10, time.Minute))
+
+	// Only the top query itself is expected. Deliberately no EXPLAIN expectation.
+	mock.ExpectQuery(expectedScrapeTopQuery).WillReturnRows(sqlmock.NewRows(rowNames).FromCSVString(values[:len(values)-1]))
+
+	actualLogs, err := scraper.scrapeTopQuery(t.Context(), 31, 32, 33, time.Minute)
+	assert.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	// A failed EXPLAIN attempt would still cache an empty plan, so an absent cache
+	// entry is what distinguishes "skipped" from "attempted and failed".
+	_, cached := scraper.queryPlanCache.Get(queryid + "-plan")
+	assert.False(t, cached, "no EXPLAIN should have been attempted for a superuser query")
+
+	// The query is still reported, just without a plan.
+	records := actualLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
+	require.Equal(t, 1, records.Len())
+	planAttr, exists := records.At(0).Attributes().Get("postgresql.query_plan")
+	require.True(t, exists)
+	assert.Empty(t, planAttr.Str())
 }
 
 func TestIsExplainableQuery(t *testing.T) {

--- a/receiver/postgresqlreceiver/templates/topQueryTemplate.tmpl
+++ b/receiver/postgresqlreceiver/templates/topQueryTemplate.tmpl
@@ -14,6 +14,7 @@ SELECT
   query,
   queryid::TEXT,
   rolname,
+  rolsuper::TEXT,
   rows::TEXT,
   total_exec_time,
   total_plan_time

--- a/receiver/postgresqlreceiver/testdata/integration/01-init.sql
+++ b/receiver/postgresqlreceiver/testdata/integration/01-init.sql
@@ -22,6 +22,9 @@ CREATE TABLE test2 (
 CREATE INDEX otelindex ON test1(id);
 CREATE INDEX otel2index ON test2(id);
 
+CREATE USER appuser WITH PASSWORD 'apppass';
+GRANT SELECT ON test2 TO appuser;
+
 -- Generating usage of index
 INSERT INTO test2 (id)
 VALUES(67);

--- a/receiver/postgresqlreceiver/testdata/scraper/top-query/expectedSql.sql
+++ b/receiver/postgresqlreceiver/testdata/scraper/top-query/expectedSql.sql
@@ -14,6 +14,7 @@ SELECT
   query,
   queryid::TEXT,
   rolname,
+  rolsuper::TEXT,
   rows::TEXT,
   total_exec_time,
   total_plan_time


### PR DESCRIPTION
### Description

EXPLAIN must resolve every object a query references, so it fails with a permission error when the monitoring user lacks grants on those objects. Queries owned by superusers routinely reference objects outside a least-privilege monitoring user's grants.

Each such query is retried every time its plan-cache entry expires. Every attempt logs an error, opens and closes a connection, and consumes one slot of the per-interval EXPLAIN budget (max_explain_each_interval).

This selects rolsuper alongside the existing rolname join in the top query template and skips the EXPLAIN when it is true. rolsuper is used only for that decision and is not emitted as an attribute.

  ### Design note

Superuser-owned queries are kept in the top query results with only the explain plan omitted, rather than filtered out in the `WHERE` clause. The `AND NOT rolsuper` condition previously in this template was removed in [#556](https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/556) so that top SQL would include queries from all users, and restoring it would undo that.

  ### Testing

**Unit** - added `TestScrapeTopQueriesSkipsExplainForSuperuserQueries`. No EXPLAIN expectation is registered on the mock, so an unexpected EXPLAIN fails ExpectationsWereMet(). It also asserts the plan cache holds no entry for the query: a failed attempt would still cache an empty plan, so an absent entry is what distinguishes "skipped" from "attempted and failed". Finally it asserts the query is still emitted, with an empty postgresql.query_plan. 

**Integration**- `TestScrapeLogsFromContainer` extended to cover both branches against PostgreSQL. The query under test now runs as a new non-superuser role (appuser) and asserts a non-empty plan; a second query runs as the superuser root and asserts it is still reported as a top query with an empty plan. Confirmed the new assertion fails without this change. 

Integration tests for this receiver were run locally and all passed. In CI, tests for this module is in the `receiver-2` group, where test iterates alphabetically and stops on `receiver/podmanreceiver`'s failing `TestEventLoopHandles` before reaching `postgresqlreceiver`, so `integration-tests-matrix (receiver-2)` reports a failure without running this module's tests. That failure is unrelated to this change and will be handled separately.