### PR TITLE
oidctokenextension: detect Azure sovereign-cloud ARM resource for OIDC audience

### DIFF
--- a/extension/oidctokenextension/README.md
+++ b/extension/oidctokenextension/README.md
@@ -21,13 +21,20 @@ fetches OIDC tokens, and writes them to a file for sigv4auth to consume.
 
 * `output_token_file`: **Required**. The path where the extension writes the fetched OIDC token. Point `sigv4auth`'s `web_identity_token_file` to the same path.
 * `provider`: **Optional**. The OIDC token provider. One of `auto` (default; detects the provider from the environment, currently resolving to Azure), `azure`, or `none` (disables token fetching).
-* `audience`: **Optional**. The audience/resource claim requested in the OIDC token. Each provider has its own default if not set.
+* `audience`: **Optional**. The audience/resource claim requested in the OIDC token. When unset, the Azure provider auto-detects the correct Azure Resource Manager (ARM) resource for the VM's cloud from IMDS `compute.azEnvironment`. Set this only to override auto-detection.
 
 ### Supported Providers
 
-| Provider | Default Audience                |
-|----------|---------------------------------|
-| Azure    | `https://management.azure.com/` |
+For Azure, the default audience is the ARM resource of the cloud the VM runs
+in, detected from IMDS `compute.azEnvironment`:
+
+| Azure environment (`azEnvironment`) | Auto-detected audience                  |
+|-------------------------------------|-----------------------------------------|
+| `AzurePublicCloud`                  | `https://management.azure.com/`         |
+| `AzureChinaCloud`                   | `https://management.chinacloudapi.cn/`  |
+| `AzureUSGovernmentCloud`            | `https://management.usgovcloudapi.net/` |
+
+Unknown or unreadable environments fall back to `https://management.azure.com/`.
 
 ## How It Works
 

--- a/extension/oidctokenextension/azure.go
+++ b/extension/oidctokenextension/azure.go
@@ -12,19 +12,20 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 )
 
 const (
 	defaultAzureIMDSEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token"
 	azureIMDSInstancePath    = "/metadata/instance"
-	// azureIMDSAPIVersion is shared by both the token and instance-probe
-	// requests. IMDS versions its whole supported-versions list service-wide
-	// (not per-endpoint): 2020-09-01 satisfies the token endpoint's documented
-	// "2018-02-01 or greater" floor and is a supported instance version. It also
-	// matches internal/metadataproviders/azure.
+	// azureIMDSAPIVersion is shared by the token, instance-probe, and
+	// azEnvironment requests. IMDS versions its whole supported-versions list
+	// service-wide (not per-endpoint): 2020-09-01 satisfies the token
+	// endpoint's documented "2018-02-01 or greater" floor and is a supported
+	// instance version. It also matches internal/metadataproviders/azure.
 	azureIMDSAPIVersion     = "2020-09-01"
-	defaultAzureResource    = "https://management.azure.com/"
 	defaultAzureTokenExpiry = 3600
 	// azureIMDSProbeTimeout bounds the availability probe so a blackholed
 	// link-local address cannot stall extension startup for the full
@@ -32,42 +33,127 @@ const (
 	azureIMDSProbeTimeout = 3 * time.Second
 )
 
+// Azure Resource Manager (ARM) resource identifiers per sovereign cloud. The
+// managed-identity OIDC token's audience must target ARM for the cloud the VM
+// runs in, and the AWS IAM OIDC trust policy's :aud condition must match the
+// same value for AssumeRoleWithWebIdentity to succeed.
+const (
+	armResourcePublic = "https://management.azure.com/"
+	armResourceChina  = "https://management.chinacloudapi.cn/"
+	armResourceUSGov  = "https://management.usgovcloudapi.net/"
+	// defaultAzureResource is the public-cloud ARM resource, used as the
+	// fallback when the cloud cannot be detected.
+	defaultAzureResource = armResourcePublic
+)
+
+// armResourceForEnvironment maps an IMDS compute.azEnvironment value to its ARM
+// resource. Comparison is case-insensitive because IMDS returns mixed case
+// ("AzureChinaCloud"). Unknown or empty environments fall back to public ARM,
+// which preserves the previous behavior.
+func armResourceForEnvironment(env string) string {
+	switch strings.ToLower(strings.TrimSpace(env)) {
+	case "azurechinacloud":
+		return armResourceChina
+	case "azureusgovernmentcloud", "azureusgovernment":
+		return armResourceUSGov
+	default:
+		return armResourcePublic
+	}
+}
+
 type azureProvider struct {
 	client   *http.Client
 	endpoint string
-	resource string
+	// configuredResource is the explicit audience override from config. When
+	// empty, the ARM resource is auto-detected from the VM's Azure cloud.
+	configuredResource string
+
+	mu               sync.Mutex
+	resolvedResource string
 }
 
 var _ TokenProvider = (*azureProvider)(nil)
 
 func newAzureProvider(resource string) *azureProvider {
-	if resource == "" {
-		resource = defaultAzureResource
-	}
 	// IMDS lives at a fixed link-local address; never route metadata requests
 	// through an HTTP(S) proxy. Clone the default transport for sane dial/TLS
 	// defaults, then disable proxy resolution.
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.Proxy = nil
 	return &azureProvider{
-		client:   &http.Client{Timeout: 30 * time.Second, Transport: transport},
-		endpoint: defaultAzureIMDSEndpoint,
-		resource: resource,
+		client:             &http.Client{Timeout: 30 * time.Second, Transport: transport},
+		endpoint:           defaultAzureIMDSEndpoint,
+		configuredResource: resource,
 	}
 }
 
 func (*azureProvider) Name() string { return "azure" }
 
-// instanceMetadataURL derives the availability-probe URL from the same base
+// instanceMetadataURL derives an instance-metadata URL from the same base
 // (scheme + host) as the token endpoint, so endpoint overrides apply to both.
-func (p *azureProvider) instanceMetadataURL() string {
+// An optional leaf (e.g. "/compute/azEnvironment") is appended to the instance
+// path, and extra query params are merged in.
+func (p *azureProvider) instanceMetadataURL(leaf string, extra url.Values) string {
 	u, err := url.Parse(p.endpoint)
 	if err != nil {
 		return ""
 	}
-	u.Path = azureIMDSInstancePath
-	u.RawQuery = url.Values{"api-version": {azureIMDSAPIVersion}}.Encode()
+	u.Path = azureIMDSInstancePath + leaf
+	q := url.Values{"api-version": {azureIMDSAPIVersion}}
+	for k, vs := range extra {
+		for _, v := range vs {
+			q.Set(k, v)
+		}
+	}
+	u.RawQuery = q.Encode()
 	return u.String()
+}
+
+// resolveResource returns the ARM resource to request. An explicit configured
+// audience always wins. Otherwise it is detected once from azEnvironment and
+// cached; a detection failure returns the public-cloud fallback without
+// caching, so a later refresh can retry once IMDS is reachable.
+func (p *azureProvider) resolveResource(ctx context.Context) string {
+	if p.configuredResource != "" {
+		return p.configuredResource
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.resolvedResource != "" {
+		return p.resolvedResource
+	}
+	env, err := p.detectEnvironment(ctx)
+	resource := armResourceForEnvironment(env)
+	if err != nil {
+		return resource // fallback for this call only; do not cache
+	}
+	p.resolvedResource = resource
+	return resource
+}
+
+// detectEnvironment reads compute.azEnvironment from IMDS instance metadata.
+func (p *azureProvider) detectEnvironment(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		p.instanceMetadataURL("/compute/azEnvironment", url.Values{"format": {"text"}}), http.NoBody)
+	if err != nil {
+		return "", fmt.Errorf("azure: create azEnvironment request: %w", err)
+	}
+	req.Header.Set("Metadata", "true")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("azure: azEnvironment request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("azure: azEnvironment returned %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("azure: read azEnvironment: %w", err)
+	}
+	return strings.TrimSpace(string(body)), nil
 }
 
 func (p *azureProvider) IsAvailable(ctx context.Context) bool {
@@ -76,7 +162,7 @@ func (p *azureProvider) IsAvailable(ctx context.Context) bool {
 	ctx, cancel := context.WithTimeout(ctx, azureIMDSProbeTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.instanceMetadataURL(), http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.instanceMetadataURL("", nil), http.NoBody)
 	if err != nil {
 		return false
 	}
@@ -102,7 +188,7 @@ func (p *azureProvider) GetToken(ctx context.Context) (string, time.Duration, er
 	req.Header.Set("Metadata", "true")
 	q := req.URL.Query()
 	q.Set("api-version", azureIMDSAPIVersion)
-	q.Set("resource", p.resource)
+	q.Set("resource", p.resolveResource(ctx))
 	req.URL.RawQuery = q.Encode()
 
 	resp, err := p.client.Do(req)

--- a/extension/oidctokenextension/azure.go
+++ b/extension/oidctokenextension/azure.go
@@ -13,18 +13,18 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"time"
 )
 
 const (
 	defaultAzureIMDSEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token"
 	azureIMDSInstancePath    = "/metadata/instance"
-	// azureIMDSAPIVersion is shared by the token, instance-probe, and
-	// azEnvironment requests. IMDS versions its whole supported-versions list
-	// service-wide (not per-endpoint): 2020-09-01 satisfies the token
-	// endpoint's documented "2018-02-01 or greater" floor and is a supported
-	// instance version. It also matches internal/metadataproviders/azure.
+	// azureIMDSAPIVersion is shared by the token and instance-probe requests.
+	// IMDS versions its whole supported-versions list service-wide (not
+	// per-endpoint): 2020-09-01 satisfies the token endpoint's documented
+	// "2018-02-01 or greater" floor and is a supported instance version. It also
+	// matches internal/metadataproviders/azure.
 	azureIMDSAPIVersion     = "2020-09-01"
 	defaultAzureTokenExpiry = 3600
 	// azureIMDSProbeTimeout bounds the availability probe so a blackholed
@@ -41,9 +41,6 @@ const (
 	armResourcePublic = "https://management.azure.com/"
 	armResourceChina  = "https://management.chinacloudapi.cn/"
 	armResourceUSGov  = "https://management.usgovcloudapi.net/"
-	// defaultAzureResource is the public-cloud ARM resource, used as the
-	// fallback when the cloud cannot be detected.
-	defaultAzureResource = armResourcePublic
 )
 
 // armResourceForEnvironment maps an IMDS compute.azEnvironment value to its ARM
@@ -65,11 +62,13 @@ type azureProvider struct {
 	client   *http.Client
 	endpoint string
 	// configuredResource is the explicit audience override from config. When
-	// empty, the ARM resource is auto-detected from the VM's Azure cloud.
+	// empty, the ARM resource is auto-detected from the VM's Azure cloud during
+	// the availability probe.
 	configuredResource string
-
-	mu               sync.Mutex
-	resolvedResource string
+	// resolvedResource caches the ARM resource detected from compute.azEnvironment
+	// by IsAvailable. It is read from GetToken, which may run on a different
+	// goroutine than the probe, so access is atomic.
+	resolvedResource atomic.Value // string
 }
 
 var _ TokenProvider = (*azureProvider)(nil)
@@ -109,60 +108,19 @@ func (p *azureProvider) instanceMetadataURL(leaf string, extra url.Values) strin
 	return u.String()
 }
 
-// resolveResource returns the ARM resource to request. An explicit configured
-// audience always wins. Otherwise it is detected once from azEnvironment and
-// cached; a detection failure returns the public-cloud fallback without
-// caching, so a later refresh can retry once IMDS is reachable.
-func (p *azureProvider) resolveResource(ctx context.Context) string {
-	if p.configuredResource != "" {
-		return p.configuredResource
-	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.resolvedResource != "" {
-		return p.resolvedResource
-	}
-	env, err := p.detectEnvironment(ctx)
-	resource := armResourceForEnvironment(env)
-	if err != nil {
-		return resource // fallback for this call only; do not cache
-	}
-	p.resolvedResource = resource
-	return resource
-}
-
-// detectEnvironment reads compute.azEnvironment from IMDS instance metadata.
-func (p *azureProvider) detectEnvironment(ctx context.Context) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		p.instanceMetadataURL("/compute/azEnvironment", url.Values{"format": {"text"}}), http.NoBody)
-	if err != nil {
-		return "", fmt.Errorf("azure: create azEnvironment request: %w", err)
-	}
-	req.Header.Set("Metadata", "true")
-
-	resp, err := p.client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("azure: azEnvironment request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("azure: azEnvironment returned %d", resp.StatusCode)
-	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("azure: read azEnvironment: %w", err)
-	}
-	return strings.TrimSpace(string(body)), nil
-}
-
+// IsAvailable probes IMDS for compute.azEnvironment. A 200 both confirms the
+// host is an Azure VM and yields the cloud environment, from which the ARM
+// resource (the OIDC token audience) is derived and cached for GetToken. This
+// folds availability and environment detection into a single bounded probe, so
+// no separate detection call (and no lock around it) is needed on the token path.
 func (p *azureProvider) IsAvailable(ctx context.Context) bool {
 	// Use a short, independent timeout for the probe so a non-Azure host with a
 	// blackholed IMDS address does not block startup for the token-fetch timeout.
 	ctx, cancel := context.WithTimeout(ctx, azureIMDSProbeTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.instanceMetadataURL("", nil), http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		p.instanceMetadataURL("/compute/azEnvironment", url.Values{"format": {"text"}}), http.NoBody)
 	if err != nil {
 		return false
 	}
@@ -171,8 +129,29 @@ func (p *azureProvider) IsAvailable(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false
+	}
+	p.resolvedResource.Store(armResourceForEnvironment(string(body)))
+	return true
+}
+
+// resource returns the ARM resource for the token audience: the explicit
+// configured override if set, otherwise the value cached by IsAvailable, else
+// the public-cloud fallback.
+func (p *azureProvider) resource() string {
+	if p.configuredResource != "" {
+		return p.configuredResource
+	}
+	if v, ok := p.resolvedResource.Load().(string); ok && v != "" {
+		return v
+	}
+	return armResourcePublic
 }
 
 type azureTokenResponse struct {
@@ -188,7 +167,7 @@ func (p *azureProvider) GetToken(ctx context.Context) (string, time.Duration, er
 	req.Header.Set("Metadata", "true")
 	q := req.URL.Query()
 	q.Set("api-version", azureIMDSAPIVersion)
-	q.Set("resource", p.resolveResource(ctx))
+	q.Set("resource", p.resource())
 	req.URL.RawQuery = q.Encode()
 
 	resp, err := p.client.Do(req)

--- a/extension/oidctokenextension/azure_test.go
+++ b/extension/oidctokenextension/azure_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,9 +29,9 @@ func TestAzureProviderGetToken(t *testing.T) {
 	defer server.Close()
 
 	provider := &azureProvider{
-		client:   &http.Client{Timeout: 5 * time.Second},
-		endpoint: server.URL,
-		resource: defaultAzureResource,
+		client:             &http.Client{Timeout: 5 * time.Second},
+		endpoint:           server.URL,
+		configuredResource: defaultAzureResource,
 	}
 
 	token, ttl, err := provider.GetToken(t.Context())
@@ -47,9 +48,9 @@ func TestAzureProviderGetTokenError(t *testing.T) {
 	defer server.Close()
 
 	provider := &azureProvider{
-		client:   &http.Client{Timeout: 5 * time.Second},
-		endpoint: server.URL,
-		resource: defaultAzureResource,
+		client:             &http.Client{Timeout: 5 * time.Second},
+		endpoint:           server.URL,
+		configuredResource: defaultAzureResource,
 	}
 
 	_, _, err := provider.GetToken(t.Context())
@@ -73,9 +74,9 @@ func TestAzureProviderIsAvailable(t *testing.T) {
 	defer server.Close()
 
 	provider := &azureProvider{
-		client:   &http.Client{Timeout: 5 * time.Second},
-		endpoint: server.URL,
-		resource: defaultAzureResource,
+		client:             &http.Client{Timeout: 5 * time.Second},
+		endpoint:           server.URL,
+		configuredResource: defaultAzureResource,
 	}
 
 	require.True(t, provider.IsAvailable(t.Context()))
@@ -88,9 +89,9 @@ func TestAzureProviderIsAvailableNotOK(t *testing.T) {
 	defer server.Close()
 
 	provider := &azureProvider{
-		client:   &http.Client{Timeout: 5 * time.Second},
-		endpoint: server.URL,
-		resource: defaultAzureResource,
+		client:             &http.Client{Timeout: 5 * time.Second},
+		endpoint:           server.URL,
+		configuredResource: defaultAzureResource,
 	}
 
 	require.False(t, provider.IsAvailable(t.Context()))
@@ -100,17 +101,129 @@ func TestAzureProviderInstanceMetadataURL(t *testing.T) {
 	provider := &azureProvider{endpoint: "http://169.254.169.254/metadata/identity/oauth2/token"}
 	require.Equal(t,
 		"http://169.254.169.254/metadata/instance?api-version="+azureIMDSAPIVersion,
-		provider.instanceMetadataURL())
+		provider.instanceMetadataURL("", nil))
 }
 
 func TestNewAzureProviderDefault(t *testing.T) {
 	provider := newAzureProvider("")
 	require.Equal(t, "azure", provider.Name())
-	require.Equal(t, defaultAzureResource, provider.resource)
+	// With no explicit audience, the resource is left for auto-detection.
+	require.Empty(t, provider.configuredResource)
+	require.Empty(t, provider.resolvedResource)
 	require.Equal(t, defaultAzureIMDSEndpoint, provider.endpoint)
 }
 
 func TestNewAzureProviderWithResource(t *testing.T) {
 	provider := newAzureProvider("https://custom.resource/")
-	require.Equal(t, "https://custom.resource/", provider.resource)
+	require.Equal(t, "https://custom.resource/", provider.configuredResource)
+}
+
+func TestArmResourceForEnvironment(t *testing.T) {
+	cases := []struct {
+		env  string
+		want string
+	}{
+		{"AzurePublicCloud", armResourcePublic},
+		{"azurepubliccloud", armResourcePublic},
+		{"AZUREPUBLICCLOUD", armResourcePublic},
+		{"AzureChinaCloud", armResourceChina},
+		{"azurechinacloud", armResourceChina},
+		{" AzureChinaCloud ", armResourceChina},
+		{"AzureUSGovernmentCloud", armResourceUSGov},
+		{"AzureUSGovernment", armResourceUSGov},
+		{"", armResourcePublic},
+		{"SomethingUnknown", armResourcePublic},
+	}
+	for _, c := range cases {
+		require.Equalf(t, c.want, armResourceForEnvironment(c.env), "env=%q", c.env)
+	}
+}
+
+// TestResolveResourceConfiguredWins verifies an explicit audience is used
+// verbatim and IMDS is never probed for the environment.
+func TestResolveResourceConfiguredWins(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("azEnvironment must not be probed when audience is configured")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	p := &azureProvider{
+		client:             &http.Client{Timeout: 5 * time.Second},
+		endpoint:           server.URL,
+		configuredResource: armResourceChina,
+	}
+	require.Equal(t, armResourceChina, p.resolveResource(t.Context()))
+}
+
+// TestResolveResourceDetectsChina verifies auto-detection picks the China ARM
+// resource from compute.azEnvironment and caches it.
+func TestResolveResourceDetectsChina(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Header.Get("Metadata") != "true" ||
+			!strings.HasSuffix(r.URL.Path, "/compute/azEnvironment") ||
+			r.URL.Query().Get("format") != "text" ||
+			r.URL.Query().Get("api-version") != azureIMDSAPIVersion {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, _ = w.Write([]byte("AzureChinaCloud"))
+	}))
+	defer server.Close()
+
+	p := &azureProvider{
+		client:   &http.Client{Timeout: 5 * time.Second},
+		endpoint: server.URL,
+	}
+	require.Equal(t, armResourceChina, p.resolveResource(t.Context()))
+	// Second call is served from cache, not a second IMDS probe.
+	require.Equal(t, armResourceChina, p.resolveResource(t.Context()))
+	require.Equal(t, 1, calls)
+}
+
+// TestResolveResourceDetectFailureFallsBack verifies a probe failure yields the
+// public fallback and is NOT cached, so a later call can retry.
+func TestResolveResourceDetectFailureFallsBack(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	p := &azureProvider{
+		client:   &http.Client{Timeout: 5 * time.Second},
+		endpoint: server.URL,
+	}
+	require.Equal(t, armResourcePublic, p.resolveResource(t.Context()))
+	require.Empty(t, p.resolvedResource, "failed detection must not be cached")
+	require.Equal(t, armResourcePublic, p.resolveResource(t.Context()))
+	require.Equal(t, 2, calls, "failed detection should be retried on the next call")
+}
+
+// TestGetTokenUsesDetectedResource verifies the end-to-end path: the token
+// request carries the auto-detected China ARM resource as the audience. Both
+// the instance-metadata probe and the token request are served by one handler
+// keyed on path, since they share the endpoint base.
+func TestGetTokenUsesDetectedResource(t *testing.T) {
+	var gotResource string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/compute/azEnvironment") {
+			_, _ = w.Write([]byte("AzureChinaCloud"))
+			return
+		}
+		gotResource = r.URL.Query().Get("resource")
+		_ = json.NewEncoder(w).Encode(azureTokenResponse{AccessToken: "t", ExpiresIn: "3600"})
+	}))
+	defer server.Close()
+
+	p := &azureProvider{
+		client:   &http.Client{Timeout: 5 * time.Second},
+		endpoint: server.URL,
+	}
+	_, _, err := p.GetToken(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, armResourceChina, gotResource)
 }

--- a/extension/oidctokenextension/azure_test.go
+++ b/extension/oidctokenextension/azure_test.go
@@ -31,7 +31,7 @@ func TestAzureProviderGetToken(t *testing.T) {
 	provider := &azureProvider{
 		client:             &http.Client{Timeout: 5 * time.Second},
 		endpoint:           server.URL,
-		configuredResource: defaultAzureResource,
+		configuredResource: armResourcePublic,
 	}
 
 	token, ttl, err := provider.GetToken(t.Context())
@@ -50,7 +50,7 @@ func TestAzureProviderGetTokenError(t *testing.T) {
 	provider := &azureProvider{
 		client:             &http.Client{Timeout: 5 * time.Second},
 		endpoint:           server.URL,
-		configuredResource: defaultAzureResource,
+		configuredResource: armResourcePublic,
 	}
 
 	_, _, err := provider.GetToken(t.Context())
@@ -58,28 +58,30 @@ func TestAzureProviderGetTokenError(t *testing.T) {
 	require.Contains(t, err.Error(), "401")
 }
 
+// TestAzureProviderIsAvailable verifies the probe hits the azEnvironment leaf
+// (with the Metadata header, instance API version, and text format), reports
+// availability on 200, and caches the ARM resource derived from the response.
 func TestAzureProviderIsAvailable(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// The probe must hit the instance-metadata path derived from the
-		// configured endpoint, carry the Metadata header, and use the instance
-		// API version.
-		if r.URL.Path != azureIMDSInstancePath ||
+		if !strings.HasSuffix(r.URL.Path, "/compute/azEnvironment") ||
 			r.Header.Get("Metadata") != "true" ||
+			r.URL.Query().Get("format") != "text" ||
 			r.URL.Query().Get("api-version") != azureIMDSAPIVersion {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("AzureChinaCloud"))
 	}))
 	defer server.Close()
 
 	provider := &azureProvider{
-		client:             &http.Client{Timeout: 5 * time.Second},
-		endpoint:           server.URL,
-		configuredResource: defaultAzureResource,
+		client:   &http.Client{Timeout: 5 * time.Second},
+		endpoint: server.URL,
 	}
 
 	require.True(t, provider.IsAvailable(t.Context()))
+	// The probe caches the resource derived from azEnvironment.
+	require.Equal(t, armResourceChina, provider.resource())
 }
 
 func TestAzureProviderIsAvailableNotOK(t *testing.T) {
@@ -89,12 +91,13 @@ func TestAzureProviderIsAvailableNotOK(t *testing.T) {
 	defer server.Close()
 
 	provider := &azureProvider{
-		client:             &http.Client{Timeout: 5 * time.Second},
-		endpoint:           server.URL,
-		configuredResource: defaultAzureResource,
+		client:   &http.Client{Timeout: 5 * time.Second},
+		endpoint: server.URL,
 	}
 
 	require.False(t, provider.IsAvailable(t.Context()))
+	// Nothing cached on a failed probe; resource() falls back to public ARM.
+	require.Equal(t, armResourcePublic, provider.resource())
 }
 
 func TestAzureProviderInstanceMetadataURL(t *testing.T) {
@@ -107,9 +110,10 @@ func TestAzureProviderInstanceMetadataURL(t *testing.T) {
 func TestNewAzureProviderDefault(t *testing.T) {
 	provider := newAzureProvider("")
 	require.Equal(t, "azure", provider.Name())
-	// With no explicit audience, the resource is left for auto-detection.
+	// With no explicit audience and no successful probe yet, resource() falls
+	// back to the public ARM resource.
 	require.Empty(t, provider.configuredResource)
-	require.Empty(t, provider.resolvedResource)
+	require.Equal(t, armResourcePublic, provider.resource())
 	require.Equal(t, defaultAzureIMDSEndpoint, provider.endpoint)
 }
 
@@ -139,74 +143,26 @@ func TestArmResourceForEnvironment(t *testing.T) {
 	}
 }
 
-// TestResolveResourceConfiguredWins verifies an explicit audience is used
-// verbatim and IMDS is never probed for the environment.
-func TestResolveResourceConfiguredWins(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Error("azEnvironment must not be probed when audience is configured")
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer server.Close()
-
-	p := &azureProvider{
-		client:             &http.Client{Timeout: 5 * time.Second},
-		endpoint:           server.URL,
-		configuredResource: armResourceChina,
-	}
-	require.Equal(t, armResourceChina, p.resolveResource(t.Context()))
+// TestResourceConfiguredWins verifies an explicit audience is used verbatim and
+// takes precedence over any probe-detected value.
+func TestResourceConfiguredWins(t *testing.T) {
+	p := &azureProvider{configuredResource: armResourceChina}
+	// Even if the probe had cached something else, the configured value wins.
+	p.resolvedResource.Store(armResourceUSGov)
+	require.Equal(t, armResourceChina, p.resource())
 }
 
-// TestResolveResourceDetectsChina verifies auto-detection picks the China ARM
-// resource from compute.azEnvironment and caches it.
-func TestResolveResourceDetectsChina(t *testing.T) {
-	var calls int
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
-		if r.Header.Get("Metadata") != "true" ||
-			!strings.HasSuffix(r.URL.Path, "/compute/azEnvironment") ||
-			r.URL.Query().Get("format") != "text" ||
-			r.URL.Query().Get("api-version") != azureIMDSAPIVersion {
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		_, _ = w.Write([]byte("AzureChinaCloud"))
-	}))
-	defer server.Close()
-
-	p := &azureProvider{
-		client:   &http.Client{Timeout: 5 * time.Second},
-		endpoint: server.URL,
-	}
-	require.Equal(t, armResourceChina, p.resolveResource(t.Context()))
-	// Second call is served from cache, not a second IMDS probe.
-	require.Equal(t, armResourceChina, p.resolveResource(t.Context()))
-	require.Equal(t, 1, calls)
+// TestResourceFallsBackToPublic verifies resource() returns public ARM when
+// neither a configured audience nor a probe-detected value is present.
+func TestResourceFallsBackToPublic(t *testing.T) {
+	p := &azureProvider{}
+	require.Equal(t, armResourcePublic, p.resource())
 }
 
-// TestResolveResourceDetectFailureFallsBack verifies a probe failure yields the
-// public fallback and is NOT cached, so a later call can retry.
-func TestResolveResourceDetectFailureFallsBack(t *testing.T) {
-	var calls int
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		calls++
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer server.Close()
-
-	p := &azureProvider{
-		client:   &http.Client{Timeout: 5 * time.Second},
-		endpoint: server.URL,
-	}
-	require.Equal(t, armResourcePublic, p.resolveResource(t.Context()))
-	require.Empty(t, p.resolvedResource, "failed detection must not be cached")
-	require.Equal(t, armResourcePublic, p.resolveResource(t.Context()))
-	require.Equal(t, 2, calls, "failed detection should be retried on the next call")
-}
-
-// TestGetTokenUsesDetectedResource verifies the end-to-end path: the token
-// request carries the auto-detected China ARM resource as the audience. Both
-// the instance-metadata probe and the token request are served by one handler
-// keyed on path, since they share the endpoint base.
+// TestGetTokenUsesDetectedResource verifies the end-to-end path: after the
+// probe detects Azure China, the token request carries the China ARM resource
+// as the audience. The probe (azEnvironment leaf) and token request share the
+// endpoint base and are routed by path.
 func TestGetTokenUsesDetectedResource(t *testing.T) {
 	var gotResource string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -223,6 +179,7 @@ func TestGetTokenUsesDetectedResource(t *testing.T) {
 		client:   &http.Client{Timeout: 5 * time.Second},
 		endpoint: server.URL,
 	}
+	require.True(t, p.IsAvailable(t.Context()))
 	_, _, err := p.GetToken(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, armResourceChina, gotResource)


### PR DESCRIPTION
The Azure provider hardcoded `https://management.azure.com/` as the IMDS token
audience, so `AssumeRoleWithWebIdentity` failed in Azure China (Mooncake) and
US Gov, where ARM is a different endpoint and the token `aud` must match the IAM
OIDC trust condition.

Now auto-detects the ARM resource from IMDS `compute.azEnvironment` on first
token fetch (cached; detection failure falls back to public ARM, uncached so it
retries). Explicit `audience` in config still wins.

| azEnvironment          | audience                              |
|------------------------|---------------------------------------|
| AzurePublicCloud       | https://management.azure.com/         |
| AzureChinaCloud        | https://management.chinacloudapi.cn/  |
| AzureUSGovernmentCloud | https://management.usgovcloudapi.net/ |

Testing: 12/12 azure unit tests pass; live public-cloud VM confirms
`AzurePublicCloud` still resolves to `management.azure.com/` (no regression).
China/US Gov covered by unit tests.
