### PR TITLE
[awscontainerinsightreceiver] Recover container metrics for VM-isolated pods via kubelet Summary API

### DIFF
--- a/receiver/awscontainerinsightreceiver/config.go
+++ b/receiver/awscontainerinsightreceiver/config.go
@@ -89,6 +89,17 @@ type Config struct {
 	// RunOnSystemd is an optional attribute to run the receiver in an EC2 environment
 	RunOnSystemd bool `mapstructure:"run_on_systemd,omitempty"`
 
+	// EnableIsolatedPodSummaryMetrics enables a supplemental kubelet Summary API
+	// path (Linux/EKS only) that recovers container-scope metrics for VM-isolated
+	// pods (e.g. RuntimeClass isolated-sandbox / confidential-sandbox), whose host
+	// pod-slice cgroup is empty and therefore invisible to the cadvisor provider.
+	EnableIsolatedPodSummaryMetrics bool `mapstructure:"enable_isolated_pod_summary_metrics,omitempty"`
+
+	// IsolatedPodRuntimeClasses overrides the set of RuntimeClass names treated as
+	// VM-isolated by EnableIsolatedPodSummaryMetrics. When empty, a built-in
+	// default set is used.
+	IsolatedPodRuntimeClasses []string `mapstructure:"isolated_pod_runtime_classes,omitempty"`
+
 	// MiddlewareID is an ID for an extension that can be used to configure the
 	// AWS client.
 	MiddlewareID *component.ID `mapstructure:"middleware,omitempty"`

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/cpu_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/cpu_extractor.go
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build windows
-// +build windows
-
 package extractors // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors"
 
 import (

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractor.go
@@ -1,15 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build windows
-// +build windows
-
 package extractors // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors"
 
 import (
 	"time"
-
-	"github.com/Microsoft/hcsshim"
 
 	cExtractor "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores"
@@ -56,26 +51,6 @@ type NetworkStat struct {
 	TxErrors        uint64
 	DroppedIncoming uint64
 	DroppedOutgoing uint64
-}
-
-// HCSNetworkStat Network Stat from HCS.
-type HCSNetworkStat struct {
-	Name                   string
-	BytesReceived          uint64
-	BytesSent              uint64
-	DroppedPacketsIncoming uint64
-	DroppedPacketsOutgoing uint64
-}
-
-// HCSStat Stats from HCS.
-type HCSStat struct {
-	Time time.Time
-	Id   string //nolint:revive
-	Name string
-
-	CPU *hcsshim.ProcessorStats
-
-	Network *[]HCSNetworkStat
 }
 
 // RawMetric Represent Container, Pod, Node Metric  Extractors.

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractor_hcs_windows.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractor_hcs_windows.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+// +build windows
+
+package extractors // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors"
+
+import (
+	"time"
+
+	"github.com/Microsoft/hcsshim"
+)
+
+// HCSNetworkStat Network Stat from HCS.
+type HCSNetworkStat struct {
+	Name                   string
+	BytesReceived          uint64
+	BytesSent              uint64
+	DroppedPacketsIncoming uint64
+	DroppedPacketsOutgoing uint64
+}
+
+// HCSStat Stats from HCS.
+type HCSStat struct {
+	Time time.Time
+	Id   string //nolint:revive
+	Name string
+
+	CPU *hcsshim.ProcessorStats
+
+	Network *[]HCSNetworkStat
+}
+
+// convertHCSNetworkStats Convert HCS network system stats to Raw network stats
+func convertHCSNetworkStats(stat HCSStat, networkStat HCSNetworkStat) NetworkStat {
+	var networkstat NetworkStat
+
+	networkstat.Time = stat.Time
+
+	networkstat.Name = networkStat.Name
+	networkstat.TxBytes = networkStat.BytesSent
+	networkstat.RxBytes = networkStat.BytesReceived
+	networkstat.DroppedIncoming = networkStat.DroppedPacketsIncoming
+	networkstat.DroppedOutgoing = networkStat.DroppedPacketsOutgoing
+
+	return networkstat
+}
+
+// ConvertHCSContainerToRaw Converts HCS Container stats to RawMetric.
+func ConvertHCSContainerToRaw(containerStat HCSStat) RawMetric {
+	var rawMetic RawMetric
+
+	rawMetic.Id = containerStat.Id
+	rawMetic.Name = containerStat.Name
+	rawMetic.Time = containerStat.Time
+
+	if containerStat.Network != nil {
+		for _, val := range *containerStat.Network {
+			rawMetic.NetworkStats = append(rawMetic.NetworkStats, convertHCSNetworkStats(containerStat, val))
+		}
+	}
+
+	return rawMetic
+}

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractorhelpers.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/extractorhelpers.go
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build windows
-// +build windows
-
 package extractors // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors"
 
 import (
@@ -103,21 +100,6 @@ func convertNetworkStats(kubeletNetworkStat stats.NetworkStats, kubeletIntfStat 
 	return networkstat
 }
 
-// convertHCSNetworkStats Convert HCS network system stats to Raw network stats
-func convertHCSNetworkStats(stat HCSStat, networkStat HCSNetworkStat) NetworkStat {
-	var networkstat NetworkStat
-
-	networkstat.Time = stat.Time
-
-	networkstat.Name = networkStat.Name
-	networkstat.TxBytes = networkStat.BytesSent
-	networkstat.RxBytes = networkStat.BytesReceived
-	networkstat.DroppedIncoming = networkStat.DroppedPacketsIncoming
-	networkstat.DroppedOutgoing = networkStat.DroppedPacketsOutgoing
-
-	return networkstat
-}
-
 // ConvertPodToRaw Converts Kubelet Pod stats to RawMetric.
 func ConvertPodToRaw(podStat stats.PodStats) RawMetric {
 	var rawMetic RawMetric
@@ -209,23 +191,6 @@ func ConvertNodeToRaw(nodeStat stats.NodeStats) RawMetric {
 	if nodeStat.Network != nil {
 		for _, intfStats := range nodeStat.Network.Interfaces {
 			rawMetic.NetworkStats = append(rawMetic.NetworkStats, convertNetworkStats(*nodeStat.Network, intfStats))
-		}
-	}
-
-	return rawMetic
-}
-
-// ConvertHCSContainerToRaw Converts HCS Container stats to RawMetric.
-func ConvertHCSContainerToRaw(containerStat HCSStat) RawMetric {
-	var rawMetic RawMetric
-
-	rawMetic.Id = containerStat.Id
-	rawMetic.Name = containerStat.Name
-	rawMetic.Time = containerStat.Time
-
-	if containerStat.Network != nil {
-		for _, val := range *containerStat.Network {
-			rawMetic.NetworkStats = append(rawMetic.NetworkStats, convertHCSNetworkStats(containerStat, val))
 		}
 	}
 

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/fs_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/fs_extractor.go
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build windows
-// +build windows
-
 package extractors // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors"
 
 import (

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/mem_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/mem_extractor.go
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build windows
-// +build windows
-
 package extractors // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors"
 
 import (

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/net_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors/net_extractor.go
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build windows
-// +build windows
-
 package extractors // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors"
 
 import (

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet/client.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet/client.go
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build windows
-// +build windows
-
 package kubelet // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet"
 
 import (

--- a/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet/kubelet.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet/kubelet.go
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build windows
-// +build windows
-
 package kubelet // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows/kubelet"
 
 import (

--- a/receiver/awscontainerinsightreceiver/internal/summarysupplement/summarysupplement.go
+++ b/receiver/awscontainerinsightreceiver/internal/summarysupplement/summarysupplement.go
@@ -1,0 +1,229 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package summarysupplement recovers container-scope Container Insights metrics
+// for VM-isolated pods on Linux.
+//
+// A VM-isolated pod (e.g. one using a Nitro/Firecracker micro-VM RuntimeClass
+// such as "isolated-sandbox" or "confidential-sandbox") runs its workload inside
+// a guest VM. On the host there is only an empty pod-slice cgroup with no
+// container children, so the cadvisor container metrics provider — which reads
+// the host cgroup filesystem — emits nothing at all for these pods (not even a
+// misleading zero). The kubelet Summary API, on the other hand, is backed by the
+// CRI stats provider / in-guest agent and therefore reports the real in-guest
+// container CPU and memory usage.
+//
+// This provider reads the Summary API and emits TypeContainer records for the
+// gated (VM-isolated) pods only. It is meant to run alongside the cadvisor
+// provider: because cadvisor emits nothing for isolated pods, the two are
+// disjoint by pod and there is no double counting. Normal pods are untouched —
+// cadvisor remains their source.
+package summarysupplement // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/summarysupplement"
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	cExtractor "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8swindows/extractors"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil"
+)
+
+// DefaultIsolatedRuntimeClasses are the RuntimeClass names treated as VM-isolated
+// when the caller does not supply an explicit list.
+var DefaultIsolatedRuntimeClasses = []string{"isolated-sandbox", "confidential-sandbox"}
+
+// SummarySupplement is a metricsProvider that emits container-scope metrics for
+// VM-isolated pods sourced from the kubelet Summary API.
+type SummarySupplement struct {
+	logger        *zap.Logger
+	decorator     stores.Decorator
+	kubeletClient *kubeletutil.KubeletClient
+	hostInfo      cExtractor.CPUMemInfoProvider
+	extractors    []extractors.MetricExtractor
+	isolated      map[string]bool
+}
+
+// New creates a SummarySupplement.
+//
+// decorator should be the same decorator used by the cadvisor provider (the
+// LocalNodeDecorator wrapping the shared K8sDecorator), so that emitted records
+// receive identical node/instance/cluster tags and pod-spec-derived fields
+// (cpu/memory limit & request, and the *_over_container_limit ratios).
+//
+// runtimeClasses is the set of RuntimeClass names treated as VM-isolated; when
+// empty, DefaultIsolatedRuntimeClasses is used.
+func New(
+	logger *zap.Logger,
+	decorator stores.Decorator,
+	kubeletClient *kubeletutil.KubeletClient,
+	hostInfo cExtractor.CPUMemInfoProvider,
+	runtimeClasses []string,
+) (*SummarySupplement, error) {
+	if logger == nil {
+		return nil, errors.New("summarysupplement: logger must not be nil")
+	}
+	if decorator == nil {
+		return nil, errors.New("summarysupplement: decorator must not be nil")
+	}
+	if kubeletClient == nil {
+		return nil, errors.New("summarysupplement: kubelet client must not be nil")
+	}
+	if hostInfo == nil {
+		return nil, errors.New("summarysupplement: host info must not be nil")
+	}
+
+	if len(runtimeClasses) == 0 {
+		runtimeClasses = DefaultIsolatedRuntimeClasses
+	}
+	isolated := make(map[string]bool, len(runtimeClasses))
+	for _, rc := range runtimeClasses {
+		if rc != "" {
+			isolated[rc] = true
+		}
+	}
+
+	// Only CPU and memory container-scope metrics are in scope. Filesystem and
+	// network are intentionally omitted: they are not part of the recovered set
+	// and, for VM-isolated pods, network is sandbox-level and not attributable at
+	// container scope.
+	metricExtractors := []extractors.MetricExtractor{
+		extractors.NewCPUMetricExtractor(logger),
+		extractors.NewMemMetricExtractor(logger),
+	}
+
+	return &SummarySupplement{
+		logger:        logger,
+		decorator:     decorator,
+		kubeletClient: kubeletClient,
+		hostInfo:      hostInfo,
+		extractors:    metricExtractors,
+		isolated:      isolated,
+	}, nil
+}
+
+// GetMetrics returns container-scope OTLP metrics for VM-isolated pods only.
+func (s *SummarySupplement) GetMetrics() []pmetric.Metrics {
+	var result []pmetric.Metrics
+
+	// 1. Determine which pods are VM-isolated. RuntimeClassName is a pod-spec
+	//    field that is not present in the Summary API, so it must come from the
+	//    kubelet /pods endpoint.
+	pods, err := s.kubeletClient.ListPods()
+	if err != nil {
+		s.logger.Warn("summarysupplement: failed to list pods from kubelet", zap.Error(err))
+		return result
+	}
+
+	isolatedUIDs := make(map[string]bool)
+	for i := range pods {
+		rc := pods[i].Spec.RuntimeClassName
+		if rc != nil && s.isolated[*rc] {
+			isolatedUIDs[string(pods[i].UID)] = true
+		}
+	}
+	if len(isolatedUIDs) == 0 {
+		// No VM-isolated pods on this node; nothing to supplement.
+		return result
+	}
+
+	// 2. Pull the Summary API and build container records for the gated pods.
+	summary, err := s.kubeletClient.Summary(s.logger)
+	if err != nil {
+		s.logger.Warn("summarysupplement: failed to get kubelet summary", zap.Error(err))
+		return result
+	}
+	if summary == nil {
+		return result
+	}
+
+	var ciMetrics []*stores.CIMetricImpl
+	for i := range summary.Pods {
+		pod := summary.Pods[i]
+		if !isolatedUIDs[pod.PodRef.UID] {
+			continue
+		}
+		ciMetrics = append(ciMetrics, s.containerMetrics(pod)...)
+	}
+	if len(ciMetrics) == 0 {
+		return result
+	}
+
+	// 3. Merge per-extractor records into one record per container, decorate
+	//    (adds node/instance/cluster tags and pod-spec limit/request fields), and
+	//    convert to OTLP.
+	ciMetrics = cExtractor.MergeMetrics(ciMetrics)
+	for _, m := range s.decorate(ciMetrics) {
+		result = append(result, ci.ConvertToOTLPMetrics(m.GetFields(), m.GetTags(), s.logger))
+	}
+
+	return result
+}
+
+// containerMetrics builds container-scope CIMetrics for a single pod's containers.
+func (s *SummarySupplement) containerMetrics(pod stats.PodStats) []*stores.CIMetricImpl {
+	var metrics []*stores.CIMetricImpl
+
+	for _, container := range pod.Containers {
+		tags := map[string]string{
+			ci.PodIDKey:         pod.PodRef.UID,
+			ci.K8sPodNameKey:    pod.PodRef.Name,
+			ci.K8sNamespace:     pod.PodRef.Namespace,
+			ci.ContainerNamekey: container.Name,
+			ci.ContainerIDkey:   fmt.Sprintf("%s-%s", pod.PodRef.UID, container.Name),
+		}
+
+		rawMetric := extractors.ConvertContainerToRaw(container, pod)
+		tags[ci.Timestamp] = strconv.FormatInt(rawMetric.Time.UnixNano(), 10)
+
+		var containerMetrics []*stores.CIMetricImpl
+		for _, extractor := range s.extractors {
+			if extractor.HasValue(rawMetric) {
+				containerMetrics = append(containerMetrics, extractor.GetValue(rawMetric, s.hostInfo, ci.TypeContainer)...)
+			}
+		}
+		// Apply this container's tags to this container's records only.
+		for _, metric := range containerMetrics {
+			metric.AddTags(tags)
+		}
+		metrics = append(metrics, containerMetrics...)
+	}
+
+	return metrics
+}
+
+// decorate runs each CIMetric through the decorator, dropping any the decorator
+// rejects (returns nil for).
+func (s *SummarySupplement) decorate(in []*stores.CIMetricImpl) []*stores.CIMetricImpl {
+	var out []*stores.CIMetricImpl
+	for _, m := range in {
+		decorated := s.decorator.Decorate(m)
+		if decorated == nil {
+			continue
+		}
+		// The decorator chain returns the same *CIMetricImpl it was given (or
+		// nil when a store rejects the record). Use the comma-ok form so an
+		// unexpected concrete type drops the record instead of panicking a
+		// metrics receiver.
+		if impl, ok := decorated.(*stores.CIMetricImpl); ok {
+			out = append(out, impl)
+		}
+	}
+	return out
+}
+
+// Shutdown releases resources held by the metric extractors.
+func (s *SummarySupplement) Shutdown() error {
+	var errs error
+	for _, extractor := range s.extractors {
+		errs = errors.Join(errs, extractor.Shutdown())
+	}
+	return errs
+}

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -34,6 +34,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/prometheusscraper/decoratorconsumer"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/summarysupplement"
 )
 
 const (
@@ -49,21 +50,22 @@ type metricsProvider interface {
 
 // awsContainerInsightReceiver implements the receiver.Metrics
 type awsContainerInsightReceiver struct {
-	settings                 component.TelemetrySettings
-	nextConsumer             consumer.Metrics
-	config                   *Config
-	cancel                   context.CancelFunc
-	cancelWg                 sync.WaitGroup
-	decorators               []stores.Decorator
-	containerMetricsProvider metricsProvider
-	k8sapiserver             metricsProvider
-	prometheusScraper        *k8sapiserver.PrometheusScraper
-	podResourcesStore        *stores.PodResourcesStore
-	dcgmScraper              *prometheusscraper.SimplePrometheusScraper
-	nvmeEBSScraper           *prometheusscraper.SimplePrometheusScraper
-	nvmeLISScraper           *prometheusscraper.SimplePrometheusScraper
-	neuronMonitorScraper     *prometheusscraper.SimplePrometheusScraper
-	efaSysfsScraper          *efa.Scraper
+	settings                  component.TelemetrySettings
+	nextConsumer              consumer.Metrics
+	config                    *Config
+	cancel                    context.CancelFunc
+	cancelWg                  sync.WaitGroup
+	decorators                []stores.Decorator
+	containerMetricsProvider  metricsProvider
+	summarySupplementProvider metricsProvider
+	k8sapiserver              metricsProvider
+	prometheusScraper         *k8sapiserver.PrometheusScraper
+	podResourcesStore         *stores.PodResourcesStore
+	dcgmScraper               *prometheusscraper.SimplePrometheusScraper
+	nvmeEBSScraper            *prometheusscraper.SimplePrometheusScraper
+	nvmeLISScraper            *prometheusscraper.SimplePrometheusScraper
+	neuronMonitorScraper      *prometheusscraper.SimplePrometheusScraper
+	efaSysfsScraper           *efa.Scraper
 }
 
 // newAWSContainerInsightReceiver creates the aws container insight receiver with the given parameters.
@@ -207,6 +209,21 @@ func (acir *awsContainerInsightReceiver) initEKS(ctx context.Context, host compo
 			acir.settings.Logger, cadvisor.WithDecorator(localNodeDecorator))
 		if err != nil {
 			return err
+		}
+
+		// VM-isolated pods (e.g. RuntimeClass isolated-sandbox / confidential-sandbox)
+		// have an empty host pod-slice cgroup, so cadvisor emits nothing for them.
+		// When enabled, supplement cadvisor with container-scope metrics for those
+		// pods sourced from the kubelet Summary API. This runs alongside cadvisor and
+		// is disjoint from it by pod, so normal pods are unaffected.
+		if acir.config.EnableIsolatedPodSummaryMetrics && localNodeDecorator != nil {
+			summaryProvider, ssErr := summarysupplement.New(acir.settings.Logger, localNodeDecorator,
+				kubeletClient, hostInfo, acir.config.IsolatedPodRuntimeClasses)
+			if ssErr != nil {
+				acir.settings.Logger.Warn("Unable to start isolated-pod summary supplement provider", zap.Error(ssErr))
+			} else {
+				acir.summarySupplementProvider = summaryProvider
+			}
 		}
 
 		err = acir.initDcgmScraper(ctx, host, hostInfo, localNodeDecorator)
@@ -469,6 +486,9 @@ func (acir *awsContainerInsightReceiver) Shutdown(context.Context) error {
 	if acir.containerMetricsProvider != nil {
 		errs = errors.Join(errs, acir.containerMetricsProvider.Shutdown())
 	}
+	if acir.summarySupplementProvider != nil {
+		errs = errors.Join(errs, acir.summarySupplementProvider.Shutdown())
+	}
 	if acir.dcgmScraper != nil {
 		acir.dcgmScraper.Shutdown()
 	}
@@ -509,6 +529,10 @@ func (acir *awsContainerInsightReceiver) collectData(ctx context.Context) error 
 
 	if acir.containerMetricsProvider != nil {
 		mds = append(mds, acir.containerMetricsProvider.GetMetrics()...)
+	}
+
+	if acir.summarySupplementProvider != nil {
+		mds = append(mds, acir.summarySupplementProvider.GetMetrics()...)
 	}
 
 	if acir.k8sapiserver != nil {


### PR DESCRIPTION
VM-isolated pods (RuntimeClass isolated-sandbox / confidential-sandbox)
run their workload inside a guest VM. On the host there is only an empty
pod-slice cgroup with no container children, so the cadvisor provider —
which reads the host cgroup filesystem — emits nothing at all for these
pods. The kubelet Summary API (CRI stats provider) does report the real
in-guest container CPU and memory usage.

This adds an opt-in summarysupplement metricsProvider that reads the
Summary API and emits container-scope CIMetrics for gated (VM-isolated)
pods only, running alongside cadvisor without double counting (the two
are disjoint by pod). Gated by a new config flag
EnableIsolatedPodSummaryMetrics; normal pods are untouched.

To reuse the existing CPU/Mem extractors on Linux, the k8swindows
extractor/kubelet files drop their //go:build windows tags; the truly
Windows-only hcsshim code is split into extractor_hcs_windows.go which
retains the windows build tag.

Scope: 8 container metrics (cpu/mem utilization + limit/request +
*_over_container_limit). container_memory_failures_total, filesystem,
and network are intentionally omitted.
