### PR TITLE
[extension/oidctoken] Add support for GCP OIDC token retrieval

### DIFF
--- a/extension/oidctokenextension/README.md
+++ b/extension/oidctokenextension/README.md
@@ -2,8 +2,8 @@
 # OIDC Token Extension
 
 This extension provides OIDC token management for authenticating to AWS from
-non-AWS environments (e.g., Azure VMs). It auto-detects the cloud provider,
-fetches OIDC tokens, and writes them to a file for sigv4auth to consume.
+non-AWS environments (e.g., Azure VMs, GCE instances). It auto-detects the cloud
+provider, fetches OIDC tokens, and writes them to a file for sigv4auth to consume.
 
 
 | Status                                                                                                                           |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
@@ -20,13 +20,15 @@ fetches OIDC tokens, and writes them to a file for sigv4auth to consume.
 ## Configuration
 
 * `output_token_file`: **Required**. The path where the extension writes the fetched OIDC token. Point `sigv4auth`'s `web_identity_token_file` to the same path.
-* `provider`: **Optional**. The OIDC token provider. One of `auto` (default; detects the provider from the environment, currently resolving to Azure), `azure`, or `none` (disables token fetching).
-* `audience`: **Optional**. The audience/resource claim requested in the OIDC token. When unset, the Azure provider auto-detects the correct Azure Resource Manager (ARM) resource for the VM's cloud from IMDS `compute.azEnvironment`. Set this only to override auto-detection.
+* `provider`: **Optional**. The OIDC token provider. One of `auto` (default; detects the provider from the environment by probing each cloud's metadata service), `azure`, `gcp`, or `none` (disables token fetching).
+* `audience`: **Optional**. The audience/resource claim requested in the OIDC token. Each provider has its own default (see below). Set this only to override the default.
 
 ### Supported Providers
 
-For Azure, the default audience is the ARM resource of the cloud the VM runs
-in, detected from IMDS `compute.azEnvironment`:
+#### Azure
+
+The Azure provider fetches a managed-identity token from IMDS. When `audience` is unset, it auto-detects the correct
+Azure Resource Manager (ARM) resource for the VM's cloud from IMDS `compute.azEnvironment`:
 
 | Azure environment (`azEnvironment`) | Auto-detected audience                  |
 |-------------------------------------|-----------------------------------------|
@@ -36,12 +38,22 @@ in, detected from IMDS `compute.azEnvironment`:
 
 Unknown or unreadable environments fall back to `https://management.azure.com/`.
 
+#### GCP
+
+The GCP provider fetches a Google-signed identity token (issuer `https://accounts.google.com`) from the GCE metadata
+server's service-account identity endpoint. When `audience` is unset, it defaults to `sts.amazonaws.com`.
+
+GCE service-account tokens set both an `aud` claim (the requested audience) and an `azp` claim (the service account's
+numeric unique ID), and AWS STS uses the `azp` value as the audience. So the requested `audience` is effectively
+cosmetic: the AWS IAM OIDC provider for Google must list the service account's unique ID as a client ID, and the
+role's trust policy `:aud` (and `:sub`) condition must be that unique ID.
+
 ## How It Works
 
 On startup the extension:
 
-1. Auto-detects the cloud provider (currently Azure via IMDS)
-2. Fetches an OIDC token from the provider's metadata service
+1. Auto-detects the cloud provider by probing each cloud's metadata service (Azure IMDS, GCE metadata server)
+2. Fetches an OIDC token from the detected provider's metadata service
 3. Writes the token to a file for `sigv4auth` to consume
 4. Refreshes the token before expiry
 
@@ -80,6 +92,5 @@ service:
 
 ## Notes
 
-* The extension currently supports Azure IMDS as the only auto-detected provider. Support for additional providers may be added in the future.
 * The `oidctoken` extension should be listed before `sigv4auth` in the `extensions` list to ensure the token file is available before SigV4 authentication is configured.
 * On shutdown, the token file the extension wrote is truncated (not deleted) so that `sigv4auth` validation does not fail on the next startup. On startup the extension also truncates any stale token before writing a fresh one.

--- a/extension/oidctokenextension/config.go
+++ b/extension/oidctokenextension/config.go
@@ -8,6 +8,10 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/component"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidctokenextension/internal/provider"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidctokenextension/internal/provider/azure"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidctokenextension/internal/provider/gcp"
 )
 
 // ProviderType selects the OIDC token provider.
@@ -18,17 +22,19 @@ const (
 	ProviderAuto ProviderType = "auto"
 	// ProviderAzure uses Azure VM managed identity (IMDS) to fetch tokens.
 	ProviderAzure ProviderType = "azure"
+	// ProviderGCP uses the GCE metadata server's service-account identity endpoint to fetch tokens.
+	ProviderGCP ProviderType = "gcp"
 	// ProviderNone disables token fetching.
 	ProviderNone ProviderType = "none"
 )
 
 func (p *ProviderType) UnmarshalText(text []byte) error {
 	switch v := ProviderType(text); v {
-	case ProviderAuto, ProviderAzure, ProviderNone:
+	case ProviderAuto, ProviderAzure, ProviderGCP, ProviderNone:
 		*p = v
 		return nil
 	default:
-		return fmt.Errorf("unsupported provider %q (expected auto, azure, or none)", v)
+		return fmt.Errorf("unsupported provider %q (expected auto, azure, gcp, or none)", v)
 	}
 }
 
@@ -60,13 +66,17 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-func (c *Config) buildProviders() []TokenProvider {
+func (c *Config) buildProviders() []provider.TokenProvider {
 	switch c.Provider {
 	case ProviderNone:
 		return nil
 	case ProviderAzure:
-		return []TokenProvider{newAzureProvider(c.Audience)}
+		return []provider.TokenProvider{azure.New(c.Audience)}
+	case ProviderGCP:
+		return []provider.TokenProvider{gcp.New(c.Audience)}
 	default: // ProviderAuto
-		return []TokenProvider{newAzureProvider(c.Audience)}
+		// The extension picks the first provider whose IsAvailable probe succeeds. The probes are mutually
+		// exclusive across clouds, so order does not matter.
+		return []provider.TokenProvider{azure.New(c.Audience), gcp.New(c.Audience)}
 	}
 }

--- a/extension/oidctokenextension/config.go
+++ b/extension/oidctokenextension/config.go
@@ -67,16 +67,17 @@ func (c *Config) Validate() error {
 }
 
 func (c *Config) buildProviders() []provider.TokenProvider {
+	client := provider.NewMetadataClient()
 	switch c.Provider {
 	case ProviderNone:
 		return nil
 	case ProviderAzure:
-		return []provider.TokenProvider{azure.New(c.Audience)}
+		return []provider.TokenProvider{azure.New(client, c.Audience)}
 	case ProviderGCP:
-		return []provider.TokenProvider{gcp.New(c.Audience)}
+		return []provider.TokenProvider{gcp.New(client, c.Audience)}
 	default: // ProviderAuto
 		// The extension picks the first provider whose IsAvailable probe succeeds. The probes are mutually
 		// exclusive across clouds, so order does not matter.
-		return []provider.TokenProvider{azure.New(c.Audience), gcp.New(c.Audience)}
+		return []provider.TokenProvider{azure.New(client, c.Audience), gcp.New(client, c.Audience)}
 	}
 }

--- a/extension/oidctokenextension/config_test.go
+++ b/extension/oidctokenextension/config_test.go
@@ -49,9 +49,10 @@ func TestConfig_ProviderType(t *testing.T) {
 	}{
 		{"auto", ProviderAuto, false},
 		{"azure", ProviderAzure, false},
+		{"gcp", ProviderGCP, false},
 		{"none", ProviderNone, false},
-		{"gcp", "", true},
 		{"", "", true},
+		{"aws", "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
@@ -97,7 +98,8 @@ func TestConfig_BuildProviders(t *testing.T) {
 	}{
 		{"none", ProviderNone, []string{}},
 		{"azure", ProviderAzure, []string{"azure"}},
-		{"auto", ProviderAuto, []string{"azure"}},
+		{"gcp", ProviderGCP, []string{"gcp"}},
+		{"auto", ProviderAuto, []string{"azure", "gcp"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/extension/oidctokenextension/extension.go
+++ b/extension/oidctokenextension/extension.go
@@ -15,6 +15,8 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidctokenextension/internal/provider"
 )
 
 const (
@@ -26,8 +28,8 @@ const (
 type oidcTokenExtension struct {
 	logger        *zap.Logger
 	config        *Config
-	providers     []TokenProvider
-	tokenProvider TokenProvider
+	providers     []provider.TokenProvider
+	tokenProvider provider.TokenProvider
 	done          chan struct{}
 	// refreshCtx is the long-lived parent context for the background refresh
 	// loop. It is derived from context.Background() (not Start's ctx, which may

--- a/extension/oidctokenextension/extension_test.go
+++ b/extension/oidctokenextension/extension_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidctokenextension/internal/provider"
 )
 
 func TestStartWithProvider(t *testing.T) {
@@ -25,7 +27,7 @@ func TestStartWithProvider(t *testing.T) {
 	ext := &oidcTokenExtension{
 		logger:             zap.NewNop(),
 		config:             cfg,
-		providers:          []TokenProvider{mp},
+		providers:          []provider.TokenProvider{mp},
 		minRefreshInterval: minRefreshInterval,
 	}
 
@@ -62,7 +64,7 @@ func TestShutdownNoProviderPreservesExistingFile(t *testing.T) {
 	ext := &oidcTokenExtension{
 		logger:             zap.NewNop(),
 		config:             &Config{OutputTokenFile: tokenFile},
-		providers:          []TokenProvider{mp},
+		providers:          []provider.TokenProvider{mp},
 		minRefreshInterval: minRefreshInterval,
 	}
 

--- a/extension/oidctokenextension/go.mod
+++ b/extension/oidctokenextension/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidct
 go 1.24.13
 
 require (
+	cloud.google.com/go/compute/metadata v0.9.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.30.0
 	go.opentelemetry.io/collector/component/componenttest v0.124.0

--- a/extension/oidctokenextension/go.sum
+++ b/extension/oidctokenextension/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
+cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/extension/oidctokenextension/internal/provider/azure/azure.go
+++ b/extension/oidctokenextension/internal/provider/azure/azure.go
@@ -72,11 +72,11 @@ type azureProvider struct {
 
 var _ provider.TokenProvider = (*azureProvider)(nil)
 
-// New returns an Azure managed-identity token provider. An empty resource means the ARM resource (token audience) is
-// auto-detected from IMDS.
-func New(resource string) provider.TokenProvider {
+// New returns an Azure managed-identity token provider using the given metadata HTTP client. An empty resource
+// means the ARM resource (token audience) is auto-detected from IMDS.
+func New(client *http.Client, resource string) provider.TokenProvider {
 	return &azureProvider{
-		client:             provider.NewMetadataClient(),
+		client:             client,
 		endpoint:           defaultIMDSEndpoint,
 		configuredResource: resource,
 	}

--- a/extension/oidctokenextension/internal/provider/azure/azure.go
+++ b/extension/oidctokenextension/internal/provider/azure/azure.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package oidctokenextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidctokenextension"
+package azure // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidctokenextension/internal/provider/azure"
 
 import (
 	"context"
@@ -15,22 +15,20 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidctokenextension/internal/provider"
 )
 
 const (
-	defaultAzureIMDSEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token"
-	azureIMDSInstancePath    = "/metadata/instance"
-	// azureIMDSAPIVersion is shared by the token and instance-probe requests.
-	// IMDS versions its whole supported-versions list service-wide (not
-	// per-endpoint): 2020-09-01 satisfies the token endpoint's documented
-	// "2018-02-01 or greater" floor and is a supported instance version. It also
-	// matches internal/metadataproviders/azure.
-	azureIMDSAPIVersion     = "2020-09-01"
-	defaultAzureTokenExpiry = 3600
-	// azureIMDSProbeTimeout bounds the availability probe so a blackholed
-	// link-local address cannot stall extension startup for the full
-	// token-fetch timeout.
-	azureIMDSProbeTimeout = 3 * time.Second
+	defaultIMDSEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token"
+	imdsInstancePath    = "/metadata/instance"
+	// imdsAPIVersion is shared by the token and instance-probe requests. IMDS
+	// versions its whole supported-versions list service-wide (not per-endpoint):
+	// 2020-09-01 satisfies the token endpoint's documented "2018-02-01 or greater"
+	// floor and is a supported instance version. It also matches
+	// internal/metadataproviders/azure.
+	imdsAPIVersion     = "2020-09-01"
+	defaultTokenExpiry = 3600
 )
 
 // Azure Resource Manager (ARM) resource identifiers per sovereign cloud. The
@@ -58,6 +56,7 @@ func armResourceForEnvironment(env string) string {
 	}
 }
 
+// azureProvider fetches an OIDC token from Azure VM managed identity (IMDS).
 type azureProvider struct {
 	client   *http.Client
 	endpoint string
@@ -71,17 +70,14 @@ type azureProvider struct {
 	resolvedResource atomic.Value // string
 }
 
-var _ TokenProvider = (*azureProvider)(nil)
+var _ provider.TokenProvider = (*azureProvider)(nil)
 
-func newAzureProvider(resource string) *azureProvider {
-	// IMDS lives at a fixed link-local address; never route metadata requests
-	// through an HTTP(S) proxy. Clone the default transport for sane dial/TLS
-	// defaults, then disable proxy resolution.
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.Proxy = nil
+// New returns an Azure managed-identity token provider. An empty resource means the ARM resource (token audience) is
+// auto-detected from IMDS.
+func New(resource string) provider.TokenProvider {
 	return &azureProvider{
-		client:             &http.Client{Timeout: 30 * time.Second, Transport: transport},
-		endpoint:           defaultAzureIMDSEndpoint,
+		client:             provider.NewMetadataClient(),
+		endpoint:           defaultIMDSEndpoint,
 		configuredResource: resource,
 	}
 }
@@ -97,8 +93,8 @@ func (p *azureProvider) instanceMetadataURL(leaf string, extra url.Values) strin
 	if err != nil {
 		return ""
 	}
-	u.Path = azureIMDSInstancePath + leaf
-	q := url.Values{"api-version": {azureIMDSAPIVersion}}
+	u.Path = imdsInstancePath + leaf
+	q := url.Values{"api-version": {imdsAPIVersion}}
 	for k, vs := range extra {
 		for _, v := range vs {
 			q.Set(k, v)
@@ -116,7 +112,7 @@ func (p *azureProvider) instanceMetadataURL(leaf string, extra url.Values) strin
 func (p *azureProvider) IsAvailable(ctx context.Context) bool {
 	// Use a short, independent timeout for the probe so a non-Azure host with a
 	// blackholed IMDS address does not block startup for the token-fetch timeout.
-	ctx, cancel := context.WithTimeout(ctx, azureIMDSProbeTimeout)
+	ctx, cancel := context.WithTimeout(ctx, provider.DefaultMetadataProbeTimeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
@@ -154,7 +150,7 @@ func (p *azureProvider) resource() string {
 	return armResourcePublic
 }
 
-type azureTokenResponse struct {
+type tokenResponse struct {
 	AccessToken string `json:"access_token"`
 	ExpiresIn   string `json:"expires_in"`
 }
@@ -166,7 +162,7 @@ func (p *azureProvider) GetToken(ctx context.Context) (string, time.Duration, er
 	}
 	req.Header.Set("Metadata", "true")
 	q := req.URL.Query()
-	q.Set("api-version", azureIMDSAPIVersion)
+	q.Set("api-version", imdsAPIVersion)
 	q.Set("resource", p.resource())
 	req.URL.RawQuery = q.Encode()
 
@@ -181,8 +177,8 @@ func (p *azureProvider) GetToken(ctx context.Context) (string, time.Duration, er
 		return "", 0, fmt.Errorf("azure: IMDS returned %d: %s", resp.StatusCode, string(body))
 	}
 
-	var tokenResp azureTokenResponse
-	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+	var tokenResp tokenResponse
+	if err = json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
 		return "", 0, fmt.Errorf("azure: decode response: %w", err)
 	}
 	if tokenResp.AccessToken == "" {
@@ -191,7 +187,7 @@ func (p *azureProvider) GetToken(ctx context.Context) (string, time.Duration, er
 
 	expiresIn, _ := strconv.Atoi(tokenResp.ExpiresIn)
 	if expiresIn <= 0 {
-		expiresIn = defaultAzureTokenExpiry
+		expiresIn = defaultTokenExpiry
 	}
 	return tokenResp.AccessToken, time.Duration(expiresIn) * time.Second, nil
 }

--- a/extension/oidctokenextension/internal/provider/azure/azure_test.go
+++ b/extension/oidctokenextension/internal/provider/azure/azure_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package oidctokenextension
+package azure
 
 import (
 	"encoding/json"
@@ -16,11 +16,11 @@ import (
 
 func TestAzureProviderGetToken(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Metadata") != "true" || r.URL.Query().Get("api-version") != azureIMDSAPIVersion {
+		if r.Header.Get("Metadata") != "true" || r.URL.Query().Get("api-version") != imdsAPIVersion {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		resp := azureTokenResponse{
+		resp := tokenResponse{
 			AccessToken: "test-token",
 			ExpiresIn:   "3600",
 		}
@@ -66,7 +66,7 @@ func TestAzureProviderIsAvailable(t *testing.T) {
 		if !strings.HasSuffix(r.URL.Path, "/compute/azEnvironment") ||
 			r.Header.Get("Metadata") != "true" ||
 			r.URL.Query().Get("format") != "text" ||
-			r.URL.Query().Get("api-version") != azureIMDSAPIVersion {
+			r.URL.Query().Get("api-version") != imdsAPIVersion {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
@@ -103,22 +103,22 @@ func TestAzureProviderIsAvailableNotOK(t *testing.T) {
 func TestAzureProviderInstanceMetadataURL(t *testing.T) {
 	provider := &azureProvider{endpoint: "http://169.254.169.254/metadata/identity/oauth2/token"}
 	require.Equal(t,
-		"http://169.254.169.254/metadata/instance?api-version="+azureIMDSAPIVersion,
+		"http://169.254.169.254/metadata/instance?api-version="+imdsAPIVersion,
 		provider.instanceMetadataURL("", nil))
 }
 
 func TestNewAzureProviderDefault(t *testing.T) {
-	provider := newAzureProvider("")
+	provider := New("").(*azureProvider)
 	require.Equal(t, "azure", provider.Name())
 	// With no explicit audience and no successful probe yet, resource() falls
 	// back to the public ARM resource.
 	require.Empty(t, provider.configuredResource)
 	require.Equal(t, armResourcePublic, provider.resource())
-	require.Equal(t, defaultAzureIMDSEndpoint, provider.endpoint)
+	require.Equal(t, defaultIMDSEndpoint, provider.endpoint)
 }
 
 func TestNewAzureProviderWithResource(t *testing.T) {
-	provider := newAzureProvider("https://custom.resource/")
+	provider := New("https://custom.resource/").(*azureProvider)
 	require.Equal(t, "https://custom.resource/", provider.configuredResource)
 }
 
@@ -171,7 +171,7 @@ func TestGetTokenUsesDetectedResource(t *testing.T) {
 			return
 		}
 		gotResource = r.URL.Query().Get("resource")
-		_ = json.NewEncoder(w).Encode(azureTokenResponse{AccessToken: "t", ExpiresIn: "3600"})
+		_ = json.NewEncoder(w).Encode(tokenResponse{AccessToken: "t", ExpiresIn: "3600"})
 	}))
 	defer server.Close()
 

--- a/extension/oidctokenextension/internal/provider/azure/azure_test.go
+++ b/extension/oidctokenextension/internal/provider/azure/azure_test.go
@@ -108,7 +108,7 @@ func TestAzureProviderInstanceMetadataURL(t *testing.T) {
 }
 
 func TestNewAzureProviderDefault(t *testing.T) {
-	provider := New("").(*azureProvider)
+	provider := New(&http.Client{}, "").(*azureProvider)
 	require.Equal(t, "azure", provider.Name())
 	// With no explicit audience and no successful probe yet, resource() falls
 	// back to the public ARM resource.
@@ -118,7 +118,7 @@ func TestNewAzureProviderDefault(t *testing.T) {
 }
 
 func TestNewAzureProviderWithResource(t *testing.T) {
-	provider := New("https://custom.resource/").(*azureProvider)
+	provider := New(&http.Client{}, "https://custom.resource/").(*azureProvider)
 	require.Equal(t, "https://custom.resource/", provider.configuredResource)
 }
 

--- a/extension/oidctokenextension/internal/provider/client.go
+++ b/extension/oidctokenextension/internal/provider/client.go
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package provider // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidctokenextension/internal/provider"
+
+import (
+	"net/http"
+	"time"
+)
+
+// metadataClientTimeout bounds a single token-fetch request. Availability probes use their own shorter
+// per-request timeout via context.
+const metadataClientTimeout = 30 * time.Second
+
+// DefaultMetadataProbeTimeout bounds a single availability probe so a non-matching host (where the metadata
+// endpoint is unreachable or blackholed) cannot stall extension startup for the full token-fetch timeout.
+const DefaultMetadataProbeTimeout = 3 * time.Second
+
+// NewMetadataClient returns an HTTP client for cloud metadata-server requests. Metadata endpoints are reached
+// over plain HTTP at fixed internal addresses that must never be routed through an HTTP(S) proxy: Azure IMDS
+// at the link-local 169.254.169.254, and the GCE metadata server at the hostname metadata.google.internal
+// (which resolves to that same link-local address). The client clones the default transport for sane dial/TLS
+// defaults and disables proxy resolution.
+func NewMetadataClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	return &http.Client{Timeout: metadataClientTimeout, Transport: transport}
+}

--- a/extension/oidctokenextension/internal/provider/client_test.go
+++ b/extension/oidctokenextension/internal/provider/client_test.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMetadataClient(t *testing.T) {
+	c := NewMetadataClient()
+	require.Equal(t, metadataClientTimeout, c.Timeout)
+
+	tr, ok := c.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.Nil(t, tr.Proxy)
+}

--- a/extension/oidctokenextension/internal/provider/gcp/gcp.go
+++ b/extension/oidctokenextension/internal/provider/gcp/gcp.go
@@ -9,24 +9,21 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
+	"cloud.google.com/go/compute/metadata"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidctokenextension/internal/provider"
 )
 
 const (
-	// defaultMetadataHost is the GCE metadata server base URL. The token and probe paths are joined onto it,
-	// so overriding it (in tests) redirects both.
-	defaultMetadataHost = "http://metadata.google.internal"
-	// identityPath is the service-account identity endpoint. It returns a Google-signed OIDC JWT (issuer
-	// https://accounts.google.com) for the instance's default service account.
-	identityPath = "/computeMetadata/v1/instance/service-accounts/default/identity"
-	// instanceIDPath is a stable leaf used only for the availability probe. Every GCE instance exposes it.
-	instanceIDPath = "/computeMetadata/v1/instance/id"
+	// identityPath is the GCE metadata service-account identity endpoint (relative to the metadata client's
+	// computeMetadata/v1/ base). It returns a Google-signed OIDC JWT (issuer https://accounts.google.com) for
+	// the instance's default service account.
+	identityPath = "instance/service-accounts/default/identity"
 	// defaultAudience is the audience requested in the identity token. It is effectively cosmetic: GCE tokens
 	// also carry an azp claim (the service account's unique ID), and AWS STS uses azp as the audience. The
 	// metadata endpoint just requires a non-empty value.
@@ -34,92 +31,46 @@ const (
 	// defaultTokenExpiry is the fallback TTL used when the token's exp claim cannot be parsed. GCE identity
 	// tokens are normally valid 1 hour.
 	defaultTokenExpiry = time.Hour
-	// The GCE metadata server requires this request header and echoes it back on responses, which is how a
-	// host is confirmed to be GCE.
-	metadataFlavorHeader = "Metadata-Flavor"
-	metadataFlavorValue  = "Google"
 )
 
-// gcpProvider fetches an OIDC token from the GCE metadata server.
+// gcpProvider fetches an OIDC token from the GCE metadata server via the compute/metadata client, which
+// handles the metadata host, Metadata-Flavor header, and retries.
 type gcpProvider struct {
-	client   *http.Client
-	host     string
+	client   *metadata.Client
 	audience string
 }
 
 var _ provider.TokenProvider = (*gcpProvider)(nil)
 
-// New returns a GCE metadata-server token provider. An empty audience defaults to sts.amazonaws.com.
-func New(audience string) provider.TokenProvider {
+// New returns a GCE metadata-server token provider using the given metadata HTTP client. An empty audience
+// defaults to sts.amazonaws.com.
+func New(client *http.Client, audience string) provider.TokenProvider {
 	if audience == "" {
 		audience = defaultAudience
 	}
 	return &gcpProvider{
-		client:   provider.NewMetadataClient(),
-		host:     defaultMetadataHost,
+		client:   metadata.NewClient(client),
 		audience: audience,
 	}
 }
 
 func (*gcpProvider) Name() string { return "gcp" }
 
-// IsAvailable reports whether the host is a GCE instance by probing the metadata server: a 200 with a
-// Metadata-Flavor: Google response header identifies it. Best-effort detection for provider selection, not
-// an authenticated check.
+// IsAvailable reports whether the host is a GCE instance. Best-effort detection for provider selection.
 func (p *gcpProvider) IsAvailable(ctx context.Context) bool {
 	ctx, cancel := context.WithTimeout(ctx, provider.DefaultMetadataProbeTimeout)
 	defer cancel()
-
-	probeURL, err := url.JoinPath(p.host, instanceIDPath)
-	if err != nil {
-		return false
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, probeURL, http.NoBody)
-	if err != nil {
-		return false
-	}
-	req.Header.Set(metadataFlavorHeader, metadataFlavorValue)
-	resp, err := p.client.Do(req)
-	if err != nil {
-		return false
-	}
-	defer resp.Body.Close()
-	return resp.StatusCode == http.StatusOK && resp.Header.Get(metadataFlavorHeader) == metadataFlavorValue
+	return metadata.OnGCEWithContext(ctx)
 }
 
 func (p *gcpProvider) GetToken(ctx context.Context) (string, time.Duration, error) {
-	tokenURL, err := url.JoinPath(p.host, identityPath)
-	if err != nil {
-		return "", 0, fmt.Errorf("gcp: build token url: %w", err)
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL, http.NoBody)
-	if err != nil {
-		return "", 0, fmt.Errorf("gcp: create request: %w", err)
-	}
-	req.Header.Set(metadataFlavorHeader, metadataFlavorValue)
-	q := req.URL.Query()
-	q.Set("audience", p.audience)
 	// format=standard yields a standard OIDC ID token (aud/azp/exp/iat/iss/sub), which is all STS needs.
-	q.Set("format", "standard")
-	req.URL.RawQuery = q.Encode()
-
-	resp, err := p.client.Do(req)
+	suffix := identityPath + "?audience=" + url.QueryEscape(p.audience) + "&format=standard"
+	token, err := p.client.GetWithContext(ctx, suffix)
 	if err != nil {
-		return "", 0, fmt.Errorf("gcp: metadata request failed: %w", err)
+		return "", 0, fmt.Errorf("gcp: fetch identity token: %w", err)
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return "", 0, fmt.Errorf("gcp: metadata returned %d: %s", resp.StatusCode, string(body))
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", 0, fmt.Errorf("gcp: read response: %w", err)
-	}
-	// The identity endpoint returns the raw JWT as the response body.
-	token := strings.TrimSpace(string(body))
+	token = strings.TrimSpace(token)
 	if token == "" {
 		return "", 0, errors.New("gcp: empty identity token in metadata response")
 	}

--- a/extension/oidctokenextension/internal/provider/gcp/gcp.go
+++ b/extension/oidctokenextension/internal/provider/gcp/gcp.go
@@ -77,27 +77,23 @@ func (p *gcpProvider) GetToken(ctx context.Context) (string, time.Duration, erro
 	return token, tokenTTL(token), nil
 }
 
-// tokenTTL derives the token lifetime from the JWT's exp claim, falling back to defaultTokenExpiry when the
-// token cannot be parsed.
+// tokenTTL returns the token lifetime from the JWT's exp claim, falling back to defaultTokenExpiry when exp
+// cannot be read (malformed JWT or no exp claim), matching the azure provider's fallback for a missing
+// expires_in. An already-expired token yields a non-positive TTL, which triggers an immediate refresh.
 func tokenTTL(token string) time.Duration {
-	fallback := defaultTokenExpiry
 	parts := strings.Split(token, ".")
 	if len(parts) != 3 {
-		return fallback
+		return defaultTokenExpiry
 	}
 	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
-		return fallback
+		return defaultTokenExpiry
 	}
 	var claims struct {
 		Exp int64 `json:"exp"`
 	}
 	if err = json.Unmarshal(payload, &claims); err != nil || claims.Exp == 0 {
-		return fallback
+		return defaultTokenExpiry
 	}
-	ttl := time.Until(time.Unix(claims.Exp, 0))
-	if ttl <= 0 {
-		return fallback
-	}
-	return ttl
+	return time.Until(time.Unix(claims.Exp, 0))
 }

--- a/extension/oidctokenextension/internal/provider/gcp/gcp.go
+++ b/extension/oidctokenextension/internal/provider/gcp/gcp.go
@@ -1,0 +1,152 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidctokenextension/internal/provider/gcp"
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidctokenextension/internal/provider"
+)
+
+const (
+	// defaultMetadataHost is the GCE metadata server base URL. The token and probe paths are joined onto it,
+	// so overriding it (in tests) redirects both.
+	defaultMetadataHost = "http://metadata.google.internal"
+	// identityPath is the service-account identity endpoint. It returns a Google-signed OIDC JWT (issuer
+	// https://accounts.google.com) for the instance's default service account.
+	identityPath = "/computeMetadata/v1/instance/service-accounts/default/identity"
+	// instanceIDPath is a stable leaf used only for the availability probe. Every GCE instance exposes it.
+	instanceIDPath = "/computeMetadata/v1/instance/id"
+	// defaultAudience is the audience requested in the identity token. It is effectively cosmetic: GCE tokens
+	// also carry an azp claim (the service account's unique ID), and AWS STS uses azp as the audience. The
+	// metadata endpoint just requires a non-empty value.
+	defaultAudience = "sts.amazonaws.com"
+	// defaultTokenExpiry is the fallback TTL used when the token's exp claim cannot be parsed. GCE identity
+	// tokens are normally valid 1 hour.
+	defaultTokenExpiry = time.Hour
+	// The GCE metadata server requires this request header and echoes it back on responses, which is how a
+	// host is confirmed to be GCE.
+	metadataFlavorHeader = "Metadata-Flavor"
+	metadataFlavorValue  = "Google"
+)
+
+// gcpProvider fetches an OIDC token from the GCE metadata server.
+type gcpProvider struct {
+	client   *http.Client
+	host     string
+	audience string
+}
+
+var _ provider.TokenProvider = (*gcpProvider)(nil)
+
+// New returns a GCE metadata-server token provider. An empty audience defaults to sts.amazonaws.com.
+func New(audience string) provider.TokenProvider {
+	if audience == "" {
+		audience = defaultAudience
+	}
+	return &gcpProvider{
+		client:   provider.NewMetadataClient(),
+		host:     defaultMetadataHost,
+		audience: audience,
+	}
+}
+
+func (*gcpProvider) Name() string { return "gcp" }
+
+// IsAvailable reports whether the host is a GCE instance by probing the metadata server: a 200 with a
+// Metadata-Flavor: Google response header identifies it. Best-effort detection for provider selection, not
+// an authenticated check.
+func (p *gcpProvider) IsAvailable(ctx context.Context) bool {
+	ctx, cancel := context.WithTimeout(ctx, provider.DefaultMetadataProbeTimeout)
+	defer cancel()
+
+	probeURL, err := url.JoinPath(p.host, instanceIDPath)
+	if err != nil {
+		return false
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, probeURL, http.NoBody)
+	if err != nil {
+		return false
+	}
+	req.Header.Set(metadataFlavorHeader, metadataFlavorValue)
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK && resp.Header.Get(metadataFlavorHeader) == metadataFlavorValue
+}
+
+func (p *gcpProvider) GetToken(ctx context.Context) (string, time.Duration, error) {
+	tokenURL, err := url.JoinPath(p.host, identityPath)
+	if err != nil {
+		return "", 0, fmt.Errorf("gcp: build token url: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL, http.NoBody)
+	if err != nil {
+		return "", 0, fmt.Errorf("gcp: create request: %w", err)
+	}
+	req.Header.Set(metadataFlavorHeader, metadataFlavorValue)
+	q := req.URL.Query()
+	q.Set("audience", p.audience)
+	// format=standard yields a standard OIDC ID token (aud/azp/exp/iat/iss/sub), which is all STS needs.
+	q.Set("format", "standard")
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", 0, fmt.Errorf("gcp: metadata request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", 0, fmt.Errorf("gcp: metadata returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", 0, fmt.Errorf("gcp: read response: %w", err)
+	}
+	// The identity endpoint returns the raw JWT as the response body.
+	token := strings.TrimSpace(string(body))
+	if token == "" {
+		return "", 0, errors.New("gcp: empty identity token in metadata response")
+	}
+	return token, tokenTTL(token), nil
+}
+
+// tokenTTL derives the token lifetime from the JWT's exp claim, falling back to defaultTokenExpiry when the
+// token cannot be parsed.
+func tokenTTL(token string) time.Duration {
+	fallback := defaultTokenExpiry
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return fallback
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return fallback
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err = json.Unmarshal(payload, &claims); err != nil || claims.Exp == 0 {
+		return fallback
+	}
+	ttl := time.Until(time.Unix(claims.Exp, 0))
+	if ttl <= 0 {
+		return fallback
+	}
+	return ttl
+}

--- a/extension/oidctokenextension/internal/provider/gcp/gcp_test.go
+++ b/extension/oidctokenextension/internal/provider/gcp/gcp_test.go
@@ -111,12 +111,14 @@ func TestTokenTTL(t *testing.T) {
 	require.Greater(t, ttl, 29*time.Minute)
 	require.LessOrEqual(t, ttl, 30*time.Minute)
 
-	// Malformed tokens and already-expired tokens fall back to the default TTL.
-	fallback := defaultTokenExpiry
-	require.Equal(t, fallback, tokenTTL("not-a-jwt"))
-	require.Equal(t, fallback, tokenTTL("a.b.c"))
-	require.Equal(t, fallback, tokenTTL(makeJWT(t, time.Now().Add(-time.Minute).Unix())))
-	// A valid-base64 payload that is not JSON, and a token with no usable exp, also fall back.
-	require.Equal(t, fallback, tokenTTL("aGVhZGVy."+base64.RawURLEncoding.EncodeToString([]byte("not json"))+".c2ln"))
-	require.Equal(t, fallback, tokenTTL(makeJWT(t, 0)))
+	// Tokens whose exp cannot be determined fall back to the default TTL (matching the azure provider): a
+	// malformed JWT, a non-JSON payload, and a token with no usable exp claim.
+	require.Equal(t, defaultTokenExpiry, tokenTTL("not-a-jwt"))
+	require.Equal(t, defaultTokenExpiry, tokenTTL("a.b.c"))
+	require.Equal(t, defaultTokenExpiry, tokenTTL("aGVhZGVy."+base64.RawURLEncoding.EncodeToString([]byte("not json"))+".c2ln"))
+	require.Equal(t, defaultTokenExpiry, tokenTTL(makeJWT(t, 0)))
+
+	// An exp that parses but is already in the past yields a non-positive TTL, so the extension refreshes
+	// immediately instead of masking the expired token behind the fallback.
+	require.Negative(t, tokenTTL(makeJWT(t, time.Now().Add(-time.Minute).Unix())))
 }

--- a/extension/oidctokenextension/internal/provider/gcp/gcp_test.go
+++ b/extension/oidctokenextension/internal/provider/gcp/gcp_test.go
@@ -25,27 +25,29 @@ func makeJWT(t *testing.T, exp int64) string {
 	return "aGVhZGVy." + seg + ".c2ln"
 }
 
+// pointMetadataAt redirects the compute/metadata client at the test server via GCE_METADATA_HOST, so
+// GetToken hits it instead of the real metadata server.
+func pointMetadataAt(t *testing.T, server *httptest.Server) {
+	t.Helper()
+	t.Setenv("GCE_METADATA_HOST", strings.TrimPrefix(server.URL, "http://"))
+}
+
 func TestGCPProviderGetToken(t *testing.T) {
-	exp := time.Now().Add(45 * time.Minute).Unix()
-	jwt := makeJWT(t, exp)
+	jwt := makeJWT(t, time.Now().Add(45*time.Minute).Unix())
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get(metadataFlavorHeader) != metadataFlavorValue ||
+		if r.Header.Get("Metadata-Flavor") != "Google" ||
 			r.URL.Query().Get("audience") != "sts.amazonaws.com" ||
 			r.URL.Query().Get("format") != "standard" {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
+		w.Header().Set("Metadata-Flavor", "Google")
 		_, _ = w.Write([]byte(jwt))
 	}))
 	defer server.Close()
+	pointMetadataAt(t, server)
 
-	p := &gcpProvider{
-		client:   &http.Client{Timeout: 5 * time.Second},
-		host:     server.URL,
-		audience: defaultAudience,
-	}
-
-	token, ttl, err := p.GetToken(t.Context())
+	token, ttl, err := New(&http.Client{}, defaultAudience).GetToken(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, jwt, token)
 	// TTL is derived from the JWT exp claim, so it is close to 45m (allow slack for the elapsed test time).
@@ -57,16 +59,13 @@ func TestGCPProviderGetTokenUsesConfiguredAudience(t *testing.T) {
 	var gotAudience string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAudience = r.URL.Query().Get("audience")
+		w.Header().Set("Metadata-Flavor", "Google")
 		_, _ = w.Write([]byte(makeJWT(t, time.Now().Add(time.Hour).Unix())))
 	}))
 	defer server.Close()
+	pointMetadataAt(t, server)
 
-	p := &gcpProvider{
-		client:   &http.Client{Timeout: 5 * time.Second},
-		host:     server.URL,
-		audience: "https://custom.audience/",
-	}
-	_, _, err := p.GetToken(t.Context())
+	_, _, err := New(&http.Client{}, "https://custom.audience/").GetToken(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, "https://custom.audience/", gotAudience)
 }
@@ -74,114 +73,35 @@ func TestGCPProviderGetTokenUsesConfiguredAudience(t *testing.T) {
 func TestGCPProviderGetTokenError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte("forbidden"))
 	}))
 	defer server.Close()
+	pointMetadataAt(t, server)
 
-	p := &gcpProvider{
-		client:   &http.Client{Timeout: 5 * time.Second},
-		host:     server.URL,
-		audience: defaultAudience,
-	}
-
-	_, _, err := p.GetToken(t.Context())
+	_, _, err := New(&http.Client{}, defaultAudience).GetToken(t.Context())
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "403")
 }
 
 func TestGCPProviderGetTokenEmpty(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Metadata-Flavor", "Google")
 		_, _ = w.Write([]byte("   \n"))
 	}))
 	defer server.Close()
+	pointMetadataAt(t, server)
 
-	p := &gcpProvider{
-		client:   &http.Client{Timeout: 5 * time.Second},
-		host:     server.URL,
-		audience: defaultAudience,
-	}
-
-	_, _, err := p.GetToken(t.Context())
+	_, _, err := New(&http.Client{}, defaultAudience).GetToken(t.Context())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "empty identity token")
 }
 
-// TestGCPProviderIsAvailable verifies the probe hits the instance/id leaf with the Metadata-Flavor request
-// header and requires the same header echoed back on the response.
-func TestGCPProviderIsAvailable(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.HasSuffix(r.URL.Path, instanceIDPath) ||
-			r.Header.Get(metadataFlavorHeader) != metadataFlavorValue {
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		w.Header().Set(metadataFlavorHeader, metadataFlavorValue)
-		_, _ = w.Write([]byte("1234567890"))
-	}))
-	defer server.Close()
-
-	p := &gcpProvider{
-		client: &http.Client{Timeout: 5 * time.Second},
-		host:   server.URL,
-	}
-	require.True(t, p.IsAvailable(t.Context()))
-}
-
-// TestGCPProviderIsAvailableMissingHeader verifies a 200 without the Metadata-Flavor response header (e.g.
-// some other server answering the address) is not treated as GCE.
-func TestGCPProviderIsAvailableMissingHeader(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("1234567890"))
-	}))
-	defer server.Close()
-
-	p := &gcpProvider{
-		client: &http.Client{Timeout: 5 * time.Second},
-		host:   server.URL,
-	}
-	require.False(t, p.IsAvailable(t.Context()))
-}
-
-// TestGCPProviderMetadataUnreachable points the provider at a closed server so the HTTP request fails,
-// exercising the client.Do error paths: IsAvailable reports false and GetToken returns an error.
-func TestGCPProviderMetadataUnreachable(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	host := server.URL
-	server.Close() // nothing listens on host now, so requests are refused
-
-	p := &gcpProvider{
-		client:   &http.Client{Timeout: time.Second},
-		host:     host,
-		audience: defaultAudience,
-	}
-	require.False(t, p.IsAvailable(t.Context()))
-	_, _, err := p.GetToken(t.Context())
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "metadata request failed")
-}
-
-func TestGCPProviderIsAvailableNotOK(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer server.Close()
-
-	p := &gcpProvider{
-		client: &http.Client{Timeout: 5 * time.Second},
-		host:   server.URL,
-	}
-	require.False(t, p.IsAvailable(t.Context()))
-}
-
 func TestNewGCPProviderDefault(t *testing.T) {
-	p := New("").(*gcpProvider)
+	p := New(&http.Client{}, "").(*gcpProvider)
 	require.Equal(t, "gcp", p.Name())
 	require.Equal(t, defaultAudience, p.audience)
-	require.Equal(t, defaultMetadataHost, p.host)
 }
 
 func TestNewGCPProviderWithAudience(t *testing.T) {
-	p := New("https://custom.audience/").(*gcpProvider)
+	p := New(&http.Client{}, "https://custom.audience/").(*gcpProvider)
 	require.Equal(t, "https://custom.audience/", p.audience)
 }
 

--- a/extension/oidctokenextension/internal/provider/gcp/gcp_test.go
+++ b/extension/oidctokenextension/internal/provider/gcp/gcp_test.go
@@ -1,0 +1,202 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gcp
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// makeJWT builds a minimal unsigned JWT with the given exp claim (Unix seconds). Only the payload segment
+// is meaningful for tokenTTL. The header and signature are placeholders.
+func makeJWT(t *testing.T, exp int64) string {
+	t.Helper()
+	payload, err := json.Marshal(map[string]int64{"exp": exp})
+	require.NoError(t, err)
+	seg := base64.RawURLEncoding.EncodeToString(payload)
+	return "aGVhZGVy." + seg + ".c2ln"
+}
+
+func TestGCPProviderGetToken(t *testing.T) {
+	exp := time.Now().Add(45 * time.Minute).Unix()
+	jwt := makeJWT(t, exp)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(metadataFlavorHeader) != metadataFlavorValue ||
+			r.URL.Query().Get("audience") != "sts.amazonaws.com" ||
+			r.URL.Query().Get("format") != "standard" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, _ = w.Write([]byte(jwt))
+	}))
+	defer server.Close()
+
+	p := &gcpProvider{
+		client:   &http.Client{Timeout: 5 * time.Second},
+		host:     server.URL,
+		audience: defaultAudience,
+	}
+
+	token, ttl, err := p.GetToken(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, jwt, token)
+	// TTL is derived from the JWT exp claim, so it is close to 45m (allow slack for the elapsed test time).
+	require.Greater(t, ttl, 44*time.Minute)
+	require.LessOrEqual(t, ttl, 45*time.Minute)
+}
+
+func TestGCPProviderGetTokenUsesConfiguredAudience(t *testing.T) {
+	var gotAudience string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAudience = r.URL.Query().Get("audience")
+		_, _ = w.Write([]byte(makeJWT(t, time.Now().Add(time.Hour).Unix())))
+	}))
+	defer server.Close()
+
+	p := &gcpProvider{
+		client:   &http.Client{Timeout: 5 * time.Second},
+		host:     server.URL,
+		audience: "https://custom.audience/",
+	}
+	_, _, err := p.GetToken(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "https://custom.audience/", gotAudience)
+}
+
+func TestGCPProviderGetTokenError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("forbidden"))
+	}))
+	defer server.Close()
+
+	p := &gcpProvider{
+		client:   &http.Client{Timeout: 5 * time.Second},
+		host:     server.URL,
+		audience: defaultAudience,
+	}
+
+	_, _, err := p.GetToken(t.Context())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "403")
+}
+
+func TestGCPProviderGetTokenEmpty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("   \n"))
+	}))
+	defer server.Close()
+
+	p := &gcpProvider{
+		client:   &http.Client{Timeout: 5 * time.Second},
+		host:     server.URL,
+		audience: defaultAudience,
+	}
+
+	_, _, err := p.GetToken(t.Context())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty identity token")
+}
+
+// TestGCPProviderIsAvailable verifies the probe hits the instance/id leaf with the Metadata-Flavor request
+// header and requires the same header echoed back on the response.
+func TestGCPProviderIsAvailable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, instanceIDPath) ||
+			r.Header.Get(metadataFlavorHeader) != metadataFlavorValue {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set(metadataFlavorHeader, metadataFlavorValue)
+		_, _ = w.Write([]byte("1234567890"))
+	}))
+	defer server.Close()
+
+	p := &gcpProvider{
+		client: &http.Client{Timeout: 5 * time.Second},
+		host:   server.URL,
+	}
+	require.True(t, p.IsAvailable(t.Context()))
+}
+
+// TestGCPProviderIsAvailableMissingHeader verifies a 200 without the Metadata-Flavor response header (e.g.
+// some other server answering the address) is not treated as GCE.
+func TestGCPProviderIsAvailableMissingHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("1234567890"))
+	}))
+	defer server.Close()
+
+	p := &gcpProvider{
+		client: &http.Client{Timeout: 5 * time.Second},
+		host:   server.URL,
+	}
+	require.False(t, p.IsAvailable(t.Context()))
+}
+
+// TestGCPProviderMetadataUnreachable points the provider at a closed server so the HTTP request fails,
+// exercising the client.Do error paths: IsAvailable reports false and GetToken returns an error.
+func TestGCPProviderMetadataUnreachable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	host := server.URL
+	server.Close() // nothing listens on host now, so requests are refused
+
+	p := &gcpProvider{
+		client:   &http.Client{Timeout: time.Second},
+		host:     host,
+		audience: defaultAudience,
+	}
+	require.False(t, p.IsAvailable(t.Context()))
+	_, _, err := p.GetToken(t.Context())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "metadata request failed")
+}
+
+func TestGCPProviderIsAvailableNotOK(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	p := &gcpProvider{
+		client: &http.Client{Timeout: 5 * time.Second},
+		host:   server.URL,
+	}
+	require.False(t, p.IsAvailable(t.Context()))
+}
+
+func TestNewGCPProviderDefault(t *testing.T) {
+	p := New("").(*gcpProvider)
+	require.Equal(t, "gcp", p.Name())
+	require.Equal(t, defaultAudience, p.audience)
+	require.Equal(t, defaultMetadataHost, p.host)
+}
+
+func TestNewGCPProviderWithAudience(t *testing.T) {
+	p := New("https://custom.audience/").(*gcpProvider)
+	require.Equal(t, "https://custom.audience/", p.audience)
+}
+
+func TestTokenTTL(t *testing.T) {
+	// Valid JWT with an exp ~30m out.
+	ttl := tokenTTL(makeJWT(t, time.Now().Add(30*time.Minute).Unix()))
+	require.Greater(t, ttl, 29*time.Minute)
+	require.LessOrEqual(t, ttl, 30*time.Minute)
+
+	// Malformed tokens and already-expired tokens fall back to the default TTL.
+	fallback := defaultTokenExpiry
+	require.Equal(t, fallback, tokenTTL("not-a-jwt"))
+	require.Equal(t, fallback, tokenTTL("a.b.c"))
+	require.Equal(t, fallback, tokenTTL(makeJWT(t, time.Now().Add(-time.Minute).Unix())))
+	// A valid-base64 payload that is not JSON, and a token with no usable exp, also fall back.
+	require.Equal(t, fallback, tokenTTL("aGVhZGVy."+base64.RawURLEncoding.EncodeToString([]byte("not json"))+".c2ln"))
+	require.Equal(t, fallback, tokenTTL(makeJWT(t, 0)))
+}

--- a/extension/oidctokenextension/internal/provider/provider.go
+++ b/extension/oidctokenextension/internal/provider/provider.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package oidctokenextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidctokenextension"
+package provider // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidctokenextension/internal/provider"
 
 import (
 	"context"

--- a/extension/oidctokenextension/metadata.yaml
+++ b/extension/oidctokenextension/metadata.yaml
@@ -3,8 +3,8 @@ display_name: OIDC Token Extension
 
 description: |
   This extension provides OIDC token management for authenticating to AWS from
-  non-AWS environments (e.g., Azure VMs). It auto-detects the cloud provider,
-  fetches OIDC tokens, and writes them to a file for sigv4auth to consume.
+  non-AWS environments (e.g., Azure VMs, GCE instances). It auto-detects the cloud
+  provider, fetches OIDC tokens, and writes them to a file for sigv4auth to consume.
 
 status:
   class: extension


### PR DESCRIPTION
#### Description
Adds a GCP token provider to the `oidctoken` extension so it can fetch OIDC tokens on GCE instances. The provider fetches a Google-signed identity token (issuer `https://accounts.google.com`) from the GCE metadata server's service-account identity endpoint using the `cloud.google.com/go/compute/metadata` SDK (also used in the `resourcedetection` processor) for the fetch and availability probe. The default audience is `sts.amazonaws.com` (if not provided) and the token TTL is derived by parsing the JWT `exp` claim.

https://docs.cloud.google.com/compute/docs/instances/verifying-instance-identity
> [EXPIRED_TIME]: a unix timestamp indicating when the token expires.

Moved the `TokenProvider` interface and both providers under `internal/provider/{azure,gcp}`.

#### Testing
- Added unit tests for the GCP provider that covers token fetch and parsing.
- Built into CloudWatch agent and tested on GCE instance. Verified the GCP provider was used and the token was written to the file, AssumeRoleWithWebIdentity was able to federate without issue, and metrics were able to get sent to CloudWatch.

<img width="2559" height="961" alt="image" src="https://github.com/user-attachments/assets/6bebbb4e-726b-410e-9b8c-2679d5d905d4" />

#### Documentation
Updated README.