### PR TITLE
[receiver/podmanreceiver] Fix flaky TestEventLoopHandles

### DIFF
--- a/receiver/podmanreceiver/podman_test.go
+++ b/receiver/podmanreceiver/podman_test.go
@@ -136,12 +136,12 @@ func TestEventLoopHandlesError(t *testing.T) {
 	go cli.containerEventLoop(ctx)
 	defer cancel()
 
-	assert.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(tt *assert.CollectT) {
 		for _, l := range logs.All() {
-			assert.Contains(t, l.Message, "Error watching podman container events")
-			assert.Contains(t, l.ContextMap()["error"], "EOF")
+			assert.Contains(tt, l.Message, "Error watching podman container events")
+			assert.Contains(tt, l.ContextMap()["error"], "EOF")
 		}
-		return len(logs.All()) > 0
+		assert.NotEmpty(tt, logs.All())
 	}, 1*time.Second, 1*time.Millisecond, "failed to find desired error logs.")
 
 	finished := make(chan struct{})
@@ -182,18 +182,18 @@ func TestEventLoopHandles(t *testing.T) {
 
 	eventChan <- event{ID: "c1", Status: "start"}
 
-	assert.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(tt *assert.CollectT) {
 		cli.containersLock.Lock()
 		defer cli.containersLock.Unlock()
-		return assert.Len(t, cli.containers, 1)
+		assert.Len(tt, cli.containers, 1)
 	}, 1*time.Second, 1*time.Millisecond, "failed to update containers list.")
 
 	eventChan <- event{ID: "c1", Status: "died"}
 
-	assert.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(tt *assert.CollectT) {
 		cli.containersLock.Lock()
 		defer cli.containersLock.Unlock()
-		return assert.Empty(t, cli.containers)
+		assert.Empty(tt, cli.containers)
 	}, 1*time.Second, 1*time.Millisecond, "failed to update containers list.")
 }
 


### PR DESCRIPTION
#### Description

`TestEventLoopHandles` fails intermittently under `go test -race -count=20`, at roughly a 50% rate locally. Failure signature is always:

```
FAIL: TestEventLoopHandles (0.00s)
    podman_test.go:196:
        Error: Should be empty, but was map[c1:{...}]
```

Root cause is testify's `assert.Eventually` predicate calling `assert.X(t, ...)` helpers inside the polling closure:

```go
assert.Eventually(t, func() bool {
    cli.containersLock.Lock()
    defer cli.containersLock.Unlock()
    return assert.Empty(t, cli.containers)
}, 1*time.Second, 1*time.Millisecond, "failed to update containers list.")
```

`assert.Empty(t, ...)` returns a bool AND calls `t.Errorf(...)` on failure, which permanently marks the outer test failed. `Eventually` calls this predicate on a 1ms tick. On the first poll `cli.containers` still holds `c1`, so `assert.Empty` fires `t.Errorf` before the goroutine under test has had a chance to drain the channel. `Eventually` continues polling, eventually observes the drained state and returns "success," but `t.Failed()` is already true, so the test runner prints `FAIL` regardless.

This change migrates all three `assert.Eventually` blocks in `podman_test.go` (two in `TestEventLoopHandles`, one in `TestEventLoopHandlesError`) to `assert.EventuallyWithT` + `*assert.CollectT`. `EventuallyWithT` creates a fresh `CollectT` per poll and only promotes errors to `t` on timeout, so transient failed polls no longer permanently mark the outer test failed.

#### Testing

Local tests, before vs. after this change:

| Scenario | Before | After |
|---|---|---|
| `go test -race -count=20 -run TestEventLoopHandles` | 10 fails / 20 | 0 fails / 20 |
| `go test -race -cpu=1 -count=20 -run TestEventLoopHandles` | 7 fails / 20 | 0 fails / 20 |
| `go test -race -count=100 -run TestEventLoopHandles` | 48 fails / 100 | 0 fails / 100 |
| `go test -race -count=100 -run TestEventLoopHandlesError` | 0 fails / 100 | 0 fails / 100 |
