### PR TITLE
[k8sattributesprocessor] extract pod.spec.runtimeClassName as k8s.pod.runtimeclass

### DIFF
--- a/.chloggen/k8sattributesprocessor-runtimeclass.yaml
+++ b/.chloggen/k8sattributesprocessor-runtimeclass.yaml
@@ -1,0 +1,23 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sattributesprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add support for extracting a pod's spec.runtimeClassName as the k8s.pod.runtimeclass resource attribute
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [534]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  k8s.pod.runtimeclass is opt-in via the metadata list and is not added by default. It surfaces the
+  RuntimeClass a pod runs under, which downstream processors can use to distinguish VM-isolated pods
+  whose workload runs outside the host's shared kernel.

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -78,6 +78,7 @@ are then also available for the use within association rules. Available attribut
   - k8s.pod.ip
   - k8s.pod.start_time
   - k8s.pod.uid
+  - k8s.pod.runtimeclass
   - k8s.replicaset.uid
   - k8s.replicaset.name
   - k8s.deployment.uid

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -90,7 +90,7 @@ func (cfg *Config) Validate() error {
 	for _, field := range cfg.Extract.Metadata {
 		switch field {
 		case conventions.AttributeK8SNamespaceName, conventions.AttributeK8SPodName, conventions.AttributeK8SPodUID,
-			specPodHostName, metadataPodStartTime, metadataPodIP,
+			specPodHostName, metadataPodStartTime, metadataPodIP, metadataPodRuntimeClass,
 			conventions.AttributeK8SDeploymentName, conventions.AttributeK8SDeploymentUID,
 			conventions.AttributeK8SReplicaSetName, conventions.AttributeK8SReplicaSetUID,
 			conventions.AttributeK8SDaemonSetName, conventions.AttributeK8SDaemonSetUID,

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -546,6 +546,10 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 		tags[tagNodeName] = pod.Spec.NodeName
 	}
 
+	if c.Rules.RuntimeClassName && pod.Spec.RuntimeClassName != nil {
+		tags[tagRuntimeClassName] = *pod.Spec.RuntimeClassName
+	}
+
 	if c.Rules.ClusterUID {
 		if val, ok := c.Namespaces["kube-system"]; ok {
 			tags[tagClusterUID] = val.NamespaceUID
@@ -597,6 +601,10 @@ func removeUnnecessaryPodData(pod *api_v1.Pod, rules ExtractionRules) *api_v1.Po
 
 	if rules.PodHostName {
 		transformedPod.Spec.Hostname = pod.Spec.Hostname
+	}
+
+	if rules.RuntimeClassName {
+		transformedPod.Spec.RuntimeClassName = pod.Spec.RuntimeClassName
 	}
 
 	if needContainerAttributes(rules) {

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -636,6 +636,7 @@ func TestExtractionRules(t *testing.T) {
 	// Disable saving ip into k8s.pod.ip
 	c.Associations[0].Sources[0].Name = ""
 
+	runtimeClassName := "kata-containers"
 	pod := &api_v1.Pod{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:              "auth-service-abc12-xyz3",
@@ -677,8 +678,9 @@ func TestExtractionRules(t *testing.T) {
 			},
 		},
 		Spec: api_v1.PodSpec{
-			NodeName: "node1",
-			Hostname: "host1",
+			NodeName:         "node1",
+			Hostname:         "host1",
+			RuntimeClassName: &runtimeClassName,
 		},
 		Status: api_v1.PodStatus{
 			PodIP: "1.1.1.1",
@@ -711,6 +713,15 @@ func TestExtractionRules(t *testing.T) {
 			name:       "no-rules",
 			rules:      ExtractionRules{},
 			attributes: nil,
+		},
+		{
+			name: "runtimeClassName",
+			rules: ExtractionRules{
+				RuntimeClassName: true,
+			},
+			attributes: map[string]string{
+				"k8s.pod.runtimeclass": "kata-containers",
+			},
 		},
 		{
 			name: "deployment",

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -17,12 +17,13 @@ import (
 )
 
 const (
-	podNodeField            = "spec.nodeName"
-	ignoreAnnotation string = "opentelemetry.io/k8s-processor/ignore"
-	tagNodeName             = "k8s.node.name"
-	tagStartTime            = "k8s.pod.start_time"
-	tagHostName             = "k8s.pod.hostname"
-	tagClusterUID           = "k8s.cluster.uid"
+	podNodeField               = "spec.nodeName"
+	ignoreAnnotation    string = "opentelemetry.io/k8s-processor/ignore"
+	tagNodeName                = "k8s.node.name"
+	tagStartTime               = "k8s.pod.start_time"
+	tagHostName                = "k8s.pod.hostname"
+	tagClusterUID              = "k8s.cluster.uid"
+	tagRuntimeClassName        = "k8s.pod.runtimeclass"
 	// MetadataFromPod is used to specify to extract metadata/labels/annotations from pod
 	MetadataFromPod = "pod"
 	// MetadataFromNamespace is used to specify to extract metadata/labels/annotations from namespace
@@ -232,6 +233,7 @@ type ExtractionRules struct {
 	Node                      bool
 	NodeUID                   bool
 	StartTime                 bool
+	RuntimeClassName          bool
 	ContainerName             bool
 	ContainerID               bool
 	ContainerImageName        bool

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -25,6 +25,9 @@ const (
 	metadataPodIP        = "k8s.pod.ip"
 	metadataPodStartTime = "k8s.pod.start_time"
 	specPodHostName      = "k8s.pod.hostname"
+	// metadataPodRuntimeClass extracts pod.spec.runtimeClassName. There is no
+	// semconv attribute for it yet, so a custom key is used.
+	metadataPodRuntimeClass = "k8s.pod.runtimeclass"
 	// TODO: use k8s.cluster.uid, container.image.repo_digests
 	// from semconv when available,
 	//   replace clusterUID with conventions.AttributeK8SClusterUID
@@ -152,6 +155,8 @@ func withExtractMetadata(fields ...string) option {
 				p.rules.PodHostName = true
 			case metadataPodStartTime:
 				p.rules.StartTime = true
+			case metadataPodRuntimeClass:
+				p.rules.RuntimeClassName = true
 			case metadataPodIP:
 				p.rules.PodIP = true
 			case conventions.AttributeK8SDeploymentName:


### PR DESCRIPTION
## Description

Adds a new opt-in metadata extraction rule to the `k8sattributesprocessor` that
surfaces a pod's `spec.runtimeClassName` as the resource attribute
`k8s.pod.runtimeclass`.

Today the processor can extract labels, annotations, and a fixed set of pod
metadata, but there is no way to extract `runtimeClassName` — it is a pod spec
field with no corresponding extraction rule. This change adds one.

The attribute is **opt-in**: it is only populated when `k8s.pod.runtimeclass`
is listed in the processor's `extract.metadata`. It is not added by default and
does not change any existing behavior.

```yaml
processors:
  k8sattributes:
    extract:
      metadata:
        - k8s.pod.runtimeclass   # <-- new, opt-in
```

## Motivation

Pods running under a **VM-isolated RuntimeClass** (e.g. Kata Containers, gVisor,
or other micro-VM runtimes) execute their workload outside the host's shared
kernel. On the host there is only a bare, empty pod-slice cgroup, so node-level
cadvisor scrapes report `0` for that pod's cpu/memory/network usage — a
misleading "healthy idle pod" signal in dashboards.

`runtimeClassName` is the authoritative, control-plane-associated signal for
this condition. Exposing it as a resource attribute lets downstream processors
(e.g. `filter`/`transform` via OTTL) identify these pods and handle their
host-side cgroup metrics appropriately, without resorting to fragile cgroup-id
heuristics that would misclassify ordinary Guaranteed pods.

## Changes

- `internal/kube/kube.go`: add `tagRuntimeClassName` const and a
  `RuntimeClassName` field to `ExtractionRules`.
- `options.go`: add the `metadataPodRuntimeClass` key and map it to
  `rules.RuntimeClassName` in `withExtractMetadata`.
- `config.go`: allow the new key in `Validate()`.
- `internal/kube/client.go`: populate the attribute from
  `pod.Spec.RuntimeClassName` in `extractPodAttributes`, and preserve the field
  through `removeUnnecessaryPodData`.

## Testing

- Extended `TestExtractionRules` in `internal/kube/client_test.go` with a
  `runtimeClassName` case asserting `k8s.pod.runtimeclass` is extracted from the
  pod spec.
- `go test ./...` passes for the whole `k8sattributesprocessor` module.

## Documentation

- `README.md`: `k8s.pod.runtimeclass` documented in the list of available
  (non-default) attributes.
- `.chloggen`: enhancement changelog entry added.
